### PR TITLE
Add mouse hover navigation to menus

### DIFF
--- a/menubar.go
+++ b/menubar.go
@@ -240,33 +240,59 @@ func (mb *MenuBar) ProcessKey(e *vtinput.InputEvent) bool {
 }
 
 func (mb *MenuBar) ProcessMouse(e *vtinput.InputEvent) bool {
-	if mb.IsDisabled() {
+	if mb.IsDisabled() || e.Type != vtinput.MouseEventType {
 		return false
 	}
-	if e.Type == vtinput.MouseEventType && e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown {
-		mx, my := int(e.MouseX), int(e.MouseY)
-		if mb.HitTest(mx, my) {
-			for i := range mb.Items {
-				x1 := mb.GetItemX(i)
-				var x2 int
-				if i < len(mb.Items)-1 {
-					x2 = mb.GetItemX(i+1) - 1
-				} else {
-					clean, _, _ := ParseAmpersandString(mb.Items[i].Label)
-					x2 = x1 + runewidth.StringWidth("  "+clean+"  ") - 1
-				}
-				if mx >= x1 && mx <= x2 {
-					mb.Active = true
-					mb.ActivateSubMenu(i)
-					return true
-				}
-			}
-			mb.Active = true
-			if len(mb.Items) > 0 {
-				mb.ActivateSubMenu(0)
-			}
+
+	mx, my := int(e.MouseX), int(e.MouseY)
+	if !mb.HitTest(mx, my) {
+		return false
+	}
+
+	itemAt := -1
+	for i := range mb.Items {
+		x1 := mb.GetItemX(i)
+		var x2 int
+		if i < len(mb.Items)-1 {
+			x2 = mb.GetItemX(i+1) - 1
+		} else {
+			clean, _, _ := ParseAmpersandString(mb.Items[i].Label)
+			x2 = x1 + runewidth.StringWidth("  "+clean+"  ") - 1
+		}
+		if mx >= x1 && mx <= x2 {
+			itemAt = i
+			break
+		}
+	}
+
+	if e.MouseEventFlags&vtinput.MouseMoved != 0 {
+		if !mb.Active || itemAt == -1 {
+			return false
+		}
+		if itemAt == mb.SelectPos && mb.activeSubMenu != nil {
 			return true
 		}
+
+		// Hovering switches an already active menu bar, but must not execute a
+		// command-only top-level item merely because the pointer crossed it.
+		if len(mb.Items[itemAt].SubItems) == 0 {
+			mb.closeSub()
+			mb.SelectPos = itemAt
+			return true
+		}
+		mb.ActivateSubMenu(itemAt)
+		return true
+	}
+
+	if e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown {
+		mb.Active = true
+		if itemAt == -1 && len(mb.Items) > 0 {
+			itemAt = 0
+		}
+		if itemAt != -1 {
+			mb.ActivateSubMenu(itemAt)
+		}
+		return true
 	}
 	return false
 }

--- a/menubar_test.go
+++ b/menubar_test.go
@@ -1,0 +1,108 @@
+package vtui
+
+import (
+	"testing"
+
+	"github.com/unxed/vtinput"
+)
+
+func TestMenuBar_MouseMoveSwitchesActiveSubMenu(t *testing.T) {
+	fm := &frameManager{}
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	fm.Init(scr)
+	fm.Push(NewDesktop())
+
+	oldFrameManager := FrameManager
+	FrameManager = fm
+	defer func() { FrameManager = oldFrameManager }()
+
+	mb := NewMenuBar(nil)
+	mb.Items = []MenuBarItem{
+		{Label: "File", SubItems: []MenuItem{{Text: "Open"}}},
+		{Label: "Edit", SubItems: []MenuItem{{Text: "Copy"}}},
+	}
+	mb.SetPosition(0, 0, 79, 0)
+	mb.Active = true
+	mb.ActivateSubMenu(0)
+	firstSubMenu := mb.activeSubMenu
+
+	if !mb.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          int16(mb.GetItemX(1)),
+		MouseY:          0,
+		MouseEventFlags: vtinput.MouseMoved,
+	}) {
+		t.Fatal("mouse move over an active menu bar item was not handled")
+	}
+	if mb.SelectPos != 1 {
+		t.Fatalf("hovered menu bar item = %d; want 1", mb.SelectPos)
+	}
+	if mb.activeSubMenu == nil || mb.activeSubMenu == firstSubMenu {
+		t.Fatal("hover did not replace the active submenu")
+	}
+	if got := mb.activeSubMenu.GetTitle(); got != "Edit" {
+		t.Fatalf("active submenu title = %q; want Edit", got)
+	}
+}
+
+func TestMenuBar_MouseMoveDoesNotOpenInactiveMenu(t *testing.T) {
+	mb := NewMenuBar(nil)
+	mb.Items = []MenuBarItem{
+		{Label: "File", SubItems: []MenuItem{{Text: "Open"}}},
+		{Label: "Edit", SubItems: []MenuItem{{Text: "Copy"}}},
+	}
+	mb.SetPosition(0, 0, 79, 0)
+
+	if mb.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          int16(mb.GetItemX(1)),
+		MouseY:          0,
+		MouseEventFlags: vtinput.MouseMoved,
+	}) {
+		t.Fatal("hover unexpectedly activated an inactive menu bar")
+	}
+	if mb.Active || mb.activeSubMenu != nil {
+		t.Fatal("inactive menu bar was opened by hover")
+	}
+}
+
+func TestMenuBar_MouseMoveSelectsCommandItemWithoutExecuting(t *testing.T) {
+	fm := &frameManager{}
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	fm.Init(scr)
+	commandCount := 0
+	fm.Push(&cmdMockFrame{onCmd: func(int, any) bool {
+		commandCount++
+		return true
+	}})
+
+	oldFrameManager := FrameManager
+	FrameManager = fm
+	defer func() { FrameManager = oldFrameManager }()
+
+	mb := NewMenuBar(nil)
+	mb.Items = []MenuBarItem{
+		{Label: "File", SubItems: []MenuItem{{Text: "Open"}}},
+		{Label: "Action", Command: 1234},
+	}
+	mb.SetPosition(0, 0, 79, 0)
+	mb.Active = true
+	mb.ActivateSubMenu(0)
+
+	if !mb.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          int16(mb.GetItemX(1)),
+		MouseY:          0,
+		MouseEventFlags: vtinput.MouseMoved,
+	}) {
+		t.Fatal("mouse move over a command item was not handled")
+	}
+	if mb.SelectPos != 1 || mb.activeSubMenu != nil {
+		t.Fatal("command-only item was not selected cleanly")
+	}
+	if commandCount != 0 {
+		t.Fatalf("hover executed %d command(s)", commandCount)
+	}
+}

--- a/vmenu.go
+++ b/vmenu.go
@@ -218,12 +218,28 @@ func (m *VMenu) ClearDone() {
 	m.exitCode = -1
 }
 
-// ProcessMouse handles mouse wheel scrolling and menu item clicks.
+// ProcessMouse handles mouse wheel scrolling, menu item hover, and clicks.
 func (m *VMenu) ProcessMouse(e *vtinput.InputEvent) bool {
 	if m.IsDisabled() || e.Type != vtinput.MouseEventType {
 		return false
 	}
 	if m.HandleMouseScroll(e) {
+		return true
+	}
+
+	if (e.MouseEventFlags & vtinput.MouseMoved) != 0 {
+		mx := int(e.MouseX)
+		if mx <= m.X1 || mx >= m.X2 {
+			return false
+		}
+
+		hoverIdx := m.GetClickIndex(int(e.MouseY))
+		if hoverIdx == -1 {
+			return false
+		}
+		if !m.Items[hoverIdx].Separator {
+			m.SetSelectPos(hoverIdx)
+		}
 		return true
 	}
 

--- a/vmenu_test.go
+++ b/vmenu_test.go
@@ -87,3 +87,66 @@ func TestVMenu_OnKeyDownHook(t *testing.T) {
 		t.Error("Standard navigation should still work if hook returns false")
 	}
 }
+
+func TestVMenu_MouseMoveSelectsItemWithoutActivatingIt(t *testing.T) {
+	m := NewVMenu("Menu")
+	m.AddItem(MenuItem{Text: "First"})
+	m.AddSeparator()
+	m.AddItem(MenuItem{Text: "Third"})
+	m.SetPosition(10, 5, 30, 9)
+	m.SetSelectPos(0)
+
+	actions := 0
+	m.OnAction = func(int) { actions++ }
+
+	handled := m.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          15,
+		MouseY:          8,
+		MouseEventFlags: vtinput.MouseMoved,
+	})
+	if !handled {
+		t.Fatal("mouse move over a menu item should be handled")
+	}
+	if m.SelectPos != 2 {
+		t.Fatalf("expected hovered item 2 to be selected, got %d", m.SelectPos)
+	}
+	if actions != 0 || m.IsDone() {
+		t.Fatal("hovering must not activate an item or close the menu")
+	}
+}
+
+func TestVMenu_MouseMoveIgnoresSeparatorAndOutside(t *testing.T) {
+	m := NewVMenu("Menu")
+	m.AddItem(MenuItem{Text: "First"})
+	m.AddSeparator()
+	m.AddItem(MenuItem{Text: "Third"})
+	m.SetPosition(10, 5, 30, 9)
+	m.SetSelectPos(2)
+
+	separatorHandled := m.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          15,
+		MouseY:          7,
+		MouseEventFlags: vtinput.MouseMoved,
+	})
+	if !separatorHandled {
+		t.Fatal("mouse move over a separator inside the menu should be consumed")
+	}
+	if m.SelectPos != 2 {
+		t.Fatalf("separator must not become selected, got %d", m.SelectPos)
+	}
+
+	outsideHandled := m.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          9,
+		MouseY:          6,
+		MouseEventFlags: vtinput.MouseMoved,
+	})
+	if outsideHandled {
+		t.Fatal("mouse move outside the menu content should not be handled")
+	}
+	if m.SelectPos != 2 {
+		t.Fatalf("outside movement must not change selection, got %d", m.SelectPos)
+	}
+}


### PR DESCRIPTION
## Summary
- select vertical menu items on mouse hover without activating them
- switch active menu-bar sections and submenus on hover
- keep inactive menu bars closed and avoid executing command-only items on hover
- add coverage for VMenu and MenuBar mouse movement

## Testing
- `go test . -run Test(MenuBar_MouseMove|VMenu_MouseMove|FrameManager_MenuBarNavigabilityWithSubMenu) -count=1`