### PR TITLE
Clean up closed frames after filtered events

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -1460,6 +1460,9 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 	// User-defined filter has first say
 	if !is_injected && fm.EventFilter != nil && fm.EventFilter(ev) {
 		DebugLog("FM_DISPATCH: Event CONSUMED by EventFilter (Macro?).")
+		// Filters may execute actions that close a frame. Preserve the normal
+		// end-of-dispatch cleanup even though the event itself is consumed.
+		fm.cleanupDoneFrames()
 		return
 	}
 

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -87,6 +87,31 @@ func TestFrameManager_GlobalUIPriority(t *testing.T) {
 	}
 }
 
+func TestFrameManager_FilteredEventCleansUpClosedFrame(t *testing.T) {
+	fm := &frameManager{}
+	fm.Init(NewSilentScreenBuf())
+
+	frame := newMockFrame(0, 0, 10, 10, false)
+	fm.Push(frame)
+	fm.EventFilter = func(*vtinput.InputEvent) bool {
+		frame.Close()
+		return true
+	}
+
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_ESCAPE,
+	}, false)
+
+	if !frame.IsDone() {
+		t.Fatal("filter did not close the frame")
+	}
+	if len(fm.frames) != 0 {
+		t.Fatalf("closed frame survived a consumed event: %d frame(s) remain", len(fm.frames))
+	}
+}
+
 type busyFrame struct {
 	mockFrame
 	Busy bool


### PR DESCRIPTION
## Summary
- run the normal done-frame cleanup when `EventFilter` consumes an event
- prevent frames closed by hotkey or macro actions from remaining visible until the next input event
- add a regression test that closes a frame from the filter and verifies immediate removal

## Testing
- `go test . -run TestFrameManager_FilteredEventCleansUpClosedFrame$ -count=50`
- `go test . -run TestFrameManager -count=1`

`go test ./...` also reaches the existing Windows-only `TestDebugLog_Rotation` cleanup failure because `rotation.log` remains open during `TempDir` removal; the FrameManager tests pass.