### PR TITLE
Clear pending buffer when the bottom painted screen is transparent (thruPTY overlay fix)

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -1176,6 +1176,13 @@ func (fm *frameManager) renderPhase() {
 			baseIdx--
 		}
 
+		// If even the bottom screen of the painted stack is transparent,
+		// nothing below will paint the background: clear the pending buffer
+		// so cells vacated by moved frames do not leave stale content.
+		if fm.Screens[baseIdx].Transparent {
+			fm.scr.ClearBuf()
+		}
+
 		// 2. Отрисовываем стэк экранов от базового до текущего
 		for sIdx := baseIdx; sIdx <= fm.ActiveIdx; sIdx++ {
 			frames := fm.GetActiveFrames(sIdx)

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -1920,3 +1920,62 @@ func TestFrameManager_HideCursorWhenMenuIsActive(t *testing.T) {
 		t.Error("Cursor should be hidden when MenuBar is active")
 	}
 }
+
+// trailFrame paints a single cell at a movable position. Used to verify
+// that a transparent bottom screen leaves no stale content behind.
+type trailFrame struct {
+	BaseFrame
+	x, y int
+}
+
+func (f *trailFrame) Show(scr *ScreenBuf) {
+	scr.Write(f.x, f.y, StringToCharInfo("X", SetRGBBoth(0, 0xFFFFFF, 0x000000)))
+}
+func (f *trailFrame) GetType() FrameType { return TypeUser }
+func (f *trailFrame) GetTitle() string   { return "TrailFrame" }
+
+func TestFrameManager_TransparentBaseClearsVacatedCells(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(10, 5)
+	fm := &frameManager{}
+	fm.Init(scr)
+
+	// The host paints the background itself (e.g. a terminal under the
+	// overlay): the bottom screen is declared transparent.
+	fm.Screens[0].Transparent = true
+
+	frame := &trailFrame{x: 2, y: 1}
+	fm.Push(frame)
+	fm.renderPhase()
+	if cell := scr.GetCell(2, 1); cell.Char != 'X' {
+		t.Fatalf("expected frame painted at (2,1), got %q", cell.Char)
+	}
+
+	// Move the frame: the vacated cell must be cleared, not keep the copy.
+	frame.x, frame.y = 5, 2
+	fm.renderPhase()
+	if cell := scr.GetCell(2, 1); cell.Char != 0 {
+		t.Errorf("vacated cell (2,1) still holds %q: moved frames leave a trail", cell.Char)
+	}
+	if cell := scr.GetCell(5, 2); cell.Char != 'X' {
+		t.Errorf("expected frame painted at (5,2), got %q", cell.Char)
+	}
+}
+
+func TestFrameManager_OpaqueBaseKeepsLegacyBehavior(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(10, 5)
+	fm := &frameManager{}
+	fm.Init(scr)
+
+	// Default (opaque) bottom screen: the buffer is NOT cleared between
+	// render passes — the base screen is expected to paint every cell.
+	frame := &trailFrame{x: 2, y: 1}
+	fm.Push(frame)
+	fm.renderPhase()
+	frame.x, frame.y = 5, 2
+	fm.renderPhase()
+	if cell := scr.GetCell(2, 1); cell.Char != 'X' {
+		t.Errorf("opaque base: vacated cell (2,1) unexpectedly cleared")
+	}
+}

--- a/screenbuf.go
+++ b/screenbuf.go
@@ -124,6 +124,18 @@ func (s *ScreenBuf) HardReset() {
 	s.dirty = true
 }
 
+// ClearBuf resets every cell of the pending buffer to a zero CharInfo.
+// Used by the FrameManager when the bottom of the painted frame stack is
+// transparent: nothing below will paint the background, so cells vacated
+// by moved frames must not retain stale content.
+func (s *ScreenBuf) ClearBuf() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.buf {
+		s.buf[i] = CharInfo{}
+	}
+}
+
 // AllocBuf allocates or reallocates memory for the screen buffers.
 func (s *ScreenBuf) AllocBuf(width, height int) {
 	s.mu.Lock()


### PR DESCRIPTION
renderPhase never cleared the buffer: it relies on the base screen (Desktop in regular apps) painting every cell. When the host paints the background itself (e.g. a terminal under a vtui overlay), cells vacated by moved frames kept stale content, leaving a trail behind dialogs.

If the bottom screen of the painted stack is marked Transparent, the pending buffer is now cleared via the new ScreenBuf.ClearBuf() before frames are drawn. Opaque-base apps are unaffected.

Regression tests: TestFrameManager_TransparentBaseClearsVacatedCells, TestFrameManager_OpaqueBaseKeepsLegacyBehavior.