### PR TITLE
framemanager: dismiss (not confirm) menus on outside RMB

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -1648,9 +1648,16 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 				}
 
 				if f.IsModal() {
-					// Logic for clicking OUTSIDE of a modal dialog:
-					// LMB -> ESC
-					// RMB -> ENTER
+					// Logic for clicking OUTSIDE of a modal frame:
+					// LMB -> ESC (cancel).
+					// RMB -> ENTER (confirm the default action) for a
+					//        regular dialog, but ESC for a menu — an
+					//        outside click on a drop-down / context
+					//        menu should dismiss, not silently activate
+					//        whichever row happens to be under the
+					//        cursor (typically the first item, e.g.
+					//        "Other panel" for f4's drive menu — the
+					//        exact symptom reported in unxed/f4#396).
 					if ev.KeyDown && ev.ButtonState != 0 {
 						if ev.ButtonState == vtinput.FromLeft1stButtonPressed {
 							f.ProcessKey(&vtinput.InputEvent{
@@ -1659,10 +1666,14 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 								VirtualKeyCode: vtinput.VK_ESCAPE,
 							})
 						} else if ev.ButtonState == vtinput.RightmostButtonPressed {
+							vk := uint16(vtinput.VK_RETURN)
+							if f.GetType() == TypeMenu {
+								vk = vtinput.VK_ESCAPE
+							}
 							f.ProcessKey(&vtinput.InputEvent{
 								Type:           vtinput.KeyEventType,
 								KeyDown:        true,
-								VirtualKeyCode: vtinput.VK_RETURN,
+								VirtualKeyCode: vk,
 							})
 						}
 					}

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -771,6 +771,42 @@ func TestFrameManager_ModalOutsideClicks(t *testing.T) {
 	}
 }
 
+// TestFrameManager_ModalOutsideClicks_MenuDismissesOnRMB pins the fix
+// for unxed/f4#396: the RMB-outside → ENTER shortcut is Far-style
+// muscle memory for confirming a dialog's default button, but for a
+// drop-down / context menu it silently activates whichever row happens
+// to be under the cursor (typically the first item, e.g. "Other panel"
+// for the f4 drive menu). RMB outside a TypeMenu should dismiss it
+// like LMB does.
+func TestFrameManager_ModalOutsideClicks_MenuDismissesOnRMB(t *testing.T) {
+	SetDefaultPalette()
+	fm := &frameManager{}
+	fm.Init(NewSilentScreenBuf())
+	fm.Push(NewDesktop())
+
+	menu := NewVMenu(" Test ")
+	menu.SetPosition(10, 10, 30, 20)
+	menu.AddItem(MenuItem{Text: "Would-be default action"})
+	fm.Push(menu)
+
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      5,
+		MouseY:      5,
+		ButtonState: vtinput.RightmostButtonPressed,
+	}, false)
+
+	if !menu.IsDone() {
+		t.Error("RMB outside a menu did not dismiss it")
+	}
+	if menu.exitCode != -1 {
+		t.Errorf("RMB outside menu: expected ExitCode -1 (dismissed), got %d — "+
+			"row 0 was activated instead, which is exactly what unxed/f4#396 reported",
+			menu.exitCode)
+	}
+}
+
 func TestFrameManager_ModalPriorityOverMenu(t *testing.T) {
 	fm := &frameManager{}
 	scr := NewSilentScreenBuf()


### PR DESCRIPTION
Modal-frame outside-click handling used to be uniform: LMB → ESC (cancel), RMB → ENTER (confirm the default action). The RMB shortcut is Far Manager muscle memory for confirming a dialog's default button without moving the mouse to it, but for a drop-down or context menu it silently activates whichever row happens to sit under the cursor — almost always the first row, and almost never what the user meant.

Downstream [unxed/f4#396](https://github.com/unxed/f4/issues/396) caught this: RMB on f4's path bar opens the drive menu with 'Other panel' focused; the very next RMB anywhere outside that little menu window fires the ENTER fallback and swaps the active panel to the other side.

### Change

Keep the Far-style RMB → ENTER behaviour for dialogs, but send ESC instead when the modal is a menu (`TypeMenu`). The rest of the outside-click fallback is unchanged.

### Test

- `TestFrameManager_ModalOutsideClicks` still passes (dialog RMB → ENTER remains).
- New `TestFrameManager_ModalOutsideClicks_MenuDismissesOnRMB` locks in the menu behaviour. Verified by reverting the fix — the new test fails with an explicit reference to f4#396 in its message.
- Full `go test ./...` passes; smoke-built against f4 with a local `replace` — the whole f4 suite is green.