### PR TITLE
fix: close popup frames (combobox dropdowns) when starting window drag

### DIFF
--- a/basewindow.go
+++ b/basewindow.go
@@ -271,6 +271,16 @@ func (bw *BaseWindow) handleWindowOperations(e *vtinput.InputEvent) bool {
 			return true
 		}
 		if bw.HitTest(mx, my) {
+			if FrameManager != nil {
+				for i := len(FrameManager.frames) - 1; i >= 0; i-- {
+					f := FrameManager.frames[i]
+					fx1, fy1, fx2, fy2 := f.GetPosition()
+					if fx1 == bw.X1 && fy1 == bw.Y1 && fx2 == bw.X2 && fy2 == bw.Y2 {
+						FrameManager.PopFramesAbove(f)
+						break
+					}
+				}
+			}
 			bw.isDragging = true
 			bw.dragOffX, bw.dragOffY = mx-bw.X1, my-bw.Y1
 			return true

--- a/framemanager.go
+++ b/framemanager.go
@@ -150,7 +150,6 @@ func ShowToast(msg string, dur time.Duration) {
 		}()
 	})
 }
-
 // GetActiveToast returns the message of the currently active toast if it hasn't expired yet.
 func (fm *frameManager) GetActiveToast() string {
 	if fm.currentToast != nil && time.Now().Before(fm.currentToast.Expires) {
@@ -508,6 +507,21 @@ func (fm *frameManager) RemoveFrame(f Frame) {
 	}
 }
 
+// PopFramesAbove removes all frames above the given frame from the stack.
+// Used when a drag starts on a window, to close popups (combobox dropdowns, menus) on top.
+func (fm *frameManager) PopFramesAbove(f Frame) {
+	for i := len(fm.frames) - 1; i >= 0; i-- {
+		if fm.frames[i] == f {
+			if i < len(fm.frames)-1 {
+				fm.frames = fm.frames[:i+1]
+				fm.SyncCurrentScreen()
+				f.ProcessKey(&vtinput.InputEvent{Type: vtinput.FocusEventType, SetFocus: true})
+			}
+			return
+		}
+	}
+}
+
 // HardRefresh clears the terminal shadow buffer and forces a complete redraw.
 func (fm *frameManager) HardRefresh() {
 	if fm.scr != nil {
@@ -817,7 +831,6 @@ func SetWindowTitle(title string) {
 		FrameManager.SetWindowTitle(title)
 	}
 }
-
 // GetTopFrameType returns the type of the topmost frame or -1 if empty.
 func (fm *frameManager) GetTopFrameType() FrameType {
 	if len(fm.frames) == 0 {


### PR DESCRIPTION
Сорри не удержался, думал пофиксил в прошлый раз оказалось нет.

Problem
When a ComboBox dropdown is opened (pushed as a separate Frame via FrameManager.Push), dragging the parent dialog causes the dropdown to stay at its original position while the rest of the dialog moves. This happens because the dropdown is not part of the dialog's rootGroup — it's a standalone frame in the FrameManager stack, so MoveRelative on the dialog only moves its children, not the dropdown frame.

Fix
framemanager.go — added PopFramesAbove(f Frame) method that removes all frames above a given frame from the stack, followed by SyncCurrentScreen() and a focus event to the surviving frame.
basewindow.go — when a drag starts (HitTest succeeds in handleWindowOperations), locate the dialog in the frame stack by its position and call PopFramesAbove to dismiss any popup frames (combobox dropdowns, menus) layered on top.