### PR TITLE
common_dialogs: explicit MessageKind for message dialogs

### DIFF
--- a/common_dialogs.go
+++ b/common_dialogs.go
@@ -120,24 +120,77 @@ func SelectDirDialog(title string, initialPath string, vfs FSProvider) *Window {
 	FrameManager.Push(dlg)
 	return dlg
 }
+
+// MessageKind selects the visual style of a message dialog.
+//
+// Message dialogs come in two flavours:
+//   - MessageInfo — the ordinary blue/dialog palette; use for questions,
+//     choices, and neutral notifications ("File already open, what now?").
+//   - MessageWarn — the red WarnDialog palette; use for genuinely alarming
+//     situations: destructive confirmations ("Delete N files?"), errors,
+//     data-loss risks ("Unsaved changes will be lost").
+//
+// Prefer ShowMessageEx / ShowMessageOnEx when the semantics are known.
+// The legacy ShowMessage / ShowMessageOn keep working — they infer the
+// kind from a small set of well-known titles (see legacyKindFromTitle),
+// which is retained for backward compatibility only.
+type MessageKind int
+
+const (
+	MessageInfo MessageKind = iota
+	MessageWarn
+)
+
+// legacyKindFromTitle preserves the historical behaviour of ShowMessage:
+// dialogs whose trimmed title equals "Warning", "Error", or "Confirm" are
+// rendered with the warning palette. New code should pass MessageKind
+// explicitly via ShowMessageEx / ShowMessageOnEx and stop relying on
+// this string match, which couples the visual style to the (potentially
+// localised) title text.
+func legacyKindFromTitle(title string) MessageKind {
+	trimmed := strings.TrimSpace(title)
+	if trimmed == "Warning" || trimmed == "Error" || trimmed == "Confirm" {
+		return MessageWarn
+	}
+	return MessageInfo
+}
+
+// ShowMessage displays a message dialog whose visual style is guessed
+// from the title (see legacyKindFromTitle). Kept for backward
+// compatibility; prefer ShowMessageEx in new code.
 func ShowMessage(title string, text string, buttons []string) *Window {
-	dlg := createMessageDialog(title, text, buttons)
+	return ShowMessageEx(title, text, buttons, legacyKindFromTitle(title))
+}
+
+// ShowMessageOn is the anchored variant of ShowMessage — see there for
+// the caveats. Prefer ShowMessageOnEx in new code.
+func ShowMessageOn(anchor Frame, title string, text string, buttons []string) *Window {
+	return ShowMessageOnEx(anchor, title, text, buttons, legacyKindFromTitle(title))
+}
+
+// ShowMessageEx displays a message dialog with an explicit visual kind.
+// The title no longer influences the palette — callers control the look
+// via kind, which decouples wording from styling and lets warnings stay
+// warnings regardless of localisation.
+func ShowMessageEx(title string, text string, buttons []string, kind MessageKind) *Window {
+	dlg := createMessageDialog(title, text, buttons, kind)
 	FrameManager.Push(dlg)
 	return dlg
 }
 
-// ShowMessageOn creates a message box targeted to a specific screen (via an anchor frame).
-func ShowMessageOn(anchor Frame, title string, text string, buttons []string) *Window {
-	// 1. Create the dialog but DON'T push it yet via the generic FrameManager.Push
-	dlg := createMessageDialog(title, text, buttons)
-
-	// 2. Target the specific screen
+// ShowMessageOnEx is the anchored variant of ShowMessageEx: the dialog
+// is pushed onto the screen owned by `anchor` instead of the current
+// top screen.
+func ShowMessageOnEx(anchor Frame, title string, text string, buttons []string, kind MessageKind) *Window {
+	dlg := createMessageDialog(title, text, buttons, kind)
 	FrameManager.PushToFrameScreen(anchor, dlg)
 	return dlg
 }
 
-// Internal helper to avoid code duplication
-func createMessageDialog(title string, text string, buttons []string) *Window {
+// Internal helper to avoid code duplication.
+// kind is the sole source of truth for IsWarning; title-based inference
+// is done upstream (see legacyKindFromTitle) for backward compatibility.
+func createMessageDialog(title string, text string, buttons []string, kind MessageKind) *Window {
 	const maxDialogWidth = 72 // Comfortably fits within 80 columns
 	const sidePadding = 4
 
@@ -220,8 +273,7 @@ func createMessageDialog(title string, text string, buttons []string) *Window {
 	}
 
 	dlg := NewCenteredDialog(dlgWidth, dlgHeight, title)
-	trimmedTitle := strings.TrimSpace(title)
-	if trimmedTitle == "Warning" || trimmedTitle == "Error" || trimmedTitle == "Confirm" {
+	if kind == MessageWarn {
 		dlg.IsWarning = true
 	}
 

--- a/common_dialogs_test.go
+++ b/common_dialogs_test.go
@@ -314,7 +314,7 @@ func TestLayout_StandardDialogs_Validity(t *testing.T) {
 	})
 
 	t.Run("MessageDialog", func(t *testing.T) {
-		dlg := createMessageDialog("Title", "Multi\nLine\nText", []string{"&Ok", "&Cancel"})
+		dlg := createMessageDialog("Title", "Multi\nLine\nText", []string{"&Ok", "&Cancel"}, MessageInfo)
 		AssertLayout(t, dlg)
 	})
 
@@ -342,7 +342,7 @@ func TestShowMessage_WideButtons_Layout(t *testing.T) {
 
 	// Create dialog. Logic: 1 line text + 4 padding/borders + 14 (7 buttons * 2).
 	// Expected Height = 19.
-	dlg := createMessageDialog(" Stacking Test ", "Testing vertical button stacking logic.", buttons)
+	dlg := createMessageDialog(" Stacking Test ", "Testing vertical button stacking logic.", buttons, MessageInfo)
 
 	// Layout validation (includes width/overlap/padding checks)
 	AssertLayout(t, dlg)
@@ -372,7 +372,7 @@ func TestShowMessage_HeightTruncation(t *testing.T) {
 		text += "Line\n"
 	}
 
-	dlg := createMessageDialog(" Overflow Test ", text, []string{"&Ok"})
+	dlg := createMessageDialog(" Overflow Test ", text, []string{"&Ok"}, MessageInfo)
 
 	// Expected height is exactly screen height - 2 (23)
 	height := dlg.Y2 - dlg.Y1 + 1
@@ -414,11 +414,11 @@ func TestCommonDialogs_WarningMapping(t *testing.T) {
 	SetDefaultPalette()
 	FrameManager.Init(NewSilentScreenBuf())
 
-	// 1. Create a warning dialog
-	dlg := createMessageDialog(" Warning ", "This is a test warning.", []string{"&Ok"})
+	// 1. Create a warning dialog with the explicit kind (recommended API).
+	dlg := createMessageDialog(" Warning ", "This is a test warning.", []string{"&Ok"}, MessageWarn)
 
 	if !dlg.IsWarning {
-		t.Error("Expected IsWarning to be true for ' Warning ' title")
+		t.Error("Expected IsWarning to be true for MessageWarn kind")
 	}
 
 	// 2. Check that the frame's ColorBackgroundIdx maps to ColWarnText after rendering
@@ -481,5 +481,54 @@ func TestShowMessage_Structure(t *testing.T) {
 		if dlg.ExitCode != i {
 			t.Errorf("Button %d failed to set exit code. Got %d", i, dlg.ExitCode)
 		}
+	}
+}
+
+// TestShowMessage_LegacyTitleInference guards the backward-compat path:
+// pre-existing callers pass no MessageKind and rely on the title being
+// one of "Warning" / "Error" / "Confirm" to get the warning palette.
+// New code should use ShowMessageEx with an explicit MessageWarn, but
+// the legacy inference must keep working for existing call sites.
+func TestShowMessage_LegacyTitleInference(t *testing.T) {
+	SetDefaultPalette()
+	FrameManager.Init(NewSilentScreenBuf())
+
+	cases := []struct {
+		title string
+		warn  bool
+	}{
+		{" Warning ", true},
+		{"Error", true},
+		{" Confirm ", true},
+		{" Info ", false},
+		{" File already open ", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		dlg := ShowMessage(tc.title, "body", []string{"&Ok"})
+		if dlg.IsWarning != tc.warn {
+			t.Errorf("ShowMessage(%q).IsWarning = %v, want %v", tc.title, dlg.IsWarning, tc.warn)
+		}
+	}
+}
+
+// TestShowMessageEx_ExplicitKindOverridesTitle is the whole point of the
+// new API: the caller decides the palette, not the title. A "Warning"
+// title with MessageInfo stays blue; a benign title with MessageWarn
+// goes red. This decouples wording (which is localised) from styling.
+func TestShowMessageEx_ExplicitKindOverridesTitle(t *testing.T) {
+	SetDefaultPalette()
+	FrameManager.Init(NewSilentScreenBuf())
+
+	// Title looks like a warning; caller says no — stay blue.
+	dlg := ShowMessageEx(" Warning ", "not really a warning", []string{"&Ok"}, MessageInfo)
+	if dlg.IsWarning {
+		t.Error("ShowMessageEx(MessageInfo) must not set IsWarning regardless of title")
+	}
+
+	// Title is neutral; caller says warn — go red.
+	dlg = ShowMessageEx(" File already open ", "reopen?", []string{"&Ok"}, MessageWarn)
+	if !dlg.IsWarning {
+		t.Error("ShowMessageEx(MessageWarn) must set IsWarning regardless of title")
 	}
 }


### PR DESCRIPTION
The visual palette of message dialogs is currently inferred from the title text: dialogs whose trimmed title equals `"Warning"`, `"Error"`, or `"Confirm"` are rendered with the red warning palette, everything else stays blue.

That couples styling to wording, which is fragile in two ways:

- A localised or renamed title silently loses the red background (warnings become blue).
- A semantically neutral title on a genuinely destructive action (e.g. " Delete ") makes the dialog look like an ordinary info popup even though it should shout.

This PR introduces an explicit `MessageKind`:

```go
type MessageKind int
const (
    MessageInfo MessageKind = iota  // blue/dialog palette
    MessageWarn                     // red WarnDialog palette
)
```

and two new entry points:

```go
ShowMessageEx(title, text, buttons, kind) *Window
ShowMessageOnEx(anchor, title, text, buttons, kind) *Window
```

that pass the caller's intent through to the dialog directly. New code should prefer the Ex variants; the legacy `ShowMessage` / `ShowMessageOn` keep working via `legacyKindFromTitle`, which re-implements the same three-title whitelist so every existing call site continues to render with exactly the same palette.

The internal `createMessageDialog` no longer looks at the title — `kind` is its sole source of truth.

### Backward compatibility

- Public signatures of `ShowMessage` / `ShowMessageOn` are unchanged.
- All existing titles that used to auto-detect as warnings (`Warning`/`Error`/`Confirm`) still do — via the legacy inference wrapper.
- One private helper (`createMessageDialog`) gained a `kind` parameter; the only external caller is the test file, which is updated in the same commit.

### Tests

- `TestShowMessage_LegacyTitleInference` locks the three legacy titles in place so the backward-compat path can't regress silently.
- `TestShowMessageEx_ExplicitKindOverridesTitle` proves the new API is fully decoupled from the title string in both directions (warn-looking title with `MessageInfo` stays blue; benign title with `MessageWarn` goes red).
- The existing `TestCommonDialogs_WarningMapping` was reframed to use the explicit kind (rendering assertions unchanged).
- Full `go test ./...` passes; smoke-built against f4 with a local `replace` — no regressions.

### Motivation from downstream

Prompted by [f4#379](https://github.com/unxed/f4/issues/379) — two f4 dialogs whose colour doesn't match their intent (delete confirmation is blue, "file already open" is red). Fixing both cleanly requires a way to say the palette explicitly rather than through a title string. This PR provides that primitive; the f4-side patch will follow.