### PR TITLE
Improve dialog control mouse interactions

### DIFF
--- a/button.go
+++ b/button.go
@@ -8,9 +8,11 @@ import (
 // Button represents an interactive button.
 type Button struct {
 	ScreenObject
-	OnClick   func()
-	IsDefault bool
-	caption   string
+	OnClick      func()
+	IsDefault    bool
+	caption      string
+	mouseArmed   bool
+	mousePressed bool
 }
 
 func NewButton(x, y int, text string) *Button {
@@ -49,6 +51,9 @@ func (b *Button) DisplayObject(scr *ScreenBuf) {
 		return
 	}
 	n, h := b.GetStateAttrs(ColDialogButton, ColDialogSelectedButton, ColDialogHighlightButton, ColDialogHighlightSelectedButton)
+	if b.mousePressed {
+		n, h = b.GetStateAttrs(ColDialogSelectedButton, ColDialogSelectedButton, ColDialogHighlightSelectedButton, ColDialogHighlightSelectedButton)
+	}
 	NewPainter(scr).DrawHighlightedText(b.X1, b.Y1, b.cleanText, b.hotkeyPos, n, h)
 }
 
@@ -67,10 +72,39 @@ func (b *Button) ProcessKey(e *vtinput.InputEvent) bool {
 
 func (b *Button) ProcessMouse(e *vtinput.InputEvent) bool {
 	if b.IsDisabled() {
+		b.mouseArmed = false
+		b.mousePressed = false
 		return false
 	}
-	if e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown {
-		return b.FireAction(b.OnClick, nil)
+
+	if b.mouseArmed {
+		inside := b.HitTest(int(e.MouseX), int(e.MouseY))
+		if e.ButtonState&vtinput.FromLeft1stButtonPressed != 0 {
+			b.mousePressed = inside
+			return true
+		}
+
+		activate := b.mousePressed && inside
+		b.mouseArmed = false
+		b.mousePressed = false
+		if activate {
+			b.FireAction(b.OnClick, nil)
+		}
+		return true
+	}
+
+	if e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown && e.MouseEventFlags&vtinput.MouseMoved == 0 && b.HitTest(int(e.MouseX), int(e.MouseY)) {
+		b.mouseArmed = true
+		b.mousePressed = true
+		return true
 	}
 	return false
+}
+
+func (b *Button) SetDisabled(d bool) {
+	b.ScreenObject.SetDisabled(d)
+	if d {
+		b.mouseArmed = false
+		b.mousePressed = false
+	}
 }

--- a/button_test.go
+++ b/button_test.go
@@ -25,10 +25,64 @@ func TestButton_OnClick(t *testing.T) {
 	}
 
 	clicked = false
-	// Test Mouse Click
+	// Mouse down only presses the button visually; release performs the click.
 	b.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, KeyDown: true, ButtonState: vtinput.FromLeft1stButtonPressed})
+	if clicked {
+		t.Error("Button should not click on mouse down")
+	}
+	if !b.mousePressed {
+		t.Error("Button should be visually pressed on mouse down")
+	}
+	b.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, ButtonState: 0})
 	if !clicked {
-		t.Error("Button should be clicked on Left Mouse Button")
+		t.Error("Button should be clicked on mouse release")
+	}
+	if b.mousePressed || b.mouseArmed {
+		t.Error("Button should reset its mouse state after release")
+	}
+}
+
+func TestButton_MouseReleaseOutsideCancelsClick(t *testing.T) {
+	b := NewButton(2, 1, "OK")
+	clicked := false
+	b.OnClick = func() { clicked = true }
+
+	b.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		MouseX:      3, MouseY: 1,
+	})
+	b.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, ButtonState: vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.MouseMoved,
+		MouseX:          20, MouseY: 5,
+	})
+	if b.mousePressed {
+		t.Error("Button should not look pressed while pointer is outside")
+	}
+	b.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, ButtonState: 0,
+		MouseX: 20, MouseY: 5,
+	})
+	if clicked {
+		t.Error("Button should not click when released outside")
+	}
+}
+
+func TestButton_DragBackInsideRestoresPressedStateAndClicks(t *testing.T) {
+	b := NewButton(2, 1, "OK")
+	clicked := false
+	b.OnClick = func() { clicked = true }
+
+	b.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, KeyDown: true, ButtonState: vtinput.FromLeft1stButtonPressed, MouseX: 3, MouseY: 1})
+	b.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, ButtonState: vtinput.FromLeft1stButtonPressed, MouseEventFlags: vtinput.MouseMoved, MouseX: 20, MouseY: 5})
+	b.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, ButtonState: vtinput.FromLeft1stButtonPressed, MouseEventFlags: vtinput.MouseMoved, MouseX: 3, MouseY: 1})
+	if !b.mousePressed {
+		t.Error("Button should look pressed again after dragging back inside")
+	}
+	b.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, ButtonState: 0, MouseX: 3, MouseY: 1})
+	if !clicked {
+		t.Error("Button should click when released inside after dragging back")
 	}
 }
 

--- a/combobox.go
+++ b/combobox.go
@@ -8,9 +8,10 @@ import (
 // ComboBox combines an edit field and a dropdown menu.
 type ComboBox struct {
 	ScreenObject
-	Edit         *Edit
-	Menu         *VMenu
-	DropdownOnly bool // If true, manual text entry is not allowed
+	Edit              *Edit
+	Menu              *VMenu
+	DropdownOnly      bool // If true, manual text entry is not allowed
+	editMouseCaptured bool
 }
 
 func NewComboBox(x, y, width int, items []string) *ComboBox {
@@ -142,12 +143,25 @@ func (cb *ComboBox) ProcessMouse(e *vtinput.InputEvent) bool {
 	if cb.IsDisabled() {
 		return false
 	}
-	if e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown {
+	if cb.editMouseCaptured {
+		if e.ButtonState == 0 {
+			cb.editMouseCaptured = false
+			return true
+		}
+		if cb.Edit.HitTest(int(e.MouseX), int(e.MouseY)) {
+			cb.Edit.ProcessMouse(e)
+		}
+		return true
+	}
+	if e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown && e.MouseEventFlags&vtinput.MouseMoved == 0 {
 		mx := int(e.MouseX)
 		// If arrow clicked or DropdownOnly is true and clicked anywhere within the bounds
 		if mx == cb.X2 || cb.DropdownOnly {
 			cb.Open()
 			return true
+		}
+		if cb.Edit.HitTest(mx, int(e.MouseY)) {
+			cb.editMouseCaptured = true
 		}
 	}
 	return cb.Edit.ProcessMouse(e)
@@ -197,11 +211,17 @@ func (cb *ComboBox) Open() {
 func (cb *ComboBox) SetFocus(f bool) {
 	cb.focused = f
 	cb.Edit.SetFocus(f)
+	if !f {
+		cb.editMouseCaptured = false
+	}
 }
 
 func (cb *ComboBox) SetDisabled(d bool) {
 	cb.ScreenObject.SetDisabled(d)
 	cb.Edit.SetDisabled(d)
+	if d {
+		cb.editMouseCaptured = false
+	}
 }
 func (cb *ComboBox) WantsChars() bool {
 	return !cb.DropdownOnly

--- a/combobox.go
+++ b/combobox.go
@@ -82,10 +82,27 @@ func (cb *ComboBox) DisplayObject(scr *ScreenBuf) {
 	}
 
 	attr := cb.GetStateAttr(ColDialogText, ColDialogSelectedButton)
+	backgroundIdx := cb.Edit.ColorTextIdx
+	if cb.DropdownOnly && cb.focused {
+		backgroundIdx = cb.Edit.ColorSelectedIdx
+	}
+	attr = withBackground(attr, cb.GetStateAttr(backgroundIdx, backgroundIdx))
 	if cb.IsDisabled() {
 		attr = DimColor(attr)
 	}
 	scr.Write(cb.X2, cb.Y1, StringToCharInfo("↓", attr))
+}
+
+// withBackground keeps the foreground and text attributes from attr while
+// taking the background from backgroundAttr. ComboBox arrows are rendered as
+// a separate cell, but visually belong to the edit field beside them.
+func withBackground(attr, backgroundAttr uint64) uint64 {
+	if backgroundAttr&IsBgRGB != 0 {
+		attr = SetRGBBack(attr, GetRGBBack(backgroundAttr))
+	} else {
+		attr = SetIndexBack(attr, GetIndexBack(backgroundAttr))
+	}
+	return attr&^BackgroundIntensity | backgroundAttr&BackgroundIntensity
 }
 
 func (cb *ComboBox) ProcessKey(e *vtinput.InputEvent) bool {

--- a/combobox.go
+++ b/combobox.go
@@ -144,12 +144,10 @@ func (cb *ComboBox) ProcessMouse(e *vtinput.InputEvent) bool {
 		return false
 	}
 	if cb.editMouseCaptured {
+		cb.Edit.ProcessMouse(e)
 		if e.ButtonState == 0 {
 			cb.editMouseCaptured = false
 			return true
-		}
-		if cb.Edit.HitTest(int(e.MouseX), int(e.MouseY)) {
-			cb.Edit.ProcessMouse(e)
 		}
 		return true
 	}

--- a/combobox_test.go
+++ b/combobox_test.go
@@ -182,6 +182,39 @@ func TestComboBox_EditableClickMovesCursor(t *testing.T) {
 	}
 }
 
+func TestComboBox_EditableDragSelectsTextOutsideControl(t *testing.T) {
+	cb := NewComboBox(5, 2, 10, []string{"One", "Two"})
+	cb.Edit.SetText("abcdef")
+
+	cb.ProcessMouse(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		MouseX:      int16(cb.X1 + 1), MouseY: int16(cb.Y1),
+	})
+	cb.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.MouseMoved,
+		MouseX:          int16(cb.X2 + 5), MouseY: int16(cb.Y1 + 2),
+	})
+
+	if cb.Edit.curPos != len(cb.Edit.text) {
+		t.Fatalf("cursor position = %d, want %d after dragging right", cb.Edit.curPos, len(cb.Edit.text))
+	}
+	if cb.Edit.selStart != 1 || cb.Edit.selEnd != len(cb.Edit.text) {
+		t.Fatalf("selection = [%d,%d), want [1,%d)", cb.Edit.selStart, cb.Edit.selEnd, len(cb.Edit.text))
+	}
+
+	cb.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, ButtonState: 0,
+		MouseX: int16(cb.X2 + 5), MouseY: int16(cb.Y1 + 2),
+	})
+	if cb.Edit.mouseSelecting || cb.editMouseCaptured {
+		t.Fatal("mouse selection capture was not released")
+	}
+}
+
 func sameBackground(a, b uint64) bool {
 	if a&IsBgRGB != b&IsBgRGB {
 		return false

--- a/combobox_test.go
+++ b/combobox_test.go
@@ -215,6 +215,40 @@ func TestComboBox_EditableDragSelectsTextOutsideControl(t *testing.T) {
 	}
 }
 
+func TestComboBox_EditableDoubleClickSelectsWord(t *testing.T) {
+	cb := NewComboBox(2, 1, 20, nil)
+	cb.Edit.SetText("one two three")
+
+	cb.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		KeyDown:         true,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.DoubleClick,
+		MouseX:          int16(cb.X1 + 5), MouseY: int16(cb.Y1),
+	})
+
+	if cb.Edit.selStart != 4 || cb.Edit.selEnd != 7 {
+		t.Fatalf("double-click selection = [%d,%d), want [4,7)", cb.Edit.selStart, cb.Edit.selEnd)
+	}
+}
+
+func TestComboBox_EditableTripleClickSelectsAll(t *testing.T) {
+	cb := NewComboBox(2, 1, 20, nil)
+	cb.Edit.SetText("one two three")
+
+	cb.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		KeyDown:         true,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: TripleClick,
+		MouseX:          int16(cb.X1 + 5), MouseY: int16(cb.Y1),
+	})
+
+	if cb.Edit.selStart != 0 || cb.Edit.selEnd != len(cb.Edit.text) {
+		t.Fatalf("triple-click selection = [%d,%d), want all text", cb.Edit.selStart, cb.Edit.selEnd)
+	}
+}
+
 func sameBackground(a, b uint64) bool {
 	if a&IsBgRGB != b&IsBgRGB {
 		return false

--- a/combobox_test.go
+++ b/combobox_test.go
@@ -159,6 +159,29 @@ func TestComboBox_DropdownOnlyFocusedArrowUsesSelectedBackground(t *testing.T) {
 	}
 }
 
+func TestComboBox_EditableClickMovesCursor(t *testing.T) {
+	cb := NewComboBox(5, 2, 20, []string{"One", "Two"})
+	cb.Edit.SetText("abcdef")
+
+	handled := cb.ProcessMouse(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		MouseX:      int16(cb.X1 + 2),
+		MouseY:      int16(cb.Y1),
+	})
+
+	if !handled {
+		t.Fatal("editable ComboBox did not handle text click")
+	}
+	if cb.Edit.curPos != 2 {
+		t.Fatalf("cursor position = %d, want 2", cb.Edit.curPos)
+	}
+	if cb.Edit.selStart != -1 {
+		t.Fatalf("click left selection active at %d", cb.Edit.selStart)
+	}
+}
+
 func sameBackground(a, b uint64) bool {
 	if a&IsBgRGB != b&IsBgRGB {
 		return false

--- a/combobox_test.go
+++ b/combobox_test.go
@@ -125,3 +125,46 @@ func TestComboBox_WantsChars(t *testing.T) {
 		t.Error("DropdownOnly ComboBox should not want chars")
 	}
 }
+
+func TestComboBox_ArrowUsesEditBackground(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(30, 3)
+
+	cb := NewComboBox(1, 1, 20, []string{"One", "Two"})
+	cb.Show(scr)
+
+	arrowAttr := scr.GetCell(cb.X2, cb.Y1).Attributes
+	editAttr := scr.GetCell(cb.X2-1, cb.Y1).Attributes
+	if !sameBackground(arrowAttr, editAttr) {
+		t.Fatalf("arrow background %#x does not match edit background %#x", arrowAttr, editAttr)
+	}
+}
+
+func TestComboBox_DropdownOnlyFocusedArrowUsesSelectedBackground(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(30, 3)
+
+	cb := NewComboBox(1, 1, 20, []string{"One", "Two"})
+	cb.DropdownOnly = true
+	cb.Edit.SetText("One")
+	cb.SetFocus(true)
+	cb.Show(scr)
+
+	arrowAttr := scr.GetCell(cb.X2, cb.Y1).Attributes
+	selectedTextAttr := scr.GetCell(cb.X1, cb.Y1).Attributes
+	if !sameBackground(arrowAttr, selectedTextAttr) {
+		t.Fatalf("arrow background %#x does not match selected edit background %#x", arrowAttr, selectedTextAttr)
+	}
+}
+
+func sameBackground(a, b uint64) bool {
+	if a&IsBgRGB != b&IsBgRGB {
+		return false
+	}
+	if a&IsBgRGB != 0 {
+		return GetRGBBack(a) == GetRGBBack(b) && a&BackgroundIntensity == b&BackgroundIntensity
+	}
+	return GetIndexBack(a) == GetIndexBack(b) && a&BackgroundIntensity == b&BackgroundIntensity
+}

--- a/dialog_test.go
+++ b/dialog_test.go
@@ -96,6 +96,56 @@ func TestDialog_NoDragWhenClickingElement(t *testing.T) {
 	}
 }
 
+func TestDialog_ComboBoxEditCapturesMouseUntilRelease(t *testing.T) {
+	FrameManager.Init(NewSilentScreenBuf())
+	d := NewDialog(0, 0, 30, 10, "Combo capture")
+	cb := NewComboBox(2, 2, 15, []string{"One", "Two"})
+	cb.Edit.SetText("abcdef")
+	d.AddItem(cb)
+
+	d.ProcessMouse(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		MouseX:      int16(cb.X1 + 1), MouseY: int16(cb.Y1),
+	})
+
+	// Moving onto the arrow belongs to the edit gesture and must not open the menu.
+	d.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		KeyDown:         true,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.MouseMoved,
+		MouseX:          int16(cb.X2), MouseY: int16(cb.Y1),
+	})
+	if FrameManager.GetTopFrameType() == TypeMenu {
+		t.Fatal("dragging from combo edit onto arrow opened the dropdown")
+	}
+
+	// Moving onto empty dialog space must not start moving the dialog.
+	d.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		KeyDown:         false,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.MouseMoved,
+		MouseX:          20, MouseY: 6,
+	})
+	if d.isDragging {
+		t.Fatal("dragging from combo edit onto dialog started moving the dialog")
+	}
+	if d.X1 != 0 || d.Y1 != 0 {
+		t.Fatalf("dialog moved to (%d,%d) during captured combo gesture", d.X1, d.Y1)
+	}
+
+	d.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, ButtonState: 0,
+		MouseX: 20, MouseY: 6,
+	})
+	if cb.editMouseCaptured || d.rootGroup.mouseCapture != nil {
+		t.Fatal("mouse capture was not released with the button")
+	}
+}
+
 func TestDialog_DragRelativeConsistency(t *testing.T) {
 	// Test for "error accumulation" during multiple moves
 	d := NewDialog(0, 0, 10, 10, "Consistency")

--- a/dialog_test.go
+++ b/dialog_test.go
@@ -91,6 +91,13 @@ func TestDialog_NoDragWhenClickingElement(t *testing.T) {
 	if d.isDragging {
 		t.Error("Dialog should NOT start dragging when clicking on an interactive element")
 	}
+	if clicked {
+		t.Error("Button action should not run on mouse down")
+	}
+	d.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, ButtonState: 0,
+		MouseX: 1, MouseY: 1,
+	})
 	if !clicked {
 		t.Error("Button should have handled the click")
 	}

--- a/edit.go
+++ b/edit.go
@@ -864,6 +864,14 @@ func (e *Edit) ProcessMouse(ev *vtinput.InputEvent) bool {
 			}
 			if e.HitTest(int(ev.MouseX), int(ev.MouseY)) {
 				e.curPos = e.cursorPositionAtX(int(ev.MouseX))
+				if ev.MouseEventFlags&TripleClick != 0 {
+					e.SelectAll()
+					return true
+				}
+				if ev.MouseEventFlags&vtinput.DoubleClick != 0 {
+					e.selectWordAtCursor()
+					return true
+				}
 				e.ClearSelection()
 				e.clearFlag = false
 				e.mouseSelecting = true
@@ -879,6 +887,26 @@ func (e *Edit) ProcessMouse(ev *vtinput.InputEvent) bool {
 		}
 	}
 	return false
+}
+
+func (e *Edit) selectWordAtCursor() {
+	if e.curPos < 0 || e.curPos >= len(e.text) {
+		e.ClearSelection()
+		return
+	}
+
+	category := getCharCategory(e.text[e.curPos])
+	start, end := e.curPos, e.curPos+1
+	for start > 0 && getCharCategory(e.text[start-1]) == category {
+		start--
+	}
+	for end < len(e.text) && getCharCategory(e.text[end]) == category {
+		end++
+	}
+	e.selStart, e.selEnd = start, end
+	e.selAnchor = start
+	e.curPos = end
+	e.clearFlag = false
 }
 
 func (e *Edit) cursorPositionAtX(x int) int {

--- a/edit.go
+++ b/edit.go
@@ -841,6 +841,12 @@ func (e *Edit) ProcessMouse(ev *vtinput.InputEvent) bool {
 				e.OpenHistory()
 				return true
 			}
+			if e.HitTest(int(ev.MouseX), int(ev.MouseY)) {
+				e.curPos = e.cursorPositionAtX(int(ev.MouseX))
+				e.ClearSelection()
+				e.clearFlag = false
+				return true
+			}
 		}
 		// Middle-click to paste (standard TUI/Unix behavior)
 		if ev.ButtonState == vtinput.FromLeft2ndButtonPressed {
@@ -850,4 +856,24 @@ func (e *Edit) ProcessMouse(ev *vtinput.InputEvent) bool {
 		}
 	}
 	return false
+}
+
+func (e *Edit) cursorPositionAtX(x int) int {
+	if x <= e.X1 {
+		return e.leftPos
+	}
+
+	column := x - e.X1
+	width := 0
+	for i := e.leftPos; i < len(e.text); i++ {
+		runeWidth := 1
+		if !e.PasswordMode {
+			runeWidth = runewidth.RuneWidth(e.text[i])
+		}
+		if width+runeWidth > column {
+			return i
+		}
+		width += runeWidth
+	}
+	return len(e.text)
 }

--- a/edit.go
+++ b/edit.go
@@ -34,6 +34,8 @@ type Edit struct {
 	ColorSelectedIdx   int
 	HistoryID          string
 	OnTextChange       func(string)
+	mouseSelecting     bool
+	mouseSelectAnchor  int
 }
 
 // HistoryProvider is an interface for external history persistence (e.g. from f4).
@@ -835,6 +837,25 @@ func (e *Edit) ProcessMouse(ev *vtinput.InputEvent) bool {
 	if e.IsDisabled() {
 		return false
 	}
+	if e.mouseSelecting {
+		if ev.ButtonState == 0 {
+			e.mouseSelecting = false
+			return true
+		}
+		if ev.ButtonState&vtinput.FromLeft1stButtonPressed != 0 {
+			e.curPos = e.cursorPositionAtX(int(ev.MouseX))
+			e.selAnchor = e.mouseSelectAnchor
+			if e.curPos < e.selAnchor {
+				e.selStart, e.selEnd = e.curPos, e.selAnchor
+			} else {
+				e.selStart, e.selEnd = e.selAnchor, e.curPos
+			}
+			if e.selStart == e.selEnd {
+				e.ClearSelection()
+			}
+			return true
+		}
+	}
 	if ev.KeyDown {
 		if ev.ButtonState == vtinput.FromLeft1stButtonPressed {
 			if e.ShowHistoryButton && int(ev.MouseX) == e.X2 && int(ev.MouseY) == e.Y1 {
@@ -845,6 +866,8 @@ func (e *Edit) ProcessMouse(ev *vtinput.InputEvent) bool {
 				e.curPos = e.cursorPositionAtX(int(ev.MouseX))
 				e.ClearSelection()
 				e.clearFlag = false
+				e.mouseSelecting = true
+				e.mouseSelectAnchor = e.curPos
 				return true
 			}
 		}
@@ -859,8 +882,18 @@ func (e *Edit) ProcessMouse(ev *vtinput.InputEvent) bool {
 }
 
 func (e *Edit) cursorPositionAtX(x int) int {
-	if x <= e.X1 {
+	if x < e.X1 {
+		return 0
+	}
+	if x == e.X1 {
 		return e.leftPos
+	}
+	visibleRight := e.X2
+	if e.ShowHistoryButton {
+		visibleRight--
+	}
+	if x > visibleRight {
+		return len(e.text)
 	}
 
 	column := x - e.X1

--- a/framemanager.go
+++ b/framemanager.go
@@ -130,6 +130,7 @@ type frameManager struct {
 	lastMouseClickTime     time.Time
 	lastMouseX, lastMouseY int
 	lastMouseButton        uint32
+	lastMouseClickCount    int
 	lastMouseEventX        int
 	lastMouseEventY        int
 	mousePositionKnown     bool
@@ -1452,20 +1453,7 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 		return
 	}
 
-	// Generate DoubleClick flag from sequence of clicks
-	if ev.Type == vtinput.MouseEventType && ev.ButtonState != 0 && ev.KeyDown && (ev.MouseEventFlags&vtinput.MouseMoved) == 0 {
-		now := time.Now()
-		if ev.ButtonState == fm.lastMouseButton && int(ev.MouseX) == fm.lastMouseX && int(ev.MouseY) == fm.lastMouseY && now.Sub(fm.lastMouseClickTime) < 400*time.Millisecond {
-			ev.MouseEventFlags |= vtinput.DoubleClick
-			fm.lastMouseButton = 0 // prevent triple click
-			DebugLog("FM: DoubleClick generated at (%d,%d)", ev.MouseX, ev.MouseY)
-		} else {
-			fm.lastMouseButton = ev.ButtonState
-			fm.lastMouseX = int(ev.MouseX)
-			fm.lastMouseY = int(ev.MouseY)
-			fm.lastMouseClickTime = now
-		}
-	}
+	fm.markMultiClick(ev, time.Now())
 
 	topFrame := fm.frames[len(fm.frames)-1]
 	activeMenu := fm.GetActiveMenuBar()
@@ -1762,4 +1750,35 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 
 	// 4. Cleanup: Remove all frames that are marked as done.
 	fm.cleanupDoneFrames()
+}
+
+func (fm *frameManager) markMultiClick(ev *vtinput.InputEvent, now time.Time) {
+	if ev.Type != vtinput.MouseEventType || ev.ButtonState == 0 || !ev.KeyDown || ev.MouseEventFlags&vtinput.MouseMoved != 0 {
+		return
+	}
+
+	sameClick := ev.ButtonState == fm.lastMouseButton &&
+		int(ev.MouseX) == fm.lastMouseX && int(ev.MouseY) == fm.lastMouseY &&
+		now.Sub(fm.lastMouseClickTime) < 400*time.Millisecond
+	if sameClick {
+		fm.lastMouseClickCount++
+	} else {
+		fm.lastMouseClickCount = 1
+	}
+
+	fm.lastMouseButton = ev.ButtonState
+	fm.lastMouseX = int(ev.MouseX)
+	fm.lastMouseY = int(ev.MouseY)
+	fm.lastMouseClickTime = now
+
+	switch fm.lastMouseClickCount {
+	case 2:
+		ev.MouseEventFlags |= vtinput.DoubleClick
+		DebugLog("FM: DoubleClick generated at (%d,%d)", ev.MouseX, ev.MouseY)
+	case 3:
+		ev.MouseEventFlags &^= vtinput.DoubleClick
+		ev.MouseEventFlags |= TripleClick
+		fm.lastMouseClickCount = 0
+		DebugLog("FM: TripleClick generated at (%d,%d)", ev.MouseX, ev.MouseY)
+	}
 }

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -1788,19 +1788,7 @@ func TestFrameManager_DoubleClickDetection(t *testing.T) {
 	fm.Push(frame)
 
 	dispatch := func(e *vtinput.InputEvent) {
-		// Simplified dispatch from fm.Run()
-		if e.Type == vtinput.MouseEventType && e.ButtonState != 0 && e.KeyDown && (e.MouseEventFlags&vtinput.MouseMoved) == 0 {
-			now := time.Now()
-			if e.ButtonState == fm.lastMouseButton && int(e.MouseX) == fm.lastMouseX && int(e.MouseY) == fm.lastMouseY && now.Sub(fm.lastMouseClickTime) < 400*time.Millisecond {
-				e.MouseEventFlags |= vtinput.DoubleClick
-				fm.lastMouseButton = 0 // prevent triple click
-			} else {
-				fm.lastMouseButton = e.ButtonState
-				fm.lastMouseX = int(e.MouseX)
-				fm.lastMouseY = int(e.MouseY)
-				fm.lastMouseClickTime = now
-			}
-		}
+		fm.markMultiClick(e, time.Now())
 		frame.ProcessMouse(e)
 	}
 
@@ -1817,21 +1805,31 @@ func TestFrameManager_DoubleClickDetection(t *testing.T) {
 		t.Error("Fast second click was not detected as double click")
 	}
 
-	// 3. Slow third click - no double click
-	time.Sleep(500 * time.Millisecond)
+	// 3. Fast third click, same spot - IS triple click
+	time.Sleep(100 * time.Millisecond)
 	dispatch(&vtinput.InputEvent{Type: vtinput.MouseEventType, KeyDown: true, MouseX: 10, MouseY: 10, ButtonState: vtinput.FromLeft1stButtonPressed})
+	if (lastEvent.MouseEventFlags & TripleClick) == 0 {
+		t.Error("Fast third click was not detected as triple click")
+	}
 	if (lastEvent.MouseEventFlags & vtinput.DoubleClick) != 0 {
-		t.Error("Slow third click should not be a double click")
+		t.Error("Triple click should not also be marked as double click")
 	}
 
-	// 4. Fast click, different spot - no double click
+	// 4. Slow next click - no multi-click
+	time.Sleep(500 * time.Millisecond)
+	dispatch(&vtinput.InputEvent{Type: vtinput.MouseEventType, KeyDown: true, MouseX: 10, MouseY: 10, ButtonState: vtinput.FromLeft1stButtonPressed})
+	if (lastEvent.MouseEventFlags & (vtinput.DoubleClick | TripleClick)) != 0 {
+		t.Error("Slow click should not be a multi-click")
+	}
+
+	// 5. Fast click, different spot - no double click
 	time.Sleep(100 * time.Millisecond)
 	dispatch(&vtinput.InputEvent{Type: vtinput.MouseEventType, KeyDown: true, MouseX: 11, MouseY: 10, ButtonState: vtinput.FromLeft1stButtonPressed})
 	if (lastEvent.MouseEventFlags & vtinput.DoubleClick) != 0 {
 		t.Error("Click in different spot should not be a double click")
 	}
 
-	// 5. Fast click, different button - no double click
+	// 6. Fast click, different button - no double click
 	time.Sleep(100 * time.Millisecond)
 	dispatch(&vtinput.InputEvent{Type: vtinput.MouseEventType, KeyDown: true, MouseX: 11, MouseY: 10, ButtonState: vtinput.RightmostButtonPressed})
 	if (lastEvent.MouseEventFlags & vtinput.DoubleClick) != 0 {

--- a/group.go
+++ b/group.go
@@ -14,10 +14,11 @@ type FocusDirectionSetter interface {
 }
 type Group struct {
 	ScreenObject
-	items     []UIElement
-	focusIdx  int
-	WrapFocus bool
-	links     []autoLink
+	items        []UIElement
+	focusIdx     int
+	WrapFocus    bool
+	links        []autoLink
+	mouseCapture UIElement
 }
 
 func (g *Group) SetFocusDirection(direction int) {
@@ -245,6 +246,14 @@ func (g *Group) ProcessKey(e *vtinput.InputEvent) bool {
 
 // ProcessMouse handles mouse events by hit-testing child elements.
 func (g *Group) ProcessMouse(e *vtinput.InputEvent) bool {
+	if g.mouseCapture != nil {
+		g.mouseCapture.ProcessMouse(e)
+		if e.ButtonState == 0 {
+			g.mouseCapture = nil
+		}
+		return true
+	}
+
 	mx, my := int(e.MouseX), int(e.MouseY)
 	for i := len(g.items) - 1; i >= 0; i-- {
 		item := g.items[i]
@@ -255,6 +264,9 @@ func (g *Group) ProcessMouse(e *vtinput.InputEvent) bool {
 				}
 			}
 			if item.ProcessMouse(e) {
+				if e.KeyDown && e.ButtonState != 0 && e.MouseEventFlags&vtinput.MouseMoved == 0 {
+					g.mouseCapture = item
+				}
 				return true
 			}
 

--- a/group_test.go
+++ b/group_test.go
@@ -333,6 +333,10 @@ func TestGroup_ProcessMouse_EmptySpacePropagation(t *testing.T) {
 	if win.isDragging {
 		t.Error("Click on button should not initiate window dragging")
 	}
+	win.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, MouseX: 18, MouseY: 9,
+		ButtonState: 0, KeyDown: false,
+	})
 
 	// Тест 2: Клик по пустому пространству GroupBox должен провалиться глубже
 	// и инициировать перетаскивание родительского BaseWindow

--- a/types.go
+++ b/types.go
@@ -2,6 +2,10 @@ package vtui
 
 import "github.com/unxed/vtinput"
 
+// TripleClick is a VTUI mouse event flag generated for the third consecutive
+// click at the same position. The native console flags only define DoubleClick.
+const TripleClick uint32 = 0x0010
+
 // Coord defines the coordinates in the console.
 type Coord struct {
 	X int16


### PR DESCRIPTION
## Summary
- match the combo box arrow background with the edit field state
- move the edit cursor to the clicked character
- capture edit mouse gestures until button release
- support linear drag selection inside and outside edit controls
- select a word on double-click and all text on triple-click
- prevent captured edit gestures from opening dropdowns or moving dialogs
- show buttons as pressed on mouse down and execute their action only on release inside
- cancel button activation when released outside

## Tests
- targeted Button, Edit, ComboBox, Group, Dialog, and multi-click tests