### PR TITLE
Fuzzy search and table enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+AGENTS.md
 debug*log
 run*.sh
 cmd/test-app/test-app

--- a/cmd/test-app/main.go
+++ b/cmd/test-app/main.go
@@ -50,6 +50,9 @@ func (d *DemoWindow) HandleCommand(cmd int, args any) bool {
 	case 1002: // Showcase dialog
 		showShowcaseDialog()
 		return true
+	case 1003: // Table demo dialog
+		showTableDialog()
+		return true
 	}
 	// Fallback to default window behavior (e.g. CmClose, CmZoom)
 	return d.Window.HandleCommand(cmd, args)
@@ -139,6 +142,81 @@ func showShowcaseDialog() {
 	vtui.FrameManager.Push(dlg)
 }
 
+type demoTableRow struct {
+	name, typ, size, modified, desc string
+}
+
+func (r demoTableRow) GetCellText(col int) string {
+	switch col {
+	case 0:
+		return r.name
+	case 1:
+		return r.typ
+	case 2:
+		return r.size
+	case 3:
+		return r.modified
+	case 4:
+		return r.desc
+	}
+	return ""
+}
+
+func showTableDialog() {
+	vtui.FrameManager.Push(buildTableDialog())
+}
+
+func buildTableDialog() *vtui.Window {
+	w, h := 78, 22
+	dlg := vtui.NewCenteredDialog(w, h, " Table Demo ")
+	dlg.ShowClose = true
+
+	// Name and Description are flexible columns (Width 0): they share the
+	// space left after the fixed columns and follow the dialog on resize.
+	// Name additionally demonstrates MinWidth; without it the title width
+	// would be the minimum.
+	table := vtui.NewTable(dlg.X1+2, dlg.Y1+2, w-4, h-8, []vtui.TableColumn{
+		{Title: "Name", MinWidth: 12},
+		{Title: "Type", Width: 8},
+		{Title: "Size", Width: 9, Alignment: vtui.AlignRight},
+		{Title: "Modified", Width: 16},
+		{Title: "Description"},
+	})
+	table.Sortable = true    // click a column header to sort, again to reverse
+	table.QuickSearch = true // type to fuzzy-filter (Myers bit-vector)
+	table.ShowScrollBar = true
+	table.SetRows([]vtui.TableRow{
+		demoTableRow{"README.md", "doc", "2 KB", "2026-07-30 10:12", "Project overview and build instructions"},
+		demoTableRow{"LICENSE", "doc", "1 KB", "2025-11-02 09:00", "MIT license text"},
+		demoTableRow{"rocket_launcher.sh", "script", "128 KB", "2026-06-14 22:41", "Starts the demo environment"},
+		demoTableRow{"data.json", "data", "10 MB", "2026-08-01 08:15", "Exported metrics, updated hourly"},
+		demoTableRow{"main.go", "source", "18 KB", "2026-08-05 19:03", "Demo application entry point"},
+		demoTableRow{"table.go", "source", "24 KB", "2026-08-06 17:45", "Table widget: sort, flex columns, search"},
+		demoTableRow{"fuzzy.go", "source", "6 KB", "2026-08-06 18:20", "Myers bit-vector fuzzy matcher"},
+		demoTableRow{"notes.txt", "doc", "4 KB", "2026-05-19 14:27", "Random ideas and TODO items"},
+		demoTableRow{"backup_2026.tar", "archive", "812 MB", "2026-01-11 03:30", "Full backup of the project"},
+		demoTableRow{"photo_cat.png", "image", "340 KB", "2026-04-02 12:05", "The office cat, demanding attention"},
+		demoTableRow{"Отчёт.xlsx", "sheet", "96 KB", "2026-07-21 16:50", "Квартальный отчёт по проекту"},
+		demoTableRow{"Документы", "dir", "-", "2026-07-25 11:11", "Папка с рабочими документами"},
+		demoTableRow{"installer.exe", "binary", "54 MB", "2026-03-17 09:44", "Windows installer for the demo"},
+		demoTableRow{"config.yaml", "config", "3 KB", "2026-08-03 13:37", "Runtime configuration overrides"},
+		demoTableRow{"changelog.md", "doc", "11 KB", "2026-08-04 15:58", "Release notes since v0.1"},
+	})
+	table.SetGrowMode(vtui.GrowHiX | vtui.GrowHiY)
+	dlg.AddItem(table)
+
+	hint := vtui.NewLabel(dlg.X1+2, dlg.Y1+h-5, "Type to fuzzy-filter, click a header to sort, Esc clears the filter", nil)
+	hint.SetGrowMode(vtui.GrowLoY | vtui.GrowHiY)
+	dlg.AddItem(hint)
+
+	btnClose := vtui.NewButton(dlg.X1+w/2-5, dlg.Y1+h-3, "&Close")
+	btnClose.OnClick = func() { dlg.Close() }
+	btnClose.SetGrowMode(vtui.GrowLoY | vtui.GrowHiY | vtui.GrowLoX | vtui.GrowHiX)
+	dlg.AddItem(btnClose)
+
+	return dlg
+}
+
 func main() {
 	guiMode := false
 	guiBackend := ""
@@ -216,6 +294,7 @@ func main() {
 				{Text: "&Colors"},
 				{Separator: true},
 				{Text: "UI S&howcase", Command: 1002},
+				{Text: "&Table Demo", Command: 1003},
 			}},
 			{Label: "&Right", SubItems: []vtui.MenuItem{{Text: "Command &2"}}},
 		}

--- a/cmd/test-app/main_test.go
+++ b/cmd/test-app/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/vtui"
+)
+
+// The Table Demo dialog must satisfy the same layout rules as framework
+// dialogs: no overlaps, "air" between interactive elements, border padding.
+func TestTableDemoDialog_Layout(t *testing.T) {
+	vtui.SetDefaultPalette()
+
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	vtui.FrameManager.Init(scr)
+
+	dlg := buildTableDialog()
+	vtui.AssertLayout(t, dlg)
+}

--- a/colors.go
+++ b/colors.go
@@ -70,6 +70,27 @@ func SetIndexBoth(attr uint64, idxFore, idxBack uint8) uint64 {
 	return SetIndexBack(SetIndexFore(attr, idxFore), idxBack)
 }
 
+// InvertColors swaps the foreground and background colors of the attribute,
+// preserving each color's mode (palette index vs 24-bit RGB). Style flags
+// (bold, underscore, etc.) are kept as-is.
+func InvertColors(attr uint64) uint64 {
+	fgIdx, bgIdx := GetIndexFore(attr), GetIndexBack(attr)
+	fgRGB, bgRGB := GetRGBFore(attr), GetRGBBack(attr)
+	fgIsRGB := attr&IsFgRGB != 0
+	bgIsRGB := attr&IsBgRGB != 0
+	if bgIsRGB {
+		attr = SetRGBFore(attr, bgRGB)
+	} else {
+		attr = SetIndexFore(attr, bgIdx)
+	}
+	if fgIsRGB {
+		attr = SetRGBBack(attr, fgRGB)
+	} else {
+		attr = SetIndexBack(attr, fgIdx)
+	}
+	return attr
+}
+
 // DimColor reduces the brightness of the foreground color to visually indicate a disabled state.
 func DimColor(attr uint64) uint64 {
 	if attr&IsFgRGB != 0 {

--- a/fuzzy.go
+++ b/fuzzy.go
@@ -1,0 +1,268 @@
+package vtui
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// fuzzyMatcher implements approximate substring search using Myers'
+// bit-vector algorithm. For needles of up to 64 runes the edit distance is
+// computed in O(len(text)) bit-parallel operations over a single uint64.
+// Longer needles degrade to exact substring search.
+//
+// The matcher reports the best (lowest) edit distance between the needle and
+// any substring of the text, plus the starting position of that match.
+// Case-insensitive matching is done by indexing both cases of every needle
+// character, so the text is looked up as-is.
+type fuzzyMatcher struct {
+	m int // needle length in runes
+	k int // max edit distance accepted as a match
+
+	needle        string
+	caseSensitive bool
+
+	ascii    bool
+	peqAscii [256]uint64     // L1-resident fast path for ASCII needles and texts
+	peqRune  map[rune]uint64 // built lazily on the first non-ASCII text
+
+	exactOnly  bool   // needle longer than 64 runes
+	needleFold string // needle (folded in case-insensitive mode) for exactOnly
+	fold       bool   // fold the haystack too (case-insensitive exactOnly)
+
+	rev *fuzzyMatcher // lazy reversed-needle matcher used to locate match starts
+}
+
+// newFuzzyMatcher builds a matcher for the given needle. It returns nil for
+// an empty needle. The acceptance threshold is len(needle)/3 errors: exact
+// substring matches always pass (score 0), short needles stay almost strict,
+// longer ones tolerate more typos.
+func newFuzzyMatcher(needle string, caseSensitive bool) *fuzzyMatcher {
+	if needle == "" {
+		return nil
+	}
+	fm := &fuzzyMatcher{m: utf8.RuneCountInString(needle), needle: needle, caseSensitive: caseSensitive}
+	fm.k = fm.m / 3
+
+	if fm.m > 64 {
+		fm.exactOnly = true
+		fm.fold = !caseSensitive
+		if caseSensitive {
+			fm.needleFold = needle
+		} else {
+			fm.needleFold = strings.ToLower(needle)
+		}
+		return fm
+	}
+
+	fm.ascii = isASCIIString(needle)
+	if fm.ascii {
+		for i := 0; i < len(needle); i++ {
+			b := needle[i]
+			fm.peqAscii[b] |= 1 << uint(i)
+			if !caseSensitive {
+				if 'a' <= b && b <= 'z' {
+					fm.peqAscii[b-'a'+'A'] |= 1 << uint(i)
+				} else if 'A' <= b && b <= 'Z' {
+					fm.peqAscii[b-'A'+'a'] |= 1 << uint(i)
+				}
+			}
+		}
+	} else {
+		fm.buildRuneTable()
+	}
+	return fm
+}
+
+// buildRuneTable populates the Unicode peq table. For ASCII needles it is
+// built lazily on the first non-ASCII text, so the common all-ASCII case
+// never pays for the map.
+func (fm *fuzzyMatcher) buildRuneTable() {
+	fm.peqRune = make(map[rune]uint64, fm.m)
+	i := 0
+	for _, r := range fm.needle {
+		bit := uint64(1) << uint(i)
+		fm.peqRune[r] |= bit
+		if !fm.caseSensitive {
+			fm.peqRune[unicode.ToLower(r)] |= bit
+			fm.peqRune[unicode.ToUpper(r)] |= bit
+		}
+		i++
+	}
+}
+
+// match searches the needle inside text. It returns the best edit distance,
+// the starting position (in runes) of the best matching substring, and
+// whether the distance is within the acceptance threshold.
+// match searches the needle inside text. It returns the best edit distance,
+// the span [start, end] (inclusive, in runes) of the best matching substring,
+// and whether the distance is within the acceptance threshold.
+func (fm *fuzzyMatcher) match(text string) (score, start, end int, ok bool) {
+	if fm.exactOnly {
+		hay := text
+		if fm.fold {
+			hay = strings.ToLower(text)
+		}
+		idx := strings.Index(hay, fm.needleFold)
+		if idx < 0 {
+			return 0, 0, 0, false
+		}
+		start = utf8.RuneCountInString(text[:idx])
+		return 0, start, start + fm.m - 1, true
+	}
+	if fm.ascii && isASCIIString(text) {
+		score, end = fm.matchASCII(text)
+	} else {
+		if fm.peqRune == nil {
+			fm.buildRuneTable()
+		}
+		score, end = fm.matchRunes(text)
+	}
+	score = clampScore(score, fm.m)
+	if score == 0 {
+		// An exact match spans exactly m runes.
+		start = end - fm.m + 1
+	} else {
+		start = fm.findStart(text, end)
+	}
+	if start < 0 {
+		start = 0
+	}
+	return score, start, end, score <= fm.k
+}
+
+// findStart locates the beginning of the best fuzzy match ending at end
+// (rune index). It runs a second bit-vector pass with the reversed needle
+// over the reversed text prefix; edit distance is symmetric under reversal,
+// so the reverse pass reproduces the same score and its end position maps
+// back to the start of the forward match. Only used for inexact matches, so
+// it runs at most once per matched row per filter rebuild — never in the
+// render hot path.
+func (fm *fuzzyMatcher) findStart(text string, end int) int {
+	rev := fm.reverseMatcher()
+
+	runes := []rune(text)
+	if end+1 < len(runes) {
+		runes = runes[:end+1]
+	}
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	if rev.peqRune == nil {
+		rev.buildRuneTable()
+	}
+	_, revEnd := rev.matchRunes(string(runes))
+	return end - revEnd
+}
+
+// reverseMatcher lazily builds the matcher for the reversed needle.
+func (fm *fuzzyMatcher) reverseMatcher() *fuzzyMatcher {
+	if fm.rev == nil {
+		r := []rune(fm.needle)
+		for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+			r[i], r[j] = r[j], r[i]
+		}
+		fm.rev = newFuzzyMatcher(string(r), fm.caseSensitive)
+	}
+	return fm.rev
+}
+
+// matchASCII runs the bit-vector scan over bytes; text must be pure ASCII,
+// so byte positions equal rune positions. Returns the best score and the
+// end position of the best match.
+func (fm *fuzzyMatcher) matchASCII(s string) (bestScore, bestEnd int) {
+	m := fm.m
+	top := uint64(1) << uint(m-1)
+	pv := ^uint64(0)
+	mv := uint64(0)
+	score := m
+	bestScore = m + 1
+	bestEnd = 0
+	for j := 0; j < len(s); j++ {
+		eq := fm.peqAscii[s[j]]
+		xv := eq | mv
+		xh := (((eq & pv) + pv) ^ pv) | eq
+		ph := mv | ^(xh | pv)
+		mh := pv & xh
+		if ph&top != 0 {
+			score++
+		} else if mh&top != 0 {
+			score--
+		}
+		// Substring search: D[0][j] = 0, so the horizontal delta injected
+		// into row 0 is 0 and both vectors shift in a zero bit.
+		ph <<= 1
+		mh <<= 1
+		pv = mh | ^(xv | ph)
+		mv = ph & xv
+		if score < bestScore {
+			bestScore = score
+			bestEnd = j
+			if bestScore == 0 {
+				break // cannot do better; first exact match ends here
+			}
+		} else if score == bestScore {
+			// Among equal-scoring matches prefer the latest end: it yields
+			// the fullest span (e.g. "abxc" for needle "abc", not just "ab").
+			bestEnd = j
+		}
+	}
+	return bestScore, bestEnd
+}
+
+// matchRunes is the Unicode fallback of the same algorithm.
+func (fm *fuzzyMatcher) matchRunes(s string) (bestScore, bestEnd int) {
+	m := fm.m
+	top := uint64(1) << uint(m-1)
+	pv := ^uint64(0)
+	mv := uint64(0)
+	score := m
+	bestScore = m + 1
+	bestEnd = 0
+	j := 0
+	for _, r := range s {
+		eq := fm.peqRune[r]
+		xv := eq | mv
+		xh := (((eq & pv) + pv) ^ pv) | eq
+		ph := mv | ^(xh | pv)
+		mh := pv & xh
+		if ph&top != 0 {
+			score++
+		} else if mh&top != 0 {
+			score--
+		}
+		ph <<= 1
+		mh <<= 1
+		pv = mh | ^(xv | ph)
+		mv = ph & xv
+		if score < bestScore {
+			bestScore = score
+			bestEnd = j
+			if bestScore == 0 {
+				break
+			}
+		} else if score == bestScore {
+			bestEnd = j // see matchASCII: latest end gives the fullest span
+		}
+		j++
+	}
+	return bestScore, bestEnd
+}
+
+// clampScore converts the "no text scanned" sentinel into the real distance
+// (needle length: deleting the whole needle matches the empty substring).
+func clampScore(bestScore, m int) int {
+	if bestScore > m {
+		return m
+	}
+	return bestScore
+}
+
+func isASCIIString(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}

--- a/fuzzy_test.go
+++ b/fuzzy_test.go
@@ -1,0 +1,233 @@
+package vtui
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+)
+
+// refSubstringMatch is the classic dynamic-programming reference for
+// approximate substring search: D[0][j] = 0 (a match may start anywhere),
+// D[i][0] = i. It returns the best edit distance over all ending positions
+// and the earliest ending position achieving it.
+func refSubstringMatch(pattern, text string, fold bool) (bestScore, bestEnd int) {
+	p := []rune(pattern)
+	s := []rune(text)
+	if fold {
+		for i := range p {
+			p[i] = unicode.ToLower(p[i])
+		}
+		for i := range s {
+			s[i] = unicode.ToLower(s[i])
+		}
+	}
+	m := len(p)
+
+	prev := make([]int, m+1)
+	for i := range prev {
+		prev[i] = i
+	}
+	cur := make([]int, m+1)
+
+	bestScore = m
+	bestEnd = 0
+	for j := 1; j <= len(s); j++ {
+		cur[0] = 0
+		for i := 1; i <= m; i++ {
+			sub := prev[i-1]
+			if p[i-1] != s[j-1] {
+				sub++
+			}
+			v := prev[i] + 1
+			if cur[i-1]+1 < v {
+				v = cur[i-1] + 1
+			}
+			if sub < v {
+				v = sub
+			}
+			cur[i] = v
+		}
+		if cur[m] < bestScore {
+			bestScore = cur[m]
+			bestEnd = j - 1
+		}
+		prev, cur = cur, prev
+	}
+	return bestScore, bestEnd
+}
+
+func TestFuzzyMatcher_AgainstReference(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	alphabet := []rune("abcdAB")
+
+	for iter := 0; iter < 2000; iter++ {
+		m := 1 + rng.Intn(8)
+		n := rng.Intn(17)
+		needle := make([]rune, m)
+		for i := range needle {
+			needle[i] = alphabet[rng.Intn(len(alphabet))]
+		}
+		text := make([]rune, n)
+		for i := range text {
+			text[i] = alphabet[rng.Intn(len(alphabet))]
+		}
+		// Sometimes embed the needle to guarantee exact matches occur.
+		if n > m && rng.Intn(2) == 0 {
+			start := rng.Intn(n - m)
+			copy(text[start:start+m], needle)
+		}
+
+		fm := newFuzzyMatcher(string(needle), true)
+		score, pos, _, _ := fm.match(string(text))
+		wantScore, wantEnd := refSubstringMatch(string(needle), string(text), false)
+		wantPos := wantEnd - m + 1
+		if wantPos < 0 {
+			wantPos = 0
+		}
+		if score != wantScore {
+			t.Errorf("needle=%q text=%q: score %d, want %d", string(needle), string(text), score, wantScore)
+		} else if score == 0 && pos != wantPos {
+			// Position is exact only for exact (score 0) matches.
+			t.Errorf("needle=%q text=%q: pos %d, want %d", string(needle), string(text), pos, wantPos)
+		}
+	}
+}
+
+func TestFuzzyMatcher_Unicode(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	alphabet := []rune("абвгдАБВ")
+
+	for iter := 0; iter < 1000; iter++ {
+		m := 1 + rng.Intn(6)
+		n := rng.Intn(14)
+		needle := make([]rune, m)
+		for i := range needle {
+			needle[i] = alphabet[rng.Intn(len(alphabet))]
+		}
+		text := make([]rune, n)
+		for i := range text {
+			text[i] = alphabet[rng.Intn(len(alphabet))]
+		}
+
+		fm := newFuzzyMatcher(string(needle), true)
+		score, _, _, _ := fm.match(string(text))
+		wantScore, _ := refSubstringMatch(string(needle), string(text), false)
+		if score != wantScore {
+			t.Errorf("needle=%q text=%q: score %d, want %d", string(needle), string(text), score, wantScore)
+		}
+	}
+}
+
+func TestFuzzyMatcher_CaseInsensitive(t *testing.T) {
+	rng := rand.New(rand.NewSource(13))
+	alphabet := []rune("abABюЮ")
+
+	for iter := 0; iter < 1000; iter++ {
+		m := 1 + rng.Intn(6)
+		n := rng.Intn(14)
+		needle := make([]rune, m)
+		for i := range needle {
+			needle[i] = alphabet[rng.Intn(len(alphabet))]
+		}
+		text := make([]rune, n)
+		for i := range text {
+			text[i] = alphabet[rng.Intn(len(alphabet))]
+		}
+
+		fm := newFuzzyMatcher(string(needle), false)
+		score, _, _, _ := fm.match(string(text))
+		wantScore, _ := refSubstringMatch(string(needle), string(text), true)
+		if score != wantScore {
+			t.Errorf("needle=%q text=%q: folded score %d, want %d", string(needle), string(text), score, wantScore)
+		}
+	}
+}
+
+func TestFuzzyMatcher_Threshold(t *testing.T) {
+	// k = len/3: needle of 3..5 runes allows 1 error.
+	fm := newFuzzyMatcher("abc", true)
+	if fm.k != 1 {
+		t.Fatalf("expected k=1, got %d", fm.k)
+	}
+	if _, _, _, ok := fm.match("xxabcxx"); !ok {
+		t.Error("exact substring must pass")
+	}
+	if _, _, _, ok := fm.match("xxabdxx"); !ok {
+		t.Error("one error must pass for k=1")
+	}
+	if _, _, _, ok := fm.match("xxaexx"); ok {
+		t.Error("two errors must not pass for k=1")
+	}
+
+	// Needles of 1-2 runes are exact-only (k=0).
+	fm = newFuzzyMatcher("ab", true)
+	if _, _, _, ok := fm.match("ac"); ok {
+		t.Error("k=0 must reject any error")
+	}
+	if _, _, _, ok := fm.match("xxabyy"); !ok {
+		t.Error("k=0 must accept exact substring")
+	}
+}
+
+func TestFuzzyMatcher_ExactPosition(t *testing.T) {
+	fm := newFuzzyMatcher("needle", true)
+	score, pos, _, ok := fm.match("find the needle here")
+	if !ok || score != 0 {
+		t.Fatalf("expected exact match, score=%d ok=%v", score, ok)
+	}
+	if pos != 9 {
+		t.Errorf("expected pos 9, got %d", pos)
+	}
+}
+
+func TestFuzzyMatcher_LongNeedleExactOnly(t *testing.T) {
+	needle := strings.Repeat("a", 70)
+	fm := newFuzzyMatcher(needle, true)
+	if !fm.exactOnly {
+		t.Fatal("needle > 64 runes must degrade to exact search")
+	}
+	if _, _, _, ok := fm.match("xx" + needle + "yy"); !ok {
+		t.Error("exact long needle must match")
+	}
+	if _, _, _, ok := fm.match(strings.Repeat("a", 69)); ok {
+		t.Error("one error must not pass in exactOnly mode")
+	}
+
+	// Case-insensitive long needle.
+	fm = newFuzzyMatcher(strings.Repeat("Ab", 35), false)
+	if _, pos, _, ok := fm.match("zz" + strings.Repeat("aB", 35) + "zz"); !ok || pos != 2 {
+		t.Errorf("case-insensitive exactOnly failed: ok=%v pos=%d", ok, pos)
+	}
+}
+
+func TestFuzzyMatcher_Empty(t *testing.T) {
+	if fm := newFuzzyMatcher("", true); fm != nil {
+		t.Error("empty needle must produce nil matcher")
+	}
+
+	fm := newFuzzyMatcher("abc", true)
+	score, _, _, ok := fm.match("")
+	if ok {
+		t.Error("empty text must not match a non-empty needle")
+	}
+	if score != 3 {
+		t.Errorf("empty text distance must equal needle length, got %d", score)
+	}
+}
+
+func TestFuzzyMatcher_RunePositions(t *testing.T) {
+	// Position must be in runes even for the Unicode path.
+	fm := newFuzzyMatcher("game", true)
+	_, pos, _, ok := fm.match("моя game")
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if pos != 4 {
+		t.Errorf("expected rune pos 4, got %d", pos)
+	}
+	if got := utf8.RuneCountInString("моя "); got != 4 {
+		t.Fatalf("test invariant broken: %d", got)
+	}
+}

--- a/table.go
+++ b/table.go
@@ -3,13 +3,21 @@ package vtui
 import (
 	"github.com/mattn/go-runewidth"
 	"github.com/unxed/vtinput"
+	"sort"
 	"strings"
 )
 
 // TableColumn defines the properties of a single table column.
 type TableColumn struct {
-	Title     string
-	Width     int // Width in characters
+	Title string
+	// Width in characters. Width <= 0 makes the column flexible: all flexible
+	// columns evenly share the space left after fixed-width columns and
+	// separators, and are recomputed whenever the table is resized.
+	Width int
+	// MinWidth is the minimum width of a flexible column (Width <= 0), in
+	// characters. If MinWidth <= 0, the title width is used as the minimum.
+	// Ignored for fixed-width columns.
+	MinWidth  int
 	Alignment Alignment
 }
 
@@ -46,12 +54,62 @@ type Table struct {
 	ShowSeparators   bool
 	AlwaysShowCursor bool
 
+	// Sortable enables click-on-header sorting. Default is false: no sorting
+	// and header clicks are ignored, so applications doing their own sorting
+	// (e.g. by rewriting column titles) are unaffected.
+	Sortable bool
+	// SortColumn is the column rows are sorted by; -1 (default) means no
+	// sorting. SortAscending controls the direction. SortCompare is an
+	// optional comparator; when nil, rows are compared by cell text.
+	SortColumn    int
+	SortAscending bool
+	SortCompare   func(a, b TableRow, col int) int
+
+	// QuickSearch enables type-to-filter: while the table is focused,
+	// printable characters go into a search string shown in a line below the
+	// table, and rows are filtered by fuzzy match (Myers' bit-vector
+	// algorithm) against all columns, best match wins. The filtered list is
+	// ranked by (edit distance, match position). Default is false.
+	QuickSearch bool
+	// SearchCaseSensitive makes QuickSearch case-sensitive (default false).
+	SearchCaseSensitive bool
+	// OnSearchChange is called whenever the search string changes.
+	OnSearchChange func(text string)
+
 	ColorTextIdx             int
 	ColorSelectedTextIdx     int
 	ColorItemSelectTextIdx   int
 	ColorItemSelectCursorIdx int
 	ColorTitleIdx            int
 	ColorBoxIdx              int
+
+	// colWidths caches the resolved column widths (flexible columns expanded);
+	// reused across frames to avoid allocations in the render hot path.
+	colWidths []int
+	// order maps display position to Rows index when sorting is active.
+	// The Rows slice itself is never reordered.
+	order []int
+	// searchRunes is the QuickSearch string; searchCursor/searchLeft are the
+	// cursor and horizontal scroll positions (in runes) within it.
+	searchRunes  []rune
+	searchCursor int
+	searchLeft   int
+	// matchBuf is reused by the search filter to avoid allocations.
+	matchBuf []searchMatch
+	// matchSpans holds the matched cell span per Rows index for needle
+	// highlighting; col == -1 means the row is not matched.
+	matchSpans []cellHighlight
+}
+
+// searchMatch is one row passing the QuickSearch filter.
+type searchMatch struct {
+	idx, score, pos int
+}
+
+// cellHighlight locates the matched substring inside one cell: column index
+// and the [start, end] span in runes of that cell's text.
+type cellHighlight struct {
+	col, start, end int
 }
 
 func NewTable(x, y, w, h int, columns []TableColumn) *Table {
@@ -66,6 +124,7 @@ func NewTable(x, y, w, h int, columns []TableColumn) *Table {
 		ColorItemSelectCursorIdx: ColTableSelectedText,
 		ColorTitleIdx:            ColTableColumnTitle,
 		ColorBoxIdx:              ColTableBox,
+		SortColumn:               -1,
 	}
 	t.canFocus = true
 	t.InitScrollBar(t)
@@ -73,9 +132,73 @@ func NewTable(x, y, w, h int, columns []TableColumn) *Table {
 	return t
 }
 
+// resolvedWidths returns the effective width of every column. Columns with
+// Width <= 0 are flexible: each gets its minimum width (MinWidth, or the
+// title width if unset), then the remaining content width (after fixed-width
+// columns and the 1-cell gaps between columns) is distributed between them
+// evenly. The result is recomputed on every call, so it follows widget
+// resizes automatically.
+func (t *Table) resolvedWidths() []int {
+	n := len(t.Columns)
+	t.colWidths = t.colWidths[:0]
+	if n == 0 {
+		return t.colWidths
+	}
+
+	flexCount := 0
+	fixed := 0
+	minSum := 0
+	for i := range t.Columns {
+		if t.Columns[i].Width <= 0 {
+			flexCount++
+			minSum += t.Columns[i].minWidth()
+		} else {
+			fixed += t.Columns[i].Width
+		}
+	}
+
+	extra := 0
+	if flexCount > 0 {
+		avail := t.GetContentWidth() - fixed - (n - 1)
+		if avail < minSum {
+			avail = minSum // each flexible column gets at least its minimum
+		}
+		extra = avail - minSum
+	}
+	per := 0
+	rem := 0
+	if flexCount > 0 {
+		per = extra / flexCount
+		rem = extra % flexCount
+	}
+
+	for i := range t.Columns {
+		w := t.Columns[i].Width
+		if w <= 0 {
+			w = t.Columns[i].minWidth() + per
+			if rem > 0 {
+				w++
+				rem--
+			}
+		}
+		t.colWidths = append(t.colWidths, w)
+	}
+	return t.colWidths
+}
+
+// minWidth returns the minimum width of a flexible column: MinWidth if set,
+// otherwise the width of the column title.
+func (c *TableColumn) minWidth() int {
+	if c.MinWidth > 0 {
+		return c.MinWidth
+	}
+	return runewidth.StringWidth(c.Title)
+}
+
 func (t *Table) SetRows(rows []TableRow) {
 	t.Rows = rows
 	t.ItemCount = len(rows)
+	t.resort()
 	if t.ItemCount == 0 {
 		t.SelectPos = 0
 	} else if t.SelectPos >= t.ItemCount {
@@ -84,6 +207,155 @@ func (t *Table) SetRows(rows []TableRow) {
 		t.SelectPos = 0
 	}
 	t.EnsureVisible()
+}
+
+// SetSort sorts rows by the given column. A negative col disables sorting.
+// The header of the sorted column shows a direction arrow (↑/↓).
+func (t *Table) SetSort(col int, ascending bool) {
+	t.SortColumn = col
+	t.SortAscending = ascending
+	t.resort()
+}
+
+// ClearSort disables sorting and restores the original row order.
+func (t *Table) ClearSort() {
+	t.SortColumn = -1
+	t.resort()
+}
+
+// resort rebuilds the display-to-row index mapping. With no active sort it
+// is the identity mapping; the Rows slice itself is never reordered.
+func (t *Table) resort() {
+	n := len(t.Rows)
+	if cap(t.order) < n {
+		t.order = make([]int, n)
+	} else {
+		t.order = t.order[:n]
+	}
+	for i := range t.order {
+		t.order[i] = i
+	}
+
+	if len(t.searchRunes) > 0 {
+		// While searching, the column sort gives way to match ranking.
+		t.applySearchFilter()
+	} else if col := t.SortColumn; col >= 0 && col < len(t.Columns) && n >= 2 {
+		ascending := t.SortAscending
+		cmp := t.SortCompare
+		sort.SliceStable(t.order, func(i, j int) bool {
+			a, b := t.Rows[t.order[i]], t.Rows[t.order[j]]
+			c := 0
+			if cmp != nil {
+				c = cmp(a, b, col)
+			} else {
+				c = strings.Compare(a.GetCellText(col), b.GetCellText(col))
+			}
+			if !ascending {
+				c = -c
+			}
+			return c < 0
+		})
+	}
+
+	t.ItemCount = len(t.order)
+	if t.SelectPos >= t.ItemCount {
+		t.SelectPos = t.ItemCount - 1
+	}
+	if t.SelectPos < 0 {
+		t.SelectPos = 0
+	}
+}
+
+// applySearchFilter keeps only rows fuzzy-matching the search string (best
+// match across all columns wins) and ranks them by (distance, position).
+// The matched cell span is remembered per row for needle highlighting.
+func (t *Table) applySearchFilter() {
+	matcher := newFuzzyMatcher(string(t.searchRunes), t.SearchCaseSensitive)
+	t.matchBuf = t.matchBuf[:0]
+	if cap(t.matchSpans) < len(t.Rows) {
+		t.matchSpans = make([]cellHighlight, len(t.Rows))
+	} else {
+		t.matchSpans = t.matchSpans[:len(t.Rows)]
+	}
+	for i := range t.matchSpans {
+		t.matchSpans[i].col = -1
+	}
+	for i, row := range t.Rows {
+		bestScore := -1
+		bestStart, bestEnd, bestCol := 0, 0, 0
+		for col := range t.Columns {
+			score, start, end, ok := matcher.match(row.GetCellText(col))
+			if ok && (bestScore < 0 || score < bestScore || (score == bestScore && start < bestStart)) {
+				bestScore, bestStart, bestEnd, bestCol = score, start, end, col
+			}
+		}
+		if bestScore >= 0 {
+			t.matchBuf = append(t.matchBuf, searchMatch{i, bestScore, bestStart})
+			t.matchSpans[i] = cellHighlight{bestCol, bestStart, bestEnd}
+		}
+	}
+	sort.Slice(t.matchBuf, func(a, b int) bool {
+		ma, mb := t.matchBuf[a], t.matchBuf[b]
+		if ma.score != mb.score {
+			return ma.score < mb.score
+		}
+		if ma.pos != mb.pos {
+			return ma.pos < mb.pos
+		}
+		return ma.idx < mb.idx
+	})
+	t.order = t.order[:len(t.matchBuf)]
+	for i, m := range t.matchBuf {
+		t.order[i] = m.idx
+	}
+}
+
+// SearchText returns the current QuickSearch string.
+func (t *Table) SearchText() string {
+	return string(t.searchRunes)
+}
+
+// SetSearchText replaces the QuickSearch string and refilters the rows.
+func (t *Table) SetSearchText(text string) {
+	t.searchRunes = []rune(text)
+	t.searchCursor = len(t.searchRunes)
+	t.searchLeft = 0
+	t.resort()
+	t.EnsureVisible()
+	t.fireSearchChange()
+}
+
+// ClearSearch empties the QuickSearch string and restores the full row list.
+func (t *Table) ClearSearch() {
+	if len(t.searchRunes) == 0 {
+		return
+	}
+	t.searchRunes = t.searchRunes[:0]
+	t.searchCursor = 0
+	t.searchLeft = 0
+	t.resort()
+	t.fireSearchChange()
+}
+
+func (t *Table) fireSearchChange() {
+	if t.OnSearchChange != nil {
+		t.OnSearchChange(string(t.searchRunes))
+	}
+}
+
+// rowAt maps a display position to the index in Rows, accounting for the
+// active sorting. Out-of-range positions are returned unchanged.
+func (t *Table) rowAt(pos int) int {
+	if pos >= 0 && pos < len(t.order) {
+		return t.order[pos]
+	}
+	return pos
+}
+
+// RowAt maps a display position (e.g. SelectPos) to the index in Rows,
+// accounting for the active sorting. With no sorting it returns pos.
+func (t *Table) RowAt(pos int) int {
+	return t.rowAt(pos)
 }
 
 func (t *Table) Show(scr *ScreenBuf) {
@@ -100,7 +372,6 @@ func (t *Table) DisplayObject(scr *ScreenBuf) {
 	t.SetPosition(t.X1, t.Y1, t.X2, t.Y2)
 
 	yOffset := 0
-	height := t.Y2 - t.Y1 + 1
 
 	// 1. Draw Header
 	if t.ShowHeader {
@@ -108,16 +379,24 @@ func (t *Table) DisplayObject(scr *ScreenBuf) {
 		yOffset++
 	}
 
-	// 2. Draw Data Rows
-	dataHeight := height - yOffset
+	// 2. Draw Data Rows (ViewHeight already excludes header and search line).
+	// While a search is active, results are shown bottom-up (best match right
+	// above the search line), telescope-style.
+	dataHeight := t.ViewHeight
 	if dataHeight < 0 {
 		dataHeight = 0
 	}
+	bottomUp := len(t.searchRunes) > 0
+	dataBottom := t.Y1 + yOffset + dataHeight - 1
 	for i := 0; i < dataHeight; i++ {
-		rowIdx := t.TopPos + i
+		displayPos := t.TopPos + i
 		currY := t.Y1 + yOffset + i
+		if bottomUp {
+			currY = dataBottom - i
+		}
 
-		if rowIdx < len(t.Rows) {
+		if displayPos < t.ItemCount {
+			rowIdx := t.rowAt(displayPos)
 			//isSelected := false
 			// Calculate standard attribute as a fallback (passed into drawRow)
 			attr := Palette[t.ColorTextIdx]
@@ -131,21 +410,29 @@ func (t *Table) DisplayObject(scr *ScreenBuf) {
 	// 3. Draw Vertical Separators if needed
 	if t.ShowSeparators {
 		p := NewPainter(scr)
+		widths := t.resolvedWidths()
 		currX := t.X1
-		sepChar := boxSymbols[bsV] // │
+		sepChar := boxSymbols[bsV]     // │
+		sepY2 := t.Y2 - t.MarginBottom // do not cross the search line
 		for i := 0; i < len(t.Columns)-1; i++ {
-			currX += t.Columns[i].Width
-			p.Fill(currX, t.Y1, currX, t.Y2, sepChar, Palette[t.ColorBoxIdx])
+			currX += widths[i]
+			p.Fill(currX, t.Y1, currX, sepY2, sepChar, Palette[t.ColorBoxIdx])
 			currX++
 		}
 	}
 
 	// 4. Draw Scrollbar
 	t.DrawScrollBar(scr)
+
+	// 5. Draw the QuickSearch line
+	if t.QuickSearch {
+		t.drawSearchLine(scr)
+	}
 }
 
 func (t *Table) drawRow(scr *ScreenBuf, y int, rowIdx int, attr uint64) {
 	endX := t.X1 + t.GetContentWidth() - 1
+	widths := t.resolvedWidths()
 
 	currX := t.X1
 	for colIdx, col := range t.Columns {
@@ -223,10 +510,21 @@ func (t *Table) drawRow(scr *ScreenBuf, y int, rowIdx int, attr uint64) {
 			}
 		}
 
-		// Prepare cell text with alignment
-		cellText := t.formatCell(text, col.Width, col.Alignment)
-		scr.Write(currX, y, StringToCharInfo(cellText, cellAttr))
-		currX += col.Width
+		// Prepare cell text with alignment. The sorted column's header gets a
+		// direction arrow appended at the right edge of the cell.
+		cellText := t.formatCell(text, widths[colIdx], col.Alignment)
+		if rowIdx == -1 && colIdx == t.SortColumn {
+			cellText = t.formatSortedHeader(text, widths[colIdx], col.Alignment)
+		}
+		cis := StringToCharInfo(cellText, cellAttr)
+		// Invert the colors of the matched substring (QuickSearch highlight).
+		if rowIdx >= 0 && len(t.searchRunes) > 0 && rowIdx < len(t.matchSpans) {
+			if span := t.matchSpans[rowIdx]; span.col == colIdx {
+				t.applyCellHighlight(cis, text, widths[colIdx], col.Alignment, span)
+			}
+		}
+		scr.Write(currX, y, cis)
+		currX += widths[colIdx]
 
 		// Skip separator space if not the last column
 		if colIdx < len(t.Columns)-1 {
@@ -239,6 +537,56 @@ func (t *Table) drawRow(scr *ScreenBuf, y int, rowIdx int, attr uint64) {
 	if lastX < endX {
 		scr.FillRect(lastX+1, y, endX, y, ' ', attr)
 	}
+}
+
+// applyCellHighlight inverts the colors of the cells covered by the matched
+// substring. span.start/span.end are rune indices in the original cell text;
+// they are mapped to display cells accounting for truncation, alignment
+// padding and wide runes.
+func (t *Table) applyCellHighlight(cis []CharInfo, text string, width int, align Alignment, span cellHighlight) {
+	truncated := runewidth.Truncate(text, width, "")
+	space := width - runewidth.StringWidth(truncated)
+	if space < 0 {
+		space = 0
+	}
+	padLeft := 0
+	switch align {
+	case AlignRight:
+		padLeft = space
+	case AlignCenter:
+		padLeft = space / 2
+	}
+	cellPos := padLeft
+	runeIdx := 0
+	for _, r := range truncated {
+		w := runewidth.RuneWidth(r)
+		if w < 1 {
+			runeIdx++
+			continue // zero-width runes occupy no display cell
+		}
+		if runeIdx >= span.start && runeIdx <= span.end {
+			for k := 0; k < w && cellPos+k < len(cis); k++ {
+				cis[cellPos+k].Attributes = InvertColors(cis[cellPos+k].Attributes)
+			}
+		}
+		cellPos += w
+		runeIdx++
+	}
+}
+
+// formatSortedHeader renders a column header with a sort direction arrow
+// (↑/↓) at the right edge of the cell, reserving space for it so the title
+// itself is truncated first.
+func (t *Table) formatSortedHeader(title string, width int, align Alignment) string {
+	arrow := " ↓"
+	if t.SortAscending {
+		arrow = " ↑"
+	}
+	arrowWidth := runewidth.StringWidth(arrow)
+	if width <= arrowWidth {
+		return runewidth.Truncate(arrow, width, "")
+	}
+	return t.formatCell(title, width-arrowWidth, align) + arrow
 }
 
 func (t *Table) formatCell(text string, width int, align Alignment) string {
@@ -267,15 +615,38 @@ func (t *Table) ProcessKey(e *vtinput.InputEvent) bool {
 		return false
 	}
 
+	searchActive := len(t.searchRunes) > 0
 	switch e.VirtualKeyCode {
 	case vtinput.VK_UP:
-		if t.SelectPos == 0 {
+		// With bottom-up search results Up moves towards worse matches.
+		if searchActive {
+			if t.SelectPos == t.ItemCount-1 {
+				return false
+			}
+		} else if t.SelectPos == 0 {
 			return false
 		}
 	case vtinput.VK_DOWN:
-		if t.SelectPos == t.ItemCount-1 {
+		if searchActive {
+			if t.SelectPos == 0 {
+				return false
+			}
+		} else if t.SelectPos == t.ItemCount-1 {
 			return false
 		}
+	}
+
+	if searchActive {
+		switch e.VirtualKeyCode {
+		case vtinput.VK_UP:
+			return t.MoveSelection(1)
+		case vtinput.VK_DOWN:
+			return t.MoveSelection(-1)
+		}
+	}
+
+	if t.QuickSearch && t.processSearchKey(e) {
+		return true
 	}
 
 	if t.CellSelection {
@@ -310,6 +681,82 @@ func (t *Table) ProcessKey(e *vtinput.InputEvent) bool {
 	return t.HandleKey(e)
 }
 
+// processSearchKey handles QuickSearch editing keys. It returns true if the
+// event was consumed. Up/Down and all other navigation keys fall through to
+// the default table handling; with CellSelection enabled it wins plain
+// Left/Right, and the search cursor moves with Ctrl+Left/Right instead.
+func (t *Table) processSearchKey(e *vtinput.InputEvent) bool {
+	ctrl := e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0
+	alt := e.ControlKeyState&(vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0
+
+	switch e.VirtualKeyCode {
+	case vtinput.VK_ESCAPE:
+		if len(t.searchRunes) > 0 {
+			t.ClearSearch()
+			return true
+		}
+		return false
+	case vtinput.VK_BACK:
+		if t.searchCursor > 0 {
+			t.searchRunes = append(t.searchRunes[:t.searchCursor-1], t.searchRunes[t.searchCursor:]...)
+			t.searchCursor--
+			t.resort()
+			t.EnsureVisible()
+			t.fireSearchChange()
+		}
+		return true
+	case vtinput.VK_DELETE:
+		if t.searchCursor < len(t.searchRunes) {
+			t.searchRunes = append(t.searchRunes[:t.searchCursor], t.searchRunes[t.searchCursor+1:]...)
+			t.resort()
+			t.EnsureVisible()
+			t.fireSearchChange()
+		}
+		return true
+	case vtinput.VK_LEFT:
+		if ctrl || !t.CellSelection {
+			if t.searchCursor > 0 {
+				t.searchCursor--
+			}
+			return true
+		}
+		return false
+	case vtinput.VK_RIGHT:
+		if ctrl || !t.CellSelection {
+			if t.searchCursor < len(t.searchRunes) {
+				t.searchCursor++
+			}
+			return true
+		}
+		return false
+	case vtinput.VK_HOME:
+		if ctrl {
+			t.searchCursor = 0
+			return true
+		}
+		return false
+	case vtinput.VK_END:
+		if ctrl {
+			t.searchCursor = len(t.searchRunes)
+			return true
+		}
+		return false
+	}
+
+	// Printable characters are appended at the cursor position.
+	if e.Char >= ' ' && !ctrl && !alt {
+		t.searchRunes = append(t.searchRunes, 0)
+		copy(t.searchRunes[t.searchCursor+1:], t.searchRunes[t.searchCursor:])
+		t.searchRunes[t.searchCursor] = e.Char
+		t.searchCursor++
+		t.resort()
+		t.EnsureVisible()
+		t.fireSearchChange()
+		return true
+	}
+	return false
+}
+
 func (t *Table) ProcessMouse(e *vtinput.InputEvent) bool {
 	if t.IsDisabled() {
 		return false
@@ -320,21 +767,72 @@ func (t *Table) ProcessMouse(e *vtinput.InputEvent) bool {
 	colChanged := false
 
 	if e.Type == vtinput.MouseEventType && e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown {
-		if t.CellSelection && t.HitTest(int(e.MouseX), int(e.MouseY)) {
+		// Click on a column header toggles sorting (only when Sortable).
+		// Clicks on separator cells are consumed but do not change the sort.
+		if t.Sortable && t.ShowHeader && int(e.MouseY) == t.Y1 &&
+			int(e.MouseX) >= t.X1 && int(e.MouseX) <= t.X2 {
+			widths := t.resolvedWidths()
 			currX := t.X1
-			for i, col := range t.Columns {
-				if int(e.MouseX) >= currX && int(e.MouseX) < currX+col.Width {
+			for i := range t.Columns {
+				if int(e.MouseX) >= currX && int(e.MouseX) < currX+widths[i] {
+					if t.SortColumn == i {
+						t.SortAscending = !t.SortAscending
+					} else {
+						t.SortColumn = i
+						t.SortAscending = true
+					}
+					t.resort()
+					break
+				}
+				currX += widths[i]
+				if i < len(t.Columns)-1 {
+					currX++
+				}
+			}
+			return true
+		}
+
+		if t.CellSelection && t.HitTest(int(e.MouseX), int(e.MouseY)) {
+			widths := t.resolvedWidths()
+			currX := t.X1
+			for i := range t.Columns {
+				if int(e.MouseX) >= currX && int(e.MouseX) < currX+widths[i] {
 					if t.SelectCol != i {
 						t.SelectCol = i
 						colChanged = true
 					}
 					break
 				}
-				currX += col.Width
+				currX += widths[i]
 				if i < len(t.Columns)-1 {
 					currX++
 				}
 			}
+		}
+	}
+
+	// With bottom-up search results, clicks in the data area map to rows
+	// counted from the bottom; consume them all so the generic handler does
+	// not mis-map empty rows above the results.
+	if len(t.searchRunes) > 0 && e.Type == vtinput.MouseEventType && e.ButtonState != 0 && e.KeyDown {
+		dataTop := t.Y1 + t.MarginTop
+		dataBottom := dataTop + t.ViewHeight - 1
+		mx, my := int(e.MouseX), int(e.MouseY)
+		if my >= dataTop && my <= dataBottom && mx >= t.X1 && mx < t.X1+t.GetContentWidth() {
+			idx := t.TopPos + (dataBottom - my)
+			if idx >= 0 && idx < t.ItemCount {
+				oldPos := t.SelectPos
+				t.SelectPos = idx
+				if t.SelectPos != oldPos && t.OnSelect != nil {
+					t.OnSelect(t.SelectPos)
+				}
+				isLeftDoubleClick := e.ButtonState == vtinput.FromLeft1stButtonPressed && (e.MouseEventFlags&vtinput.DoubleClick) != 0
+				isMiddleClick := e.ButtonState == vtinput.FromLeft2ndButtonPressed
+				if (isLeftDoubleClick || isMiddleClick) && t.OnAction != nil {
+					t.OnAction(t.SelectPos)
+				}
+			}
+			return true
 		}
 	}
 
@@ -347,5 +845,43 @@ func (t *Table) ProcessMouse(e *vtinput.InputEvent) bool {
 
 func (t *Table) SetPosition(x1, y1, x2, y2 int) {
 	t.MarginTop = map[bool]int{true: 1, false: 0}[t.ShowHeader]
+	t.MarginBottom = map[bool]int{true: 1, false: 0}[t.QuickSearch]
 	t.ScrollView.SetPosition(x1, y1, x2, y2)
+}
+
+// drawSearchLine renders the QuickSearch string in the bottom line of the
+// table: "> text" with a hardware cursor while the table is focused.
+func (t *Table) drawSearchLine(scr *ScreenBuf) {
+	y := t.Y2
+	attr := Palette[t.ColorTextIdx]
+	scr.FillRect(t.X1, y, t.X2, y, ' ', attr)
+
+	fullWidth := t.X2 - t.X1 + 1
+	visibleWidth := fullWidth - 2 // "> " prefix
+	if visibleWidth < 0 {
+		visibleWidth = 0
+	}
+
+	// Horizontal scroll: keep the cursor visible (rune-width aware).
+	if t.searchCursor < t.searchLeft {
+		t.searchLeft = t.searchCursor
+	}
+	for t.searchLeft < t.searchCursor && runewidth.StringWidth(string(t.searchRunes[t.searchLeft:t.searchCursor])) >= visibleWidth {
+		t.searchLeft++
+	}
+
+	scr.Write(t.X1, y, StringToCharInfo("> ", attr))
+	text := string(t.searchRunes[t.searchLeft:])
+	text = runewidth.Truncate(text, visibleWidth, "")
+	scr.Write(t.X1+2, y, StringToCharInfo(text, attr))
+
+	if t.IsFocused() {
+		scr.SetCursorVisible(true)
+		scr.SetCursorShape(CursorShapeUnderline)
+		cursorX := t.X1 + 2 + runewidth.StringWidth(string(t.searchRunes[t.searchLeft:t.searchCursor]))
+		if cursorX > t.X2 {
+			cursorX = t.X2
+		}
+		scr.SetCursorPos(cursorX, y)
+	}
 }

--- a/table_test.go
+++ b/table_test.go
@@ -1,6 +1,7 @@
 package vtui
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/unxed/vtinput"
@@ -510,5 +511,711 @@ func TestTable_FormatCell(t *testing.T) {
 	res = tbl.formatCell("LongString", 4, AlignLeft)
 	if res != "Long" {
 		t.Errorf("Truncation failed: %q", res)
+	}
+}
+
+func TestTable_ResolvedWidths_Flexible(t *testing.T) {
+	SetDefaultPalette()
+
+	// Width 20, no scrollbar: content width is 20.
+	// Fixed col (5) + 2 separators = 7, leaving 13 for two flex columns: 7 + 6.
+	cols := []TableColumn{
+		{Title: "Fixed", Width: 5},
+		{Title: "Flex1", Width: 0},
+		{Title: "Flex2", Width: 0},
+	}
+	tbl := NewTable(0, 0, 20, 3, cols)
+
+	widths := tbl.resolvedWidths()
+	want := []int{5, 7, 6}
+	if len(widths) != len(want) {
+		t.Fatalf("expected %d widths, got %d", len(want), len(widths))
+	}
+	for i := range want {
+		if widths[i] != want[i] {
+			t.Errorf("col %d: expected width %d, got %d", i, want[i], widths[i])
+		}
+	}
+
+	// Columns must fill the whole content width (widths + separators).
+	total := 0
+	for _, w := range widths {
+		total += w
+	}
+	total += len(widths) - 1
+	if total != tbl.GetContentWidth() {
+		t.Errorf("columns do not fill content width: %d != %d", total, tbl.GetContentWidth())
+	}
+}
+
+func TestTable_ResolvedWidths_Resize(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{
+		{Title: "Fixed", Width: 4},
+		{Title: "Flex", Width: 0},
+	}
+	tbl := NewTable(0, 0, 10, 3, cols)
+
+	// content=10: flex = 10 - 4 - 1 = 5
+	if w := tbl.resolvedWidths()[1]; w != 5 {
+		t.Errorf("before resize: expected flex width 5, got %d", w)
+	}
+
+	// Grow the widget: flexible column must follow.
+	tbl.SetPosition(0, 0, 19, 2)
+	if w := tbl.resolvedWidths()[1]; w != 15 {
+		t.Errorf("after resize: expected flex width 15, got %d", w)
+	}
+}
+
+func TestTable_ResolvedWidths_AllFixed(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{
+		{Title: "A", Width: 5},
+		{Title: "B", Width: 6},
+	}
+	tbl := NewTable(0, 0, 30, 3, cols)
+
+	widths := tbl.resolvedWidths()
+	if widths[0] != 5 || widths[1] != 6 {
+		t.Errorf("fixed widths must be preserved, got %v", widths)
+	}
+}
+
+func TestTable_ResolvedWidths_TooNarrow(t *testing.T) {
+	SetDefaultPalette()
+
+	// No room left after the fixed column: each flex column gets at least its
+	// minimum width (here: the title width, 5 for both "Flex1" and "Flex2").
+	cols := []TableColumn{
+		{Title: "Fixed", Width: 10},
+		{Title: "Flex1", Width: 0},
+		{Title: "Flex2", Width: 0},
+	}
+	tbl := NewTable(0, 0, 10, 3, cols)
+
+	widths := tbl.resolvedWidths()
+	if widths[1] != 5 || widths[2] != 5 {
+		t.Errorf("flex columns must be clamped to their minimum width, got %v", widths)
+	}
+}
+
+func TestTable_ResolvedWidths_MinWidth(t *testing.T) {
+	SetDefaultPalette()
+
+	// Explicit MinWidth wins over the title width: "AB" is 2 cells wide,
+	// but the column must not shrink below 8.
+	cols := []TableColumn{
+		{Title: "AB", Width: 0, MinWidth: 8},
+	}
+	tbl := NewTable(0, 0, 5, 3, cols)
+
+	if w := tbl.resolvedWidths()[0]; w != 8 {
+		t.Errorf("expected MinWidth 8 to be respected, got %d", w)
+	}
+}
+
+func TestTable_ResolvedWidths_TitleAsMinWidth(t *testing.T) {
+	SetDefaultPalette()
+
+	// Without MinWidth the title width is the minimum: "LongTitle" (9 cells)
+	// must not be cut off even though the table is only 5 wide.
+	cols := []TableColumn{
+		{Title: "LongTitle", Width: 0},
+	}
+	tbl := NewTable(0, 0, 5, 3, cols)
+
+	if w := tbl.resolvedWidths()[0]; w != 9 {
+		t.Errorf("expected title width 9 as minimum, got %d", w)
+	}
+
+	// The remaining space is distributed on top of the minimums, not evenly:
+	// two flex columns with different title lengths get different widths.
+	cols = []TableColumn{
+		{Title: "AA", Width: 0},     // min 2
+		{Title: "BBBBBB", Width: 0}, // min 6
+	}
+	tbl = NewTable(0, 0, 21, 3, cols)
+	// content=21, separator=1: avail=20, mins 2+6=8, extra 12 -> +6 each.
+	widths := tbl.resolvedWidths()
+	if widths[0] != 8 || widths[1] != 12 {
+		t.Errorf("expected widths [8 12], got %v", widths)
+	}
+}
+
+func TestTable_FlexibleColumnRendering(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(10, 3)
+
+	// A single right-aligned flexible column must stretch to the full width:
+	// its header title ends at the right edge of the table.
+	cols := []TableColumn{{Title: "H", Width: 0, Alignment: AlignRight}}
+	tbl := NewTable(0, 0, 10, 3, cols)
+	tbl.SetRows([]TableRow{mockRow{col1: "X"}})
+	tbl.Show(scr)
+
+	checkCell(t, scr, 9, 0, 'H', Palette[ColTableColumnTitle])
+	checkCell(t, scr, 9, 1, 'X', Palette[ColTableText])
+}
+
+func TestTable_SortDefaultOff(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(11, 4)
+
+	cols := []TableColumn{
+		{Title: "C1", Width: 5},
+		{Title: "C2", Width: 5},
+	}
+	tbl := NewTable(0, 0, 11, 4, cols)
+	tbl.SetRows([]TableRow{mockRow{"B", "2"}, mockRow{"A", "10"}})
+
+	if tbl.SortColumn != -1 {
+		t.Errorf("sorting must be off by default, SortColumn = %d", tbl.SortColumn)
+	}
+	if tbl.RowAt(0) != 0 || tbl.RowAt(1) != 1 {
+		t.Error("row order must be identity by default")
+	}
+
+	// Header shows plain titles, no sort arrows.
+	tbl.Show(scr)
+	checkCell(t, scr, 4, 0, ' ', Palette[ColTableColumnTitle])
+	checkCell(t, scr, 10, 0, ' ', Palette[ColTableColumnTitle])
+}
+
+func TestTable_SetSort(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(11, 5)
+
+	cols := []TableColumn{
+		{Title: "C1", Width: 5},
+		{Title: "C2", Width: 5},
+	}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.SetRows([]TableRow{mockRow{"B", "2"}, mockRow{"C", "1"}, mockRow{"A", "10"}})
+
+	// Ascending by col 0: A, B, C.
+	tbl.SetSort(0, true)
+	if tbl.RowAt(0) != 2 || tbl.RowAt(1) != 0 || tbl.RowAt(2) != 1 {
+		t.Errorf("ascending sort failed: %d %d %d", tbl.RowAt(0), tbl.RowAt(1), tbl.RowAt(2))
+	}
+	tbl.Show(scr)
+	checkCell(t, scr, 0, 1, 'A', Palette[ColTableText])
+	checkCell(t, scr, 0, 2, 'B', Palette[ColTableText])
+	checkCell(t, scr, 0, 3, 'C', Palette[ColTableText])
+
+	// The sorted column header shows the ascending arrow at its right edge.
+	checkCell(t, scr, 4, 0, '↑', Palette[ColTableColumnTitle])
+
+	// Descending: C, B, A.
+	tbl.SetSort(0, false)
+	tbl.Show(scr)
+	checkCell(t, scr, 0, 1, 'C', Palette[ColTableText])
+	checkCell(t, scr, 4, 0, '↓', Palette[ColTableColumnTitle])
+
+	// The Rows slice itself must not be reordered.
+	if tbl.Rows[0].(mockRow).col1 != "B" {
+		t.Error("Rows slice must keep its original order")
+	}
+
+	// ClearSort restores the original order.
+	tbl.ClearSort()
+	if tbl.RowAt(0) != 0 || tbl.RowAt(1) != 1 || tbl.RowAt(2) != 2 {
+		t.Error("ClearSort must restore the original row order")
+	}
+}
+
+func TestTable_SortCompareCustom(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 5}}
+	tbl := NewTable(0, 0, 6, 5, cols)
+	// Default string comparison would order "10" before "2"; a custom
+	// comparator fixes numeric ordering.
+	tbl.SortCompare = func(a, b TableRow, col int) int {
+		an, _ := strconv.Atoi(a.GetCellText(col))
+		bn, _ := strconv.Atoi(b.GetCellText(col))
+		return an - bn
+	}
+	tbl.SetRows([]TableRow{mockRow{"10", ""}, mockRow{"2", ""}, mockRow{"1", ""}})
+	tbl.SetSort(0, true)
+
+	if tbl.RowAt(0) != 2 || tbl.RowAt(1) != 1 || tbl.RowAt(2) != 0 {
+		t.Errorf("custom comparator failed: %d %d %d", tbl.RowAt(0), tbl.RowAt(1), tbl.RowAt(2))
+	}
+}
+
+func TestTable_HeaderClickSort(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{
+		{Title: "C1", Width: 5},
+		{Title: "C2", Width: 5},
+	}
+	tbl := NewTable(0, 0, 11, 4, cols)
+	tbl.Sortable = true
+	tbl.SetRows([]TableRow{mockRow{"B", "2"}, mockRow{"A", "1"}})
+
+	click := func(x, y int) bool {
+		return tbl.ProcessMouse(&vtinput.InputEvent{
+			Type: vtinput.MouseEventType, KeyDown: true,
+			ButtonState: vtinput.FromLeft1stButtonPressed,
+			MouseX:      int16(x), MouseY: int16(y),
+		})
+	}
+
+	// Click on the second column header (x in 6..10, y = 0): sort ascending.
+	if !click(8, 0) {
+		t.Fatal("header click must be handled")
+	}
+	if tbl.SortColumn != 1 || !tbl.SortAscending {
+		t.Errorf("expected sort by col 1 ascending, got col=%d asc=%v", tbl.SortColumn, tbl.SortAscending)
+	}
+
+	// Second click on the same header toggles the direction.
+	click(8, 0)
+	if tbl.SortColumn != 1 || tbl.SortAscending {
+		t.Errorf("expected descending toggle, got col=%d asc=%v", tbl.SortColumn, tbl.SortAscending)
+	}
+
+	// Click on another column starts ascending sort by it.
+	click(2, 0)
+	if tbl.SortColumn != 0 || !tbl.SortAscending {
+		t.Errorf("expected sort by col 0 ascending, got col=%d asc=%v", tbl.SortColumn, tbl.SortAscending)
+	}
+
+	// Click on the separator (x = 5) is consumed but does not change the sort.
+	if !click(5, 0) {
+		t.Fatal("separator click must be consumed")
+	}
+	if tbl.SortColumn != 0 || !tbl.SortAscending {
+		t.Error("separator click must not change the sort")
+	}
+}
+
+func TestTable_HeaderClickSortDisabled(t *testing.T) {
+	SetDefaultPalette()
+
+	// f4-style manual sorting: the app rewrites titles itself and must not
+	// be affected by the built-in header-click sorting (Sortable = false).
+	cols := []TableColumn{{Title: "Name ↑", Width: 8}}
+	tbl := NewTable(0, 0, 9, 4, cols)
+	tbl.SetRows([]TableRow{mockRow{"B", ""}, mockRow{"A", ""}})
+
+	handled := tbl.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		MouseX:      2, MouseY: 0,
+	})
+	if tbl.SortColumn != -1 {
+		t.Error("header click must not sort when Sortable is false")
+	}
+	if tbl.Columns[0].Title != "Name ↑" {
+		t.Error("column title must not be modified by the table")
+	}
+	if tbl.RowAt(0) != 0 {
+		t.Error("row order must not change when Sortable is false")
+	}
+	_ = handled
+}
+
+// typeSearch feeds printable characters into the table as key events.
+func typeSearch(tbl *Table, s string) {
+	for _, r := range s {
+		tbl.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, Char: r})
+	}
+}
+
+func TestTable_QuickSearchFilter(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{
+		mockRow{"zzneedle", ""},
+		mockRow{"needle zz", ""},
+		mockRow{"x needle", ""},
+		mockRow{"unrelated", ""},
+	})
+
+	typeSearch(tbl, "needle")
+
+	if tbl.ItemCount != 3 {
+		t.Fatalf("expected 3 matching rows, got %d", tbl.ItemCount)
+	}
+	// Ranked by (score, position): all exact, positions 2, 0, 2.
+	// "needle zz" (pos 0) first; ties keep the original order.
+	got := []string{
+		tbl.Rows[tbl.RowAt(0)].(mockRow).col1,
+		tbl.Rows[tbl.RowAt(1)].(mockRow).col1,
+		tbl.Rows[tbl.RowAt(2)].(mockRow).col1,
+	}
+	want := []string{"needle zz", "zzneedle", "x needle"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d: expected %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestTable_QuickSearchFuzzyRanking(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{
+		mockRow{"xxabd", ""}, // 1 error from "abc"
+		mockRow{"xxabc", ""}, // exact
+		mockRow{"xyz", ""},   // too far, must be dropped
+	})
+
+	typeSearch(tbl, "abc") // k = 1
+
+	if tbl.ItemCount != 2 {
+		t.Fatalf("expected 2 rows, got %d", tbl.ItemCount)
+	}
+	if got := tbl.Rows[tbl.RowAt(0)].(mockRow).col1; got != "xxabc" {
+		t.Errorf("exact match must rank first, got %q", got)
+	}
+	if got := tbl.Rows[tbl.RowAt(1)].(mockRow).col1; got != "xxabd" {
+		t.Errorf("fuzzy match must rank second, got %q", got)
+	}
+}
+
+func TestTable_QuickSearchCaseInsensitive(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{mockRow{"ReadMe.txt", ""}})
+
+	typeSearch(tbl, "readme")
+	if tbl.ItemCount != 1 {
+		t.Error("case-insensitive search must match ReadMe.txt")
+	}
+
+	tbl.SearchCaseSensitive = true
+	tbl.SetSearchText("README") // 3 case mismatches > k=2, must not fuzzy-match
+	if tbl.ItemCount != 0 {
+		t.Error("case-sensitive search must not match")
+	}
+}
+
+func TestTable_QuickSearchAllColumns(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{
+		{Title: "C1", Width: 5},
+		{Title: "C2", Width: 5},
+	}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{
+		mockRow{"foo", "bar"},
+		mockRow{"baz", "qux"},
+	})
+
+	typeSearch(tbl, "qux") // only in the second column
+	if tbl.ItemCount != 1 || tbl.Rows[tbl.RowAt(0)].(mockRow).col1 != "baz" {
+		t.Error("search must span all columns")
+	}
+}
+
+func TestTable_QuickSearchEditing(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{mockRow{"abc", ""}, mockRow{"xyz", ""}})
+
+	key := func(vk uint16) {
+		tbl.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vk})
+	}
+
+	typeSearch(tbl, "ac") // no exact match, but within k=0? "ac" vs "abc": 1 error, k=0 -> no rows
+	if tbl.ItemCount != 0 {
+		t.Fatalf("expected 0 rows for k=0, got %d", tbl.ItemCount)
+	}
+
+	// Move cursor left and insert 'b' in the middle: "ac" -> "abc".
+	key(vtinput.VK_LEFT)
+	typeSearch(tbl, "b")
+	if tbl.SearchText() != "abc" {
+		t.Errorf("expected search text %q, got %q", "abc", tbl.SearchText())
+	}
+	if tbl.ItemCount != 1 {
+		t.Errorf("expected 1 row after inserting 'b', got %d", tbl.ItemCount)
+	}
+
+	// Backspace removes the char before the cursor: "abc" (cursor at 2) -> "ac".
+	key(vtinput.VK_BACK)
+	if tbl.SearchText() != "ac" {
+		t.Errorf("backspace failed: %q", tbl.SearchText())
+	}
+
+	// Delete at cursor 1 of "a|c"... wait: after backspace cursor is at 1: "a|c".
+	// Delete removes 'c' -> "a".
+	key(vtinput.VK_DELETE)
+	if tbl.SearchText() != "a" {
+		t.Errorf("delete failed: %q", tbl.SearchText())
+	}
+
+	// Esc clears the search and restores all rows.
+	key(vtinput.VK_ESCAPE)
+	if tbl.SearchText() != "" || tbl.ItemCount != 2 {
+		t.Errorf("Esc must clear search: text=%q count=%d", tbl.SearchText(), tbl.ItemCount)
+	}
+
+	// Esc on an empty search string is not consumed.
+	handled := tbl.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_ESCAPE})
+	if handled {
+		t.Error("Esc with empty search must propagate")
+	}
+}
+
+func TestTable_QuickSearchCellSelectionConflict(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{
+		{Title: "C1", Width: 5},
+		{Title: "C2", Width: 5},
+	}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.CellSelection = true
+	tbl.SetRows([]TableRow{mockRow{"ab", "cd"}})
+
+	typeSearch(tbl, "ab")
+
+	// Plain Left: CellSelection wins, the search cursor stays.
+	tbl.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_LEFT})
+	if tbl.searchCursor != 2 {
+		t.Errorf("plain Left must not move the search cursor under CellSelection, cursor=%d", tbl.searchCursor)
+	}
+
+	// Ctrl+Left moves the search cursor.
+	tbl.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_LEFT, ControlKeyState: vtinput.LeftCtrlPressed})
+	if tbl.searchCursor != 1 {
+		t.Errorf("Ctrl+Left must move the search cursor, cursor=%d", tbl.searchCursor)
+	}
+}
+
+func TestTable_QuickSearchLineRendering(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(11, 5)
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{mockRow{"abc", ""}, mockRow{"abd", ""}, mockRow{"xyz", ""}, mockRow{"aaa", ""}})
+
+	typeSearch(tbl, "ab")
+	tbl.Show(scr)
+
+	// The search line takes one row from the data area.
+	if tbl.ViewHeight != 3 {
+		t.Errorf("expected ViewHeight 3 (5 - header - search line), got %d", tbl.ViewHeight)
+	}
+
+	checkCell(t, scr, 0, 4, '>', Palette[ColTableText])
+	checkCell(t, scr, 2, 4, 'a', Palette[ColTableText])
+	checkCell(t, scr, 3, 4, 'b', Palette[ColTableText])
+}
+
+func TestTable_QuickSearchDisabledByDefault(t *testing.T) {
+	SetDefaultPalette()
+
+	// f4 compatibility: without QuickSearch, typing must not filter anything.
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.SetRows([]TableRow{mockRow{"abc", ""}, mockRow{"xyz", ""}})
+
+	typeSearch(tbl, "abc")
+	if tbl.ItemCount != 2 || tbl.SearchText() != "" {
+		t.Error("typing must not filter when QuickSearch is off")
+	}
+	if tbl.ViewHeight != 4 {
+		t.Errorf("search line must not reserve space when QuickSearch is off, ViewHeight=%d", tbl.ViewHeight)
+	}
+}
+
+func TestTable_QuickSearchOverridesColumnSort(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.Sortable = true
+	tbl.SetRows([]TableRow{mockRow{"bx", ""}, mockRow{"ax", ""}, mockRow{"cx", ""}})
+
+	// Column sort ascending: ax, bx, cx.
+	tbl.SetSort(0, true)
+	if tbl.Rows[tbl.RowAt(0)].(mockRow).col1 != "ax" {
+		t.Fatal("column sort broken before search")
+	}
+
+	// While searching, match ranking wins over the column sort: "x bx" scores
+	// lower... actually all contain "x" at pos 1; use a discriminating needle.
+	tbl.SetSearchText("bx")
+	if tbl.ItemCount != 1 || tbl.Rows[tbl.RowAt(0)].(mockRow).col1 != "bx" {
+		t.Error("search filter must apply over the column sort")
+	}
+
+	// Clearing the search restores the column sort.
+	tbl.ClearSearch()
+	if tbl.ItemCount != 3 || tbl.Rows[tbl.RowAt(0)].(mockRow).col1 != "ax" {
+		t.Error("ClearSearch must restore the column-sorted order")
+	}
+}
+
+func TestTable_QuickSearchHighlight(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(11, 5)
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{mockRow{"xxabcxx", ""}})
+
+	typeSearch(tbl, "abc")
+	tbl.Show(scr)
+
+	// Single match drawn bottom-up: ViewHeight=3, data rows y=1..3, row at y=3.
+	base := Palette[ColTableText]
+	inv := InvertColors(base)
+	checkCell(t, scr, 0, 3, 'x', base)
+	checkCell(t, scr, 1, 3, 'x', base)
+	checkCell(t, scr, 2, 3, 'a', inv)
+	checkCell(t, scr, 3, 3, 'b', inv)
+	checkCell(t, scr, 4, 3, 'c', inv)
+	checkCell(t, scr, 5, 3, 'x', base)
+}
+
+func TestTable_QuickSearchHighlightFuzzySpan(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(11, 5)
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	// "abxc" matches needle "abc" with one insertion; the whole "abxc" span
+	// must be highlighted, not just m=3 runes.
+	tbl.SetRows([]TableRow{mockRow{"abxc", ""}})
+
+	typeSearch(tbl, "abc")
+	tbl.Show(scr)
+
+	base := Palette[ColTableText]
+	inv := InvertColors(base)
+	checkCell(t, scr, 0, 3, 'a', inv)
+	checkCell(t, scr, 1, 3, 'b', inv)
+	checkCell(t, scr, 2, 3, 'x', inv)
+	checkCell(t, scr, 3, 3, 'c', inv)
+}
+
+func TestTable_QuickSearchBottomUp(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(11, 6)
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 6, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{
+		mockRow{"xab", ""}, // pos 1
+		mockRow{"abx", ""}, // pos 0 -> best
+		mockRow{"zzz", ""}, // no match
+	})
+
+	typeSearch(tbl, "ab")
+	tbl.Show(scr)
+
+	// ViewHeight = 6 - header - search = 4; data rows y=1..4, bottom y=4.
+	// Best match ("abx", displayPos 0) at the bottom, next one above it.
+	base := Palette[ColTableText]
+	inv := InvertColors(base)
+	checkCell(t, scr, 0, 4, 'a', inv)  // "abx" at the bottom, needle highlighted
+	checkCell(t, scr, 2, 4, 'x', base) // 'x' is outside the match span
+	checkCell(t, scr, 0, 3, 'x', base) // "xab" above
+	checkCell(t, scr, 0, 2, ' ', base) // empty space at the top
+	checkCell(t, scr, 0, 1, ' ', base)
+}
+
+func TestTable_QuickSearchBottomUpKeys(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{mockRow{"xab", ""}, mockRow{"abx", ""}})
+
+	typeSearch(tbl, "ab")
+	if tbl.SelectPos != 0 {
+		t.Fatalf("cursor must start at the best match, got %d", tbl.SelectPos)
+	}
+
+	key := func(vk uint16) bool {
+		return tbl.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vk})
+	}
+
+	// Up moves to the next (worse) match, Down moves back.
+	if !key(vtinput.VK_UP) || tbl.SelectPos != 1 {
+		t.Errorf("Up must move to the next match, SelectPos=%d", tbl.SelectPos)
+	}
+	if key(vtinput.VK_UP) {
+		t.Error("Up past the last match must propagate")
+	}
+	if !key(vtinput.VK_DOWN) || tbl.SelectPos != 0 {
+		t.Errorf("Down must move back towards the best match, SelectPos=%d", tbl.SelectPos)
+	}
+	if key(vtinput.VK_DOWN) {
+		t.Error("Down below the best match must propagate")
+	}
+}
+
+func TestTable_QuickSearchBottomUpMouse(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{mockRow{"xab", ""}, mockRow{"abx", ""}})
+	// DisplayObject normally re-syncs margins every frame; do it explicitly.
+	tbl.SetPosition(tbl.X1, tbl.Y1, tbl.X2, tbl.Y2)
+
+	typeSearch(tbl, "ab")
+
+	click := func(y int) {
+		tbl.ProcessMouse(&vtinput.InputEvent{
+			Type: vtinput.MouseEventType, KeyDown: true,
+			ButtonState: vtinput.FromLeft1stButtonPressed,
+			MouseX:      2, MouseY: int16(y),
+		})
+	}
+
+	// Data rows y=1..3 (ViewHeight 3); the best match is at the bottom (y=3).
+	click(3)
+	if tbl.SelectPos != 0 {
+		t.Errorf("click on the bottom row must select the best match, got %d", tbl.SelectPos)
+	}
+	click(2)
+	if tbl.SelectPos != 1 {
+		t.Errorf("click one row above must select the second match, got %d", tbl.SelectPos)
+	}
+	// Click on the empty area above the results must not move the cursor.
+	click(1)
+	if tbl.SelectPos != 1 {
+		t.Errorf("click on empty space must be ignored, got %d", tbl.SelectPos)
 	}
 }


### PR DESCRIPTION
Гибкие ширины колонок
 * Width <= 0 — колонка становится гибкой: все гибкие колонки делят остаток ширины таблицы после фиксированных колонок и разделителей. Пересчёт автоматический при ресайзе виджета — ручной подсчёт ширин в прикладном коде больше не нужен.
 * Новое поле TableColumn.MinWidth — минимальная ширина гибкой колонки; если не задано, минимумом служит ширина заголовка (заголовок никогда не обрезается).
 * Распределение: сначала каждая гибкая колонка получает минимум, остаток делится поровну.
 * Обратная совместимость: колонки с явной Width > 0 работают как раньше.

Сортировка по колонке
 * Opt-in флаг Sortable: клик по заголовку сортирует, повторный клик меняет направление; стрелка ↑/↓ рисуется при рендере, заголовок не модифицируется.
 * API: SetSort(col, ascending), ClearSort(), кастомный компаратор SortCompare (по умолчанию — строковое сравнение по тексту ячейки, стабильная сортировка).
 * Слайс Rows никогда не переупорядочивается — порядок отображения строится через индексный маппинг; RowAt(SelectPos) возвращает исходную строку.

Нечёткий поиск с фильтрацией на лету (QuickSearch)
 * Opt-in флаг QuickSearch: ввод текста идёт в поисковую строку под таблицей, Up/Down — навигация по строкам, Left/Right — курсор по тексту, Esc очищает фильтр.
 * Алгоритм Myers' bit-vector (новый fuzzy.go): приближённый поиск подстроки за O(len) битовых операций; ASCII fast path + Unicode fallback; порог k = len/3; needle > 64 рун деградирует в точный поиск. Корректность верифицирована property-тестами против классического DP-эталона (~4000 кейсов).
 * Матч по всем колонкам, лучший результат используется; ранжирование по (расстояние, позиция вхождения) — точные совпадения всегда наверху.
 * Результаты отображаются снизу вверх над строкой поиска (telescope-style): лучший матч ближе к строке ввода.
 * Подсветка совпадения: точный спан матча (включая fuzzy с инсертами/делециями — вторым проходом с развёрнутым needle), инверсия цветов через новый InvertColors, работает на всех бэкендах (ANSI и GUI).
 * При конфликте с CellSelection за стрелками остаётся навигация по колонкам, курсор поиска двигается через Ctrl+Left/Right.
 * По умолчанию выключено — существующие приложения не затронуты.

Прочее
 * Демо-приложение: диалог «Table Demo» (меню Options) со всеми новыми возможностями + обязательный layout-тест.
 * Тестовое покрытие: 20+ новых тестов (распределение ширин, ресайз, сортировка, клики, фильтрация, хайлайт, bottom-up рендер, клавиши/мышь).
 
<img width="1227" height="801" alt="image" src="https://github.com/user-attachments/assets/7fb26169-60c0-438f-a1f8-aeaf24c23c87" />
