### PR TITLE
Fix show cursor when dialog moves in TTY mode

### DIFF
--- a/keybar.go
+++ b/keybar.go
@@ -46,6 +46,10 @@ func (kb *KeyBar) SetModifiers(shift, ctrl, alt bool) {
 func (kb *KeyBar) Show(scr *ScreenBuf) {
 	kb.Bar.Show(scr)
 	kb.DisplayObject(scr)
+	_, cy := scr.GetCursorPos()
+	if cy == kb.Y1 {
+		scr.SetCursorVisible(false)
+	}
 }
 func (kb *KeyBar) ProcessMouse(e *vtinput.InputEvent) bool {
 	if !kb.IsVisible() || e.Type != vtinput.MouseEventType {

--- a/screenbuf.go
+++ b/screenbuf.go
@@ -390,6 +390,10 @@ func (s *ScreenBuf) FillRect(x1, y1, x2, y2 int, char rune, attributes uint64) {
 func (s *ScreenBuf) SetCursorPos(x, y int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.width <= 0 || s.height <= 0 || x < 0 || x >= s.width || y < 0 || y >= s.height {
+		s.cursorVisible = false
+		return
+	}
 	if s.cursorX != x || s.cursorY != y {
 		s.cursorX, s.cursorY = x, y
 		s.cursorDirty = true

--- a/statusline.go
+++ b/statusline.go
@@ -26,6 +26,10 @@ func NewStatusLine() *StatusLine {
 func (sl *StatusLine) Show(scr *ScreenBuf) {
 	sl.ScreenObject.Show(scr)
 	sl.DisplayObject(scr)
+	_, cy := scr.GetCursorPos()
+	if cy == sl.Y1 {
+		scr.SetCursorVisible(false)
+	}
 }
 
 func (sl *StatusLine) DisplayObject(scr *ScreenBuf) {


### PR DESCRIPTION
Проблема: при сдвиге диалогов влево/вниз в TTY-режиме курсор появляется
в неожиданных местах — в правом нижнем углу за тенью диалога, либо
поверх KeyBar. В GUI-режиме эффекта нет, т.к. там курсор рисуется
пикселями и обрезается границами окна/контролов.

2 причины:

SetCursorPos — невалидные координаты уходили в ANSI-escape, терминал игнорировал позиционирование, курсор оставался в углу тени
KeyBar/StatusLine — chrome-элементы не чистили курсор, и он оставался видимым поверх них после сдвига диалога вниз

Причина 1 — невалидная ANSI-последовательность:

  При сдвиге диалога влево его X1/X2 уходят в минус. Дочерние виджеты
  (Edit и др.) наследуют эти координаты через MoveRelative().
  Edit.Show() вызывает SetCursorPos(e.X1+vOffset, e.Y1) с отрицательным X.
  AnsiRenderer.Flush() генерирует "\x1b[Y+1;X+1H" с X ≤ 0 — невалидный
  escape. Терминал игнорирует его, курсор остаётся на последней
  отрисованной ячейке — нижнем правом углу тени (x2+2, y2).
  Затем "\x1b[?25h" делает его видимым.

Исправление: SetCursorPos проверяет границы s.width/s.height. Если
координаты вне экрана — курсор скрывается (cursorVisible = false),
вместо того чтобы уходить в терминал с неверной позицией.


Причина 2 — отсутствие очистки курсора в chrome-элементах:

  renderPhase() рисует фреймы (диалоги), а затем — KeyBar, StatusLine,
  MenuBar. Если диалог сдвинут вниз, его сфокусированный Edit может
  установить курсор на строку, где позже будет нарисован KeyBar
  (Y = h-1). KeyBar просто рисует текст поверх, но не трогает состояние
  курсора — курсор остаётся видимым поверх KeyBar.

Исправление: KeyBar.Show() (и StatusLine.Show() на тот же случай)
проверяет текущую Y-позицию курсора после своей отрисовки. Если
курсор находится на строке chrome-элемента — он скрывается.