### PR TITLE
Fix close Wayland session

### DIFF
--- a/wayland_host.go
+++ b/wayland_host.go
@@ -84,6 +84,7 @@ func runInWaylandWindow(cols, rows int, fontName string, fontSize float64, setup
 	// FrameManager must run in a goroutine because Wayland's DisplayRun blocks the main thread
 	go func() {
 		FrameManager.Run(reader)
+		host.Close()
 		// On exit, close Wayland display
 		host.display.Exit()
 	}()
@@ -151,6 +152,12 @@ func (h *WaylandHost) Redraw(widget *window.Widget) {
 	}
 	// Note: We DO NOT call widget.ScheduleRedraw() here, otherwise it spins at 100% CPU.
 	// Redraws are driven by vtui.Flush() calling widget.ScheduleRedraw().
+}
+
+func (h *WaylandHost) Close() {
+	h.mu.Lock()
+	h.reader = nil
+	h.mu.Unlock()
 }
 
 // -- Pointer & Keyboard Handlers --


### PR DESCRIPTION
не было корректного завершения Wayland сессии. 
F10 Enter  вызывал crash.