### PR TITLE
implement SetWindowTitle for gogpu backend

### DIFF
--- a/gogpu_renderer.go
+++ b/gogpu_renderer.go
@@ -456,7 +456,7 @@ func (r *GogpuRenderer) Flush() {
 }
 
 func (r *GogpuRenderer) SetWindowTitle(title string) {
-	// gogpu backend does not currently support dynamic title changes after initialization
+	r.host.app.SetTitle(title)
 }
 func (r *GogpuRenderer) getCellColors(cell CharInfo) (color.Color, color.Color) {
 	bg := GetRGBBack(cell.Attributes)


### PR DESCRIPTION
GogpuRenderer.SetWindowTitle was a no-op, so the window title never
updated in GUI mode. Wire it to gogpu's App.SetTitle() to support
the ConsoleTitleTemplate mechanism.

close: https://github.com/unxed/f4/issues/115