### PR TITLE
Add MultiLineEdit — rectangular multi-line text field

### DIFF
--- a/multilineedit.go
+++ b/multilineedit.go
@@ -1,0 +1,586 @@
+package vtui
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/unxed/vtinput"
+)
+
+// MultiLineEdit is a rectangular text field with multiple visible lines.
+// It's the natural companion to Edit for dialog fields whose content
+// spans several lines (a stack of commands, a description paragraph,
+// etc.). Model: lines are stored as [][]rune, one row per string; the
+// cursor is (curRow, curCol) in rune coordinates. Rendering scrolls
+// horizontally per active row and vertically over the whole buffer.
+//
+// Not in scope for the initial cut:
+//   - selection (Shift+arrows)
+//   - overtype / undo / redo
+//   - word wrap (long lines scroll horizontally on the current row only)
+//
+// Ctrl+V / Shift+Ins paste (splitting on \n) IS supported so users can
+// bring in multiline chunks from the system clipboard.
+type MultiLineEdit struct {
+	ScreenObject
+	lines        [][]rune
+	curRow       int
+	curCol       int
+	leftPos      int // horizontal scroll for the current row
+	topPos       int // vertical scroll for the whole buffer
+	pasting      bool
+	pasteBuffer  []rune
+	OnTextChange func(string)
+	// ColorTextIdx allows callers to override the default palette entry
+	// (e.g. dim inactive field). Falls back to ColDialogEdit.
+	ColorTextIdx int
+}
+
+// NewMultiLineEdit builds a new multiline edit control anchored at (x, y)
+// with the given visible dimensions (in cells). The default text is split
+// by "\n"; an empty string yields a single empty row.
+func NewMultiLineEdit(x, y, width, height int, defaultText string) *MultiLineEdit {
+	m := &MultiLineEdit{
+		ColorTextIdx: ColDialogEdit,
+	}
+	m.canFocus = true
+	if height < 1 {
+		height = 1
+	}
+	if width < 1 {
+		width = 1
+	}
+	m.SetPosition(x, y, x+width-1, y+height-1)
+	m.SetText(defaultText)
+	return m
+}
+
+// GetText returns the buffer content joined with "\n".
+func (m *MultiLineEdit) GetText() string {
+	parts := make([]string, len(m.lines))
+	for i, line := range m.lines {
+		parts[i] = string(line)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// SetText replaces the entire buffer with the given text, splitting on
+// "\n". An empty text becomes a single empty row so the cursor always
+// has a valid position.
+func (m *MultiLineEdit) SetText(text string) {
+	parts := strings.Split(text, "\n")
+	m.lines = make([][]rune, len(parts))
+	for i, p := range parts {
+		m.lines[i] = []rune(p)
+	}
+	if len(m.lines) == 0 {
+		m.lines = [][]rune{nil}
+	}
+	m.curRow = 0
+	m.curCol = 0
+	m.leftPos = 0
+	m.topPos = 0
+	m.notifyChange()
+}
+
+// GetLines returns a copy of the buffer as a slice of strings.
+func (m *MultiLineEdit) GetLines() []string {
+	out := make([]string, len(m.lines))
+	for i, line := range m.lines {
+		out[i] = string(line)
+	}
+	return out
+}
+
+// SetLines replaces the buffer with the given rows.
+func (m *MultiLineEdit) SetLines(lines []string) {
+	if len(lines) == 0 {
+		m.lines = [][]rune{nil}
+	} else {
+		m.lines = make([][]rune, len(lines))
+		for i, s := range lines {
+			m.lines[i] = []rune(s)
+		}
+	}
+	m.curRow = 0
+	m.curCol = 0
+	m.leftPos = 0
+	m.topPos = 0
+	m.notifyChange()
+}
+
+// GetData / SetData let dialogs treat the widget as a DataControl.
+func (m *MultiLineEdit) GetData() any { return m.GetText() }
+func (m *MultiLineEdit) SetData(v any) {
+	if s, ok := v.(string); ok {
+		m.SetText(s)
+	}
+}
+
+// WantsChars — dialog input routing sends printable characters here
+// only when this returns true.
+func (m *MultiLineEdit) WantsChars() bool { return true }
+
+// notifyChange fires OnTextChange (used by callers to enable/disable
+// buttons, etc.). Also mirrors ScreenObject.NotifyChange for owners.
+func (m *MultiLineEdit) notifyChange() {
+	if m.OnTextChange != nil {
+		m.OnTextChange(m.GetText())
+	}
+	m.NotifyChange()
+}
+
+func (m *MultiLineEdit) viewHeight() int {
+	h := m.Y2 - m.Y1 + 1
+	if h < 1 {
+		return 1
+	}
+	return h
+}
+
+func (m *MultiLineEdit) viewWidth() int {
+	w := m.X2 - m.X1 + 1
+	if w < 1 {
+		return 1
+	}
+	return w
+}
+
+// runesWidth measures the on-screen width of a rune slice.
+func runesWidth(runes []rune) int {
+	w := 0
+	for _, r := range runes {
+		w += runewidth.RuneWidth(r)
+	}
+	return w
+}
+
+// ensureVisible scrolls topPos / leftPos so the cursor is on screen.
+// Called after every mutation or navigation.
+func (m *MultiLineEdit) ensureVisible() {
+	if m.curRow < 0 {
+		m.curRow = 0
+	}
+	if m.curRow >= len(m.lines) {
+		m.curRow = len(m.lines) - 1
+	}
+	line := m.lines[m.curRow]
+	if m.curCol < 0 {
+		m.curCol = 0
+	}
+	if m.curCol > len(line) {
+		m.curCol = len(line)
+	}
+
+	// Vertical scroll: keep curRow inside [topPos, topPos+viewHeight-1].
+	vh := m.viewHeight()
+	if m.curRow < m.topPos {
+		m.topPos = m.curRow
+	} else if m.curRow >= m.topPos+vh {
+		m.topPos = m.curRow - vh + 1
+	}
+	if m.topPos < 0 {
+		m.topPos = 0
+	}
+
+	// Horizontal scroll for the CURRENT row only. Long lines scroll
+	// under the cursor; other rows show their visible slice starting
+	// at leftPos too, so long lines aren't invisibly clipped.
+	vw := m.viewWidth()
+	if m.curCol < m.leftPos {
+		m.leftPos = m.curCol
+	}
+	// Measure width from leftPos up to (and including) the cursor.
+	width := runesWidth(line[m.leftPos:m.curCol])
+	for m.leftPos < m.curCol && width >= vw {
+		width -= runewidth.RuneWidth(line[m.leftPos])
+		m.leftPos++
+	}
+}
+
+// Show paints the widget onto scr.
+func (m *MultiLineEdit) Show(scr *ScreenBuf) {
+	m.ScreenObject.Show(scr)
+	m.ensureVisible()
+	m.DisplayObject(scr)
+	if m.IsFocused() {
+		scr.SetCursorVisible(true)
+		scr.SetCursorShape(CursorShapeUnderline)
+		line := m.lines[m.curRow]
+		off := runesWidth(line[m.leftPos:m.curCol])
+		scr.SetCursorPos(m.X1+off, m.Y1+m.curRow-m.topPos)
+	}
+}
+
+// DisplayObject fills the widget rectangle with background attribute
+// and renders each visible row starting at leftPos.
+func (m *MultiLineEdit) DisplayObject(scr *ScreenBuf) {
+	if !m.IsVisible() {
+		return
+	}
+	attr := m.GetStateAttr(m.ColorTextIdx, m.ColorTextIdx)
+	if m.IsDisabled() {
+		attr = DimColor(attr)
+	}
+	scr.FillRect(m.X1, m.Y1, m.X2, m.Y2, ' ', attr)
+
+	vw := m.viewWidth()
+	vh := m.viewHeight()
+	for row := 0; row < vh; row++ {
+		idx := m.topPos + row
+		if idx >= len(m.lines) {
+			break
+		}
+		line := m.lines[idx]
+		start := m.leftPos
+		if start > len(line) {
+			continue
+		}
+		x := 0
+		for i := start; i < len(line); i++ {
+			w := runewidth.RuneWidth(line[i])
+			if x+w > vw {
+				break
+			}
+			scr.Write(m.X1+x, m.Y1+row, StringToCharInfo(string(line[i]), attr))
+			x += w
+		}
+	}
+}
+
+// ProcessKey handles navigation, insertion, deletion and paste. Returns
+// true when the event was consumed so the surrounding dialog knows not
+// to reroute it.
+func (m *MultiLineEdit) ProcessKey(event *vtinput.InputEvent) bool {
+	if event.Type == vtinput.PasteEventType {
+		if event.PasteStart {
+			m.pasting = true
+			m.pasteBuffer = m.pasteBuffer[:0]
+		} else {
+			m.pasting = false
+			if len(m.pasteBuffer) > 0 {
+				m.insertString(string(m.pasteBuffer))
+			}
+			m.pasteBuffer = nil
+		}
+		return true
+	}
+	if m.pasting {
+		if event.Type == vtinput.KeyEventType && event.KeyDown && event.Char != 0 {
+			m.pasteBuffer = append(m.pasteBuffer, event.Char)
+		}
+		return true
+	}
+	if !event.KeyDown {
+		return false
+	}
+
+	ctrl := (event.ControlKeyState & (vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed)) != 0
+	alt := (event.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
+	shift := (event.ControlKeyState & vtinput.ShiftPressed) != 0
+
+	// Clipboard: Ctrl+V and Shift+Ins paste (may span multiple lines).
+	if ctrl && !alt && !shift && event.VirtualKeyCode == vtinput.VK_V {
+		if text := GetClipboard(); text != "" {
+			m.insertString(text)
+		}
+		return true
+	}
+	if shift && !ctrl && !alt && event.VirtualKeyCode == vtinput.VK_INSERT {
+		if text := GetClipboard(); text != "" {
+			m.insertString(text)
+		}
+		return true
+	}
+
+	switch event.VirtualKeyCode {
+	case vtinput.VK_LEFT:
+		if ctrl || alt || shift {
+			return false
+		}
+		if m.curCol > 0 {
+			m.curCol--
+		} else if m.curRow > 0 {
+			m.curRow--
+			m.curCol = len(m.lines[m.curRow])
+		}
+		m.ensureVisible()
+		return true
+	case vtinput.VK_RIGHT:
+		if ctrl || alt || shift {
+			return false
+		}
+		line := m.lines[m.curRow]
+		if m.curCol < len(line) {
+			m.curCol++
+		} else if m.curRow+1 < len(m.lines) {
+			m.curRow++
+			m.curCol = 0
+		}
+		m.ensureVisible()
+		return true
+	case vtinput.VK_UP:
+		if ctrl || alt || shift {
+			return false
+		}
+		if m.curRow > 0 {
+			m.curRow--
+			m.ensureVisible()
+		}
+		return true
+	case vtinput.VK_DOWN:
+		if ctrl || alt || shift {
+			return false
+		}
+		if m.curRow+1 < len(m.lines) {
+			m.curRow++
+			m.ensureVisible()
+		}
+		return true
+	case vtinput.VK_HOME:
+		if alt || shift {
+			return false
+		}
+		if ctrl {
+			m.curRow = 0
+		}
+		m.curCol = 0
+		m.ensureVisible()
+		return true
+	case vtinput.VK_END:
+		if alt || shift {
+			return false
+		}
+		if ctrl {
+			m.curRow = len(m.lines) - 1
+		}
+		m.curCol = len(m.lines[m.curRow])
+		m.ensureVisible()
+		return true
+	case vtinput.VK_PRIOR:
+		if ctrl || alt || shift {
+			return false
+		}
+		step := m.viewHeight()
+		m.curRow -= step
+		m.topPos -= step
+		m.ensureVisible()
+		return true
+	case vtinput.VK_NEXT:
+		if ctrl || alt || shift {
+			return false
+		}
+		step := m.viewHeight()
+		m.curRow += step
+		m.topPos += step
+		m.ensureVisible()
+		return true
+	case vtinput.VK_RETURN:
+		if ctrl || alt || shift {
+			// Ctrl+Enter / Shift+Enter / Alt+Enter are for the surrounding
+			// dialog (e.g. default button, insert-something menu). Let it
+			// through.
+			return false
+		}
+		m.splitLine()
+		return true
+	case vtinput.VK_BACK:
+		if ctrl || alt || shift {
+			return false
+		}
+		m.backspace()
+		return true
+	case vtinput.VK_DELETE:
+		if ctrl || alt || shift {
+			return false
+		}
+		m.deleteForward()
+		return true
+	}
+
+	// Printable character insertion — only when no Ctrl/Alt is held so we
+	// don't swallow dialog shortcuts (Alt+letter hotkeys, etc.).
+	if event.Char != 0 && !ctrl && !alt && unicode.IsPrint(event.Char) {
+		m.insertRune(event.Char)
+		return true
+	}
+	return false
+}
+
+// ProcessMouse repositions the cursor on left-click inside the widget.
+// Wheel-scroll adjusts topPos.
+func (m *MultiLineEdit) ProcessMouse(event *vtinput.InputEvent) bool {
+	if event.Type != vtinput.MouseEventType {
+		return false
+	}
+	if event.WheelDirection != 0 {
+		if event.WheelDirection > 0 && m.topPos > 0 {
+			m.topPos--
+		} else if event.WheelDirection < 0 && m.topPos+1 <= len(m.lines)-1 {
+			m.topPos++
+		}
+		return true
+	}
+	if event.ButtonState == vtinput.FromLeft1stButtonPressed && event.KeyDown {
+		x := int(event.MouseX) - m.X1
+		y := int(event.MouseY) - m.Y1
+		if x < 0 || y < 0 || x >= m.viewWidth() || y >= m.viewHeight() {
+			return false
+		}
+		row := m.topPos + y
+		if row >= len(m.lines) {
+			row = len(m.lines) - 1
+		}
+		m.curRow = row
+		// Walk the row measuring widths until we reach x.
+		line := m.lines[m.curRow]
+		col := m.leftPos
+		acc := 0
+		for col < len(line) && acc+runewidth.RuneWidth(line[col]) <= x {
+			acc += runewidth.RuneWidth(line[col])
+			col++
+		}
+		m.curCol = col
+		m.ensureVisible()
+		return true
+	}
+	return false
+}
+
+// --- mutations ---
+
+// insertRune inserts r at the cursor and advances curCol.
+func (m *MultiLineEdit) insertRune(r rune) {
+	line := m.lines[m.curRow]
+	newLine := make([]rune, 0, len(line)+1)
+	newLine = append(newLine, line[:m.curCol]...)
+	newLine = append(newLine, r)
+	newLine = append(newLine, line[m.curCol:]...)
+	m.lines[m.curRow] = newLine
+	m.curCol++
+	m.ensureVisible()
+	m.notifyChange()
+}
+
+// insertString inserts text at the cursor, splitting on "\n".
+func (m *MultiLineEdit) insertString(text string) {
+	if text == "" {
+		return
+	}
+	// Normalize CRLF and LF.
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	parts := strings.Split(text, "\n")
+
+	line := m.lines[m.curRow]
+	head := append([]rune{}, line[:m.curCol]...)
+	tail := append([]rune{}, line[m.curCol:]...)
+
+	// First fragment glues to the current row's head.
+	first := []rune(parts[0])
+	head = append(head, first...)
+
+	if len(parts) == 1 {
+		// Single-line paste — put tail back on the same row.
+		m.lines[m.curRow] = append(head, tail...)
+		m.curCol = len(head)
+		m.ensureVisible()
+		m.notifyChange()
+		return
+	}
+
+	// Last fragment gets the original tail appended.
+	last := append([]rune(parts[len(parts)-1]), tail...)
+	// Middle fragments are their own rows.
+	middle := make([][]rune, 0, len(parts)-1)
+	for i := 1; i < len(parts)-1; i++ {
+		middle = append(middle, []rune(parts[i]))
+	}
+
+	newLines := make([][]rune, 0, len(m.lines)+len(parts)-1)
+	newLines = append(newLines, m.lines[:m.curRow]...)
+	newLines = append(newLines, head)
+	newLines = append(newLines, middle...)
+	newLines = append(newLines, last)
+	newLines = append(newLines, m.lines[m.curRow+1:]...)
+	m.lines = newLines
+	m.curRow = m.curRow + len(parts) - 1
+	m.curCol = len([]rune(parts[len(parts)-1]))
+	m.ensureVisible()
+	m.notifyChange()
+}
+
+// splitLine breaks the current row at the cursor. Enter without modifiers.
+func (m *MultiLineEdit) splitLine() {
+	line := m.lines[m.curRow]
+	head := append([]rune{}, line[:m.curCol]...)
+	tail := append([]rune{}, line[m.curCol:]...)
+	newLines := make([][]rune, 0, len(m.lines)+1)
+	newLines = append(newLines, m.lines[:m.curRow]...)
+	newLines = append(newLines, head)
+	newLines = append(newLines, tail)
+	newLines = append(newLines, m.lines[m.curRow+1:]...)
+	m.lines = newLines
+	m.curRow++
+	m.curCol = 0
+	m.ensureVisible()
+	m.notifyChange()
+}
+
+// backspace deletes the char before the cursor, or merges with the
+// previous row when the cursor is at column zero.
+func (m *MultiLineEdit) backspace() {
+	if m.curCol > 0 {
+		line := m.lines[m.curRow]
+		m.lines[m.curRow] = append(line[:m.curCol-1], line[m.curCol:]...)
+		m.curCol--
+		m.ensureVisible()
+		m.notifyChange()
+		return
+	}
+	if m.curRow == 0 {
+		return
+	}
+	prev := m.lines[m.curRow-1]
+	newCol := len(prev)
+	m.lines[m.curRow-1] = append(prev, m.lines[m.curRow]...)
+	m.lines = append(m.lines[:m.curRow], m.lines[m.curRow+1:]...)
+	m.curRow--
+	m.curCol = newCol
+	m.ensureVisible()
+	m.notifyChange()
+}
+
+// deleteForward deletes the char at the cursor, or joins with the next
+// row when the cursor is at end-of-line.
+func (m *MultiLineEdit) deleteForward() {
+	line := m.lines[m.curRow]
+	if m.curCol < len(line) {
+		m.lines[m.curRow] = append(line[:m.curCol], line[m.curCol+1:]...)
+		m.notifyChange()
+		return
+	}
+	if m.curRow+1 >= len(m.lines) {
+		return
+	}
+	next := m.lines[m.curRow+1]
+	m.lines[m.curRow] = append(line, next...)
+	m.lines = append(m.lines[:m.curRow+1], m.lines[m.curRow+2:]...)
+	m.notifyChange()
+}
+
+// CursorPos exposes (row, col) for tests and dialogs that want to
+// restore a saved caret. Zero-indexed.
+func (m *MultiLineEdit) CursorPos() (int, int) { return m.curRow, m.curCol }
+
+// SetCursorPos moves the cursor to the given (row, col), clamping to
+// valid range. Scrolls the viewport so the cursor is visible.
+func (m *MultiLineEdit) SetCursorPos(row, col int) {
+	m.curRow = row
+	m.curCol = col
+	m.ensureVisible()
+}
+
+// LineCount returns the number of rows in the buffer.
+func (m *MultiLineEdit) LineCount() int { return len(m.lines) }

--- a/multilineedit_test.go
+++ b/multilineedit_test.go
@@ -1,0 +1,242 @@
+package vtui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unxed/vtinput"
+)
+
+// key builds a simple keydown InputEvent with the given VK / Char / mods.
+func mleKey(vk uint16, ch rune, mods vtinput.ControlKeyState) *vtinput.InputEvent {
+	return &vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vk,
+		Char:            ch,
+		ControlKeyState: mods,
+	}
+}
+
+func mleType(m *MultiLineEdit, s string) {
+	for _, r := range s {
+		m.ProcessKey(mleKey(0, r, 0))
+	}
+}
+
+func TestMultiLineEdit_SetGetText(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "a\nb\nc")
+	if got := m.GetText(); got != "a\nb\nc" {
+		t.Errorf("GetText = %q, want %q", got, "a\nb\nc")
+	}
+	if got := m.LineCount(); got != 3 {
+		t.Errorf("LineCount = %d, want 3", got)
+	}
+}
+
+func TestMultiLineEdit_SetTextEmptyGivesOneEmptyRow(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "")
+	if got := m.LineCount(); got != 1 {
+		t.Errorf("LineCount = %d, want 1 (empty text still needs a row for the cursor)", got)
+	}
+	row, col := m.CursorPos()
+	if row != 0 || col != 0 {
+		t.Errorf("CursorPos = (%d,%d), want (0,0)", row, col)
+	}
+}
+
+func TestMultiLineEdit_TypeInsertsAtCursor(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "")
+	mleType(m, "hello")
+	if got := m.GetText(); got != "hello" {
+		t.Errorf("after typing: %q, want %q", got, "hello")
+	}
+	row, col := m.CursorPos()
+	if row != 0 || col != 5 {
+		t.Errorf("CursorPos = (%d,%d), want (0,5)", row, col)
+	}
+}
+
+func TestMultiLineEdit_EnterSplitsLine(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "abcdef")
+	// Move cursor to col 3.
+	m.SetCursorPos(0, 3)
+	m.ProcessKey(mleKey(vtinput.VK_RETURN, '\r', 0))
+	if got := m.GetText(); got != "abc\ndef" {
+		t.Errorf("after Enter: %q, want %q", got, "abc\ndef")
+	}
+	row, col := m.CursorPos()
+	if row != 1 || col != 0 {
+		t.Errorf("CursorPos after split = (%d,%d), want (1,0)", row, col)
+	}
+}
+
+func TestMultiLineEdit_BackspaceMergesWithPrevRow(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "abc\ndef")
+	m.SetCursorPos(1, 0)
+	m.ProcessKey(mleKey(vtinput.VK_BACK, 0, 0))
+	if got := m.GetText(); got != "abcdef" {
+		t.Errorf("after BS at col=0: %q, want %q", got, "abcdef")
+	}
+	row, col := m.CursorPos()
+	if row != 0 || col != 3 {
+		t.Errorf("CursorPos = (%d,%d), want (0,3)", row, col)
+	}
+}
+
+func TestMultiLineEdit_DeleteJoinsNextRow(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "abc\ndef")
+	m.SetCursorPos(0, 3) // end of first line
+	m.ProcessKey(mleKey(vtinput.VK_DELETE, 0, 0))
+	if got := m.GetText(); got != "abcdef" {
+		t.Errorf("after Del at eol: %q, want %q", got, "abcdef")
+	}
+}
+
+func TestMultiLineEdit_ArrowsWrapAcrossLines(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "ab\ncd")
+	m.SetCursorPos(0, 2) // end of first line
+	m.ProcessKey(mleKey(vtinput.VK_RIGHT, 0, 0))
+	if row, col := m.CursorPos(); row != 1 || col != 0 {
+		t.Errorf("Right at eol → (%d,%d), want (1,0)", row, col)
+	}
+	m.ProcessKey(mleKey(vtinput.VK_LEFT, 0, 0))
+	if row, col := m.CursorPos(); row != 0 || col != 2 {
+		t.Errorf("Left at bol → (%d,%d), want (0,2)", row, col)
+	}
+}
+
+func TestMultiLineEdit_HomeEnd(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "abcdef\n1234")
+	m.SetCursorPos(1, 2)
+	m.ProcessKey(mleKey(vtinput.VK_HOME, 0, 0))
+	if row, col := m.CursorPos(); row != 1 || col != 0 {
+		t.Errorf("Home → (%d,%d), want (1,0)", row, col)
+	}
+	m.ProcessKey(mleKey(vtinput.VK_END, 0, 0))
+	if row, col := m.CursorPos(); row != 1 || col != 4 {
+		t.Errorf("End → (%d,%d), want (1,4)", row, col)
+	}
+	// Ctrl+Home / Ctrl+End jump to buffer start / end.
+	m.ProcessKey(mleKey(vtinput.VK_HOME, 0, vtinput.LeftCtrlPressed))
+	if row, col := m.CursorPos(); row != 0 || col != 0 {
+		t.Errorf("Ctrl+Home → (%d,%d), want (0,0)", row, col)
+	}
+	m.ProcessKey(mleKey(vtinput.VK_END, 0, vtinput.LeftCtrlPressed))
+	if row, col := m.CursorPos(); row != 1 || col != 4 {
+		t.Errorf("Ctrl+End → (%d,%d), want (1,4)", row, col)
+	}
+}
+
+func TestMultiLineEdit_MultiLinePasteViaInsertString(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "PRE\nSUF")
+	m.SetCursorPos(0, 3) // end of "PRE"
+	m.insertString("X\nY\nZ")
+	want := "PREX\nY\nZ\nSUF"
+	if got := m.GetText(); got != want {
+		t.Errorf("after paste: %q, want %q", got, want)
+	}
+	if row, col := m.CursorPos(); row != 2 || col != 1 {
+		t.Errorf("CursorPos = (%d,%d), want (2,1) — end of last pasted fragment", row, col)
+	}
+}
+
+func TestMultiLineEdit_SetTextResetsCursor(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "old")
+	m.SetCursorPos(0, 3)
+	m.SetText("brand\nnew")
+	if row, col := m.CursorPos(); row != 0 || col != 0 {
+		t.Errorf("cursor after SetText = (%d,%d), want (0,0)", row, col)
+	}
+}
+
+func TestMultiLineEdit_GetSetLines(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "")
+	m.SetLines([]string{"one", "two", "three"})
+	if got := m.GetLines(); len(got) != 3 || got[0] != "one" || got[2] != "three" {
+		t.Errorf("GetLines = %v", got)
+	}
+	if got := m.GetText(); got != "one\ntwo\nthree" {
+		t.Errorf("GetText after SetLines = %q", got)
+	}
+}
+
+func TestMultiLineEdit_BracketedPasteAccumulates(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "")
+	m.ProcessKey(&vtinput.InputEvent{Type: vtinput.PasteEventType, PasteStart: true})
+	for _, r := range "a\nb" {
+		m.ProcessKey(mleKey(0, r, 0))
+	}
+	m.ProcessKey(&vtinput.InputEvent{Type: vtinput.PasteEventType, PasteStart: false})
+	if got := m.GetText(); got != "a\nb" {
+		t.Errorf("after bracketed paste: %q, want %q", got, "a\nb")
+	}
+}
+
+func TestMultiLineEdit_MouseClickMovesCursor(t *testing.T) {
+	m := NewMultiLineEdit(2, 3, 20, 5, "hello\nworld")
+	// Click at physical (5, 4) → x=3, y=1 → row 1, col 3.
+	m.ProcessMouse(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      5,
+		MouseY:      4,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+	})
+	if row, col := m.CursorPos(); row != 1 || col != 3 {
+		t.Errorf("cursor after click = (%d,%d), want (1,3)", row, col)
+	}
+}
+
+// TestMultiLineEdit_ScrollHorizontalOnLongLine — long lines should scroll
+// under the cursor, not clip it invisibly.
+func TestMultiLineEdit_ScrollHorizontalOnLongLine(t *testing.T) {
+	line := strings.Repeat("x", 50)
+	m := NewMultiLineEdit(0, 0, 10, 3, line)
+	m.SetCursorPos(0, 40)
+	// After ensureVisible (via Show()) the leftPos should have moved so
+	// the cursor at col 40 is inside the 10-wide viewport.
+	m.ensureVisible()
+	if m.leftPos >= 40 {
+		t.Errorf("leftPos = %d, want < 40", m.leftPos)
+	}
+	if _, col := m.CursorPos(); col-m.leftPos >= 10 {
+		t.Errorf("cursor visible range: col=%d, leftPos=%d, viewWidth=10", col, m.leftPos)
+	}
+}
+
+// TestMultiLineEdit_OnTextChange fires on every mutation.
+func TestMultiLineEdit_OnTextChange(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "")
+	count := 0
+	m.OnTextChange = func(string) { count++ }
+	mleType(m, "hi")
+	m.ProcessKey(mleKey(vtinput.VK_RETURN, '\r', 0))
+	mleType(m, "there")
+	if count == 0 {
+		t.Fatal("OnTextChange never fired")
+	}
+	if got := m.GetText(); got != "hi\nthere" {
+		t.Errorf("GetText = %q", got)
+	}
+}
+
+func TestMultiLineEdit_WantsChars(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "")
+	if !m.WantsChars() {
+		t.Error("MultiLineEdit must accept printable chars")
+	}
+}
+
+// TestMultiLineEdit_CtrlEnterLeavesEvent — Ctrl+Enter should NOT be
+// swallowed, so the enclosing dialog can bind it to a default button.
+func TestMultiLineEdit_CtrlEnterLeavesEvent(t *testing.T) {
+	m := NewMultiLineEdit(0, 0, 20, 5, "line1")
+	consumed := m.ProcessKey(mleKey(vtinput.VK_RETURN, '\r', vtinput.LeftCtrlPressed))
+	if consumed {
+		t.Error("Ctrl+Enter should not be consumed by MultiLineEdit — dialog needs it")
+	}
+	if got := m.GetText(); got != "line1" {
+		t.Errorf("buffer unexpectedly changed: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `MultiLineEdit`, a rectangular multi-line text field. Companion to `Edit`, not a replacement.

Motivation: the f4 side wants a proper multi-line command box for the F2 user-menu editor (see [`unxed/f4#342`](https://github.com/unxed/f4/issues/342)) that mirrors FAR's edit-menu-item dialog. Longer term the widget is useful anywhere a single-line `Edit` isn't enough — description paragraphs, notes fields, address lists, etc.

### Model

- Lines stored as `[][]rune`, one row per element.
- Cursor is `(curRow, curCol)` in rune coordinates.
- Rendering scrolls horizontally per active row and vertically over the whole buffer.

### Behaviour

| Key                  | Effect                                                                                                    |
|----------------------|-----------------------------------------------------------------------------------------------------------|
| Left / Right         | Move within line; at bol / eol wraps to the previous / next line                                          |
| Up / Down            | Change row (col clamped)                                                                                  |
| Home / End           | Line start / end                                                                                          |
| Ctrl+Home / Ctrl+End | Buffer start / end                                                                                        |
| PgUp / PgDn          | Move viewport by one page                                                                                 |
| Enter (plain)        | Split current line at cursor                                                                              |
| Ctrl/Shift/Alt+Enter | **Not consumed** — dialog can bind to default button, insert menu, …                                      |
| Backspace            | Delete previous rune, or merge with previous line at column 0                                             |
| Delete               | Delete rune at cursor, or join with next line at eol                                                      |
| Printable char       | Insert at cursor (only when Ctrl/Alt aren't held so Alt-hotkeys survive)                                  |
| Ctrl+V, Shift+Ins    | Paste from system clipboard, splitting on `\n` (also handles CRLF / bare CR)                              |
| Bracketed paste      | Accumulates payload and inserts in one atomic mutation on end-of-paste                                    |
| Left click           | Positions cursor                                                                                          |
| Mouse wheel          | Scrolls viewport by one row                                                                               |

### Public API

- `GetText` / `SetText` — joined-by-`"\n"` round trip
- `GetLines` / `SetLines` — slice-of-strings round trip
- `CursorPos` / `SetCursorPos` — `(row, col)`
- `LineCount`
- `OnTextChange func(string)` callback
- `GetData` / `SetData` for `DataControl` compatibility

### Not in this cut (planned as follow-ups)

- Selection (Shift+arrows), copy / cut, undo / redo, overtype mode, word wrap.

## Test plan

- [x] 17 tests in `multilineedit_test.go` covering:
  - `SetText` / `GetText` round trip (empty text still yields one row for a valid cursor position)
  - Typing inserts at cursor
  - Enter splits the current line at the cursor
  - Backspace at col 0 merges with previous row; symmetric Delete at eol
  - Left/Right wrap across line boundaries
  - Home/End (line-scoped) + Ctrl+Home/Ctrl+End (buffer-scoped)
  - `insertString` multi-line paste (`"X\nY\nZ"` between `"PRE"` and `"SUF"` → `"PREX\nY\nZ\nSUF"`, cursor at end of last fragment)
  - `SetLines` / `GetLines` round trip
  - Bracketed paste accumulates and commits atomically
  - Left mouse click at (physical X, physical Y) → correct (row, col)
  - Horizontal scroll keeps cursor inside viewport on long lines
  - `OnTextChange` fires on mutations
  - `WantsChars` returns true
  - Ctrl+Enter is **not** consumed so dialogs can bind their own default button
- [x] `go test ./...` clean (existing tests unaffected).
- [x] `gofmt -w -s .` clean.
