### PR TITLE
Ignore duplicate mouse move events

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -130,6 +130,9 @@ type frameManager struct {
 	lastMouseClickTime     time.Time
 	lastMouseX, lastMouseY int
 	lastMouseButton        uint32
+	lastMouseEventX        int
+	lastMouseEventY        int
+	mousePositionKnown     bool
 	Reader                 *vtinput.Reader
 	currentToast           *Toast
 }
@@ -308,6 +311,7 @@ func (fm *frameManager) Init(scr *ScreenBuf) {
 	fm.frames = make([]Frame, 0, 10)
 	fm.Screens = []*AppScreen{{Frames: fm.frames}}
 	fm.ActiveIdx = 0
+	fm.mousePositionKnown = false
 
 	if fm.RedrawChan == nil {
 		fm.RedrawChan = make(chan struct{}, 1)
@@ -1319,7 +1323,28 @@ func (fm *frameManager) renderPhase() {
 	}
 }
 
+// isDuplicateMouseMove filters backend motion notifications that do not change
+// the pointer's cell position. Windows consoles can emit many such records
+// while the pointer is stationary; treating the first one after a menu opens as
+// hover would unexpectedly move the menu selection.
+func (fm *frameManager) isDuplicateMouseMove(ev *vtinput.InputEvent) bool {
+	if ev.Type != vtinput.MouseEventType {
+		return false
+	}
+
+	x, y := int(ev.MouseX), int(ev.MouseY)
+	isMove := ev.MouseEventFlags&vtinput.MouseMoved != 0
+	duplicate := isMove && fm.mousePositionKnown && x == fm.lastMouseEventX && y == fm.lastMouseEventY
+	fm.lastMouseEventX = x
+	fm.lastMouseEventY = y
+	fm.mousePositionKnown = true
+	return duplicate
+}
+
 func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) {
+	if fm.isDuplicateMouseMove(ev) {
+		return
+	}
 	DebugLog("FM_DISPATCH: Received event: %s", ev.String())
 	// Translator Tool: Ctrl+Alt+RightClick
 	if ev.Type == vtinput.MouseEventType && ev.ButtonState == vtinput.RightmostButtonPressed && ev.KeyDown {

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -43,6 +43,57 @@ func (m *mockFrame) ProcessMouse(e *vtinput.InputEvent) bool {
 
 func (m *mockFrame) GetType() FrameType { return TypeUser }
 func (m *mockFrame) GetTitle() string   { return "MockFrame" }
+
+func TestFrameManager_DuplicateMouseMoveDoesNotHoverNewMenu(t *testing.T) {
+	oldFM := FrameManager
+	fm := &frameManager{}
+	fm.Init(NewSilentScreenBuf())
+	FrameManager = fm
+	defer func() { FrameManager = oldFM }()
+
+	background := newMockFrame(0, 0, 40, 20, false)
+	fm.Push(background)
+
+	// Establish the pointer position before the menu exists.
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          15,
+		MouseY:          8,
+		MouseEventFlags: vtinput.MouseMoved,
+	}, false)
+
+	menu := NewVMenu("Menu")
+	menu.AddItem(MenuItem{Text: "First"})
+	menu.AddSeparator()
+	menu.AddItem(MenuItem{Text: "Third"})
+	menu.SetPosition(10, 5, 30, 9)
+	menu.SetSelectPos(0)
+	fm.Push(menu)
+
+	// A backend may repeat MouseMoved at the unchanged cell after the menu is
+	// pushed. That is not a new hover and must preserve keyboard selection.
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          15,
+		MouseY:          8,
+		MouseEventFlags: vtinput.MouseMoved,
+	}, false)
+	if menu.SelectPos != 0 {
+		t.Fatalf("duplicate mouse move selected item %d, want 0", menu.SelectPos)
+	}
+
+	// A real cell-coordinate change still enables normal hover navigation.
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          16,
+		MouseY:          8,
+		MouseEventFlags: vtinput.MouseMoved,
+	}, false)
+	if menu.SelectPos != 2 {
+		t.Fatalf("real mouse move selected item %d, want 2", menu.SelectPos)
+	}
+}
+
 func TestFrameManager_GlobalUIPriority(t *testing.T) {
 	oldFm := FrameManager
 	fm := &frameManager{}


### PR DESCRIPTION
## Summary

- drop MouseMoved notifications when the pointer remains in the same terminal cell
- prevent newly opened menus from changing selection under a stationary cursor
- preserve normal hover navigation after a real coordinate change

## Testing

- go test . -run ^(TestFrameManager_DuplicateMouseMoveDoesNotHoverNewMenu|TestVMenu_MouseMove.*|TestMenuBar_MouseMove.*)$ -count=100
- go test ./... -skip ^TestDebugLog_Rotation$