### PR TITLE
Add workspace tab bar and improve live UI interaction

### DIFF
--- a/basewindow.go
+++ b/basewindow.go
@@ -174,7 +174,8 @@ func (bw *BaseWindow) Show(scr *ScreenBuf) {
 		if bw.ShowClose {
 			offset += 3
 		}
-		scr.Write(bw.X2-offset, bw.Y1, StringToCharInfo(zoomStr, Palette[bw.frame.ColorBoxIdx]))
+		controlAttr := withForeground(Palette[bw.frame.ColorBoxIdx], Palette[bw.frame.ColorTitleIdx])
+		scr.Write(bw.X2-offset, bw.Y1, StringToCharInfo(zoomStr, controlAttr))
 	}
 	if bw.Number > 0 && bw.Number <= 9 {
 		numStr := fmt.Sprintf("%c%d%c", UIStrings.CloseBrackets[0], bw.Number, UIStrings.CloseBrackets[1])

--- a/dialog_test.go
+++ b/dialog_test.go
@@ -416,18 +416,18 @@ func TestDialog_CloseButton_Shifted(t *testing.T) {
 	d := NewDialog(0, 0, 79, 10, "Shifted Close Test")
 	d.ShowClose = true
 
-	// With 2 screens and X2=79, getControlOffset must return 6.
-	// Button [x] should be at 79-6=73, 74, 75.
+	// The [current/total] counter occupies five cells at the right edge, so
+	// the close control moves left and keeps one separating cell.
 	d.ProcessMouse(&vtinput.InputEvent{
 		Type:        vtinput.MouseEventType,
 		KeyDown:     true,
-		MouseX:      74, // Middle of [x] at offset 6
+		MouseX:      72, // Middle of [x] at offset 8
 		MouseY:      0,
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	})
 
 	if !d.IsDone() {
-		t.Error("Shifted close button click failed to close the dialog at MouseX=74")
+		t.Error("Shifted close button click failed to close the dialog at MouseX=72")
 	}
 }
 

--- a/frame.go
+++ b/frame.go
@@ -1,5 +1,7 @@
 package vtui
 
+import "github.com/mattn/go-runewidth"
+
 // BorderedFrame represents a frame container that can have a title.
 // It embeds ScreenObject for position and visibility management.
 type BorderedFrame struct {
@@ -45,7 +47,7 @@ func (f *BorderedFrame) getControlOffset() int {
 	offset := 4
 	if FrameManager != nil && FrameManager.scr != nil && len(FrameManager.Screens) > 1 {
 		if f.X2 >= FrameManager.scr.width-1 {
-			offset = 6
+			offset = runewidth.StringWidth(FrameManager.workspaceCounterText()) + 3
 		}
 	}
 	return offset
@@ -83,6 +85,7 @@ func (f *BorderedFrame) DisplayObject(scr *ScreenBuf) {
 	p.DrawTitle(f.X1, f.Y1, f.X2, f.title, Palette[f.ColorTitleIdx])
 
 	if f.ShowClose {
-		p.DrawCloseButton(f.X2, f.Y1, f.getControlOffset(), Palette[f.ColorBoxIdx])
+		controlAttr := withForeground(Palette[f.ColorBoxIdx], Palette[f.ColorTitleIdx])
+		p.DrawCloseButton(f.X2, f.Y1, f.getControlOffset(), controlAttr)
 	}
 }

--- a/framemanager.go
+++ b/framemanager.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/term"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +22,29 @@ const (
 	TypeMenu
 	TypeUser
 )
+
+// WorkspaceTabMode controls how the workspace tab bar is presented.
+type WorkspaceTabMode int
+
+const (
+	WorkspaceTabsAlways WorkspaceTabMode = iota
+	WorkspaceTabsMultiple
+	WorkspaceTabsOnCtrl
+)
+
+// WorkspaceCtrlTabMode controls whether Ctrl+Tab cycles immediately or opens
+// the existing Screens switcher and commits the selection on Ctrl release.
+type WorkspaceCtrlTabMode int
+
+const (
+	WorkspaceCtrlTabDirect WorkspaceCtrlTabMode = iota
+	WorkspaceCtrlTabMenu
+)
+
+type workspaceTabHit struct {
+	x1, x2 int
+	index  int
+}
 
 // Frame is the interface that all top-level screen objects (windows, dialogs, menus) must implement.
 type Frame interface {
@@ -55,9 +79,31 @@ type Frame interface {
 
 // AppScreen represents an isolated workspace with its own frame stack.
 type AppScreen struct {
+	Number        int // Stable workspace number; never changes during its lifetime.
 	Frames        []Frame
 	CapturedFrame Frame
 	Transparent   bool // Если true, под этим экраном будет рисоваться предыдущий
+}
+
+// WorkspaceTabTitleProvider lets an application provide a compact title for
+// the tab strip without changing the fuller title used by the Screens menu.
+type WorkspaceTabTitleProvider interface {
+	GetWorkspaceTabTitle() string
+}
+
+// WorkspaceMenuInfo describes the richer, full-width representation of a
+// workspace used by the Screens popup. Secondary is shown as an aligned second
+// column when present (for example, the right panel path).
+type WorkspaceMenuInfo struct {
+	Icon      string
+	Primary   string
+	Secondary string
+}
+
+// WorkspaceMenuInfoProvider lets an application expose structured workspace
+// information without overloading its window or compact tab title.
+type WorkspaceMenuInfoProvider interface {
+	GetWorkspaceMenuInfo() WorkspaceMenuInfo
 }
 
 func (s *AppScreen) GetTitle() string {
@@ -66,6 +112,29 @@ func (s *AppScreen) GetTitle() string {
 	}
 	// Возвращаем заголовок самого верхнего фрейма, очищенный от декоративных пробелов
 	return strings.TrimSpace(s.Frames[len(s.Frames)-1].GetTitle())
+}
+
+func (s *AppScreen) GetTabTitle() string {
+	for i := len(s.Frames) - 1; i >= 0; i-- {
+		if provider, ok := s.Frames[i].(WorkspaceTabTitleProvider); ok {
+			if title := strings.TrimSpace(provider.GetWorkspaceTabTitle()); title != "" {
+				return title
+			}
+		}
+	}
+	return s.GetTitle()
+}
+
+func (s *AppScreen) GetMenuInfo() WorkspaceMenuInfo {
+	for i := len(s.Frames) - 1; i >= 0; i-- {
+		if provider, ok := s.Frames[i].(WorkspaceMenuInfoProvider); ok {
+			info := provider.GetWorkspaceMenuInfo()
+			if strings.TrimSpace(info.Primary) != "" {
+				return info
+			}
+		}
+	}
+	return WorkspaceMenuInfo{Icon: "▣", Primary: s.GetTitle()}
 }
 
 func (s *AppScreen) GetProgress() int {
@@ -92,8 +161,9 @@ func (s *AppScreen) NeedsAttention() bool {
 
 // frameManager manages multiple screens and the main application loop.
 type frameManager struct {
-	Screens   []*AppScreen
-	ActiveIdx int
+	Screens           []*AppScreen
+	ActiveIdx         int
+	activationHistory []*AppScreen
 
 	frames         []Frame // Points to the active screen's frame stack
 	scr            *ScreenBuf
@@ -123,9 +193,21 @@ type frameManager struct {
 	capturedFrame Frame // Points to the active screen's captured frame
 
 	// Switcher State
-	ctrlPressed  bool
-	switcherMenu *VMenu
-	running      bool
+	ctrlPressed              bool
+	switcherMenu             *VMenu
+	WorkspaceTabMode         WorkspaceTabMode
+	WorkspaceCtrlTabMode     WorkspaceCtrlTabMode
+	WorkspaceAltNumberSwitch bool
+	WorkspaceTabBarAttr      uint64
+	WorkspaceActiveAttr      uint64
+	WorkspaceAccentAttr      uint64
+	WorkspaceAttentionAttr   uint64
+	workspaceColorsSet       bool
+	workspaceTabHits         []workspaceTabHit
+	workspaceNewTabX         int
+	workspaceTabDrag         *AppScreen
+	workspaceTabDragHits     []workspaceTabHit
+	running                  bool
 
 	lastMouseClickTime     time.Time
 	lastMouseX, lastMouseY int
@@ -171,11 +253,106 @@ func (fm *frameManager) GetActiveToast() string {
 // FrameManager is the global instance of the frame manager.
 var FrameManager = &frameManager{}
 
+// WorkspaceTopInset is the number of rows reserved above application frames
+// for the persistent workspace tab bar.
+func (fm *frameManager) WorkspaceTopInset() int {
+	if fm.WorkspaceTabMode == WorkspaceTabsAlways ||
+		(fm.WorkspaceTabMode == WorkspaceTabsMultiple && len(fm.Screens) > 1) {
+		return 1
+	}
+	return 0
+}
+
+// ConfigureWorkspaceTabs applies workspace presentation and Ctrl+Tab policy.
+// Frames are resized because the persistent modes can add or remove a top row.
+func (fm *frameManager) ConfigureWorkspaceTabs(tabMode WorkspaceTabMode, ctrlTabMode WorkspaceCtrlTabMode) {
+	if tabMode < WorkspaceTabsAlways || tabMode > WorkspaceTabsOnCtrl {
+		tabMode = WorkspaceTabsMultiple
+	}
+	if ctrlTabMode < WorkspaceCtrlTabDirect || ctrlTabMode > WorkspaceCtrlTabMenu {
+		ctrlTabMode = WorkspaceCtrlTabDirect
+	}
+	oldInset := fm.WorkspaceTopInset()
+	fm.WorkspaceTabMode = tabMode
+	fm.WorkspaceCtrlTabMode = ctrlTabMode
+	if oldInset != fm.WorkspaceTopInset() {
+		fm.ResizeAllScreens()
+	}
+	fm.Redraw()
+}
+
+// ConfigureWorkspaceAltNumberSwitch controls direct Alt+1..9 activation by
+// stable workspace number. Applications opt in explicitly to avoid taking
+// existing Alt combinations from embedders that do not expose workspace tabs.
+func (fm *frameManager) ConfigureWorkspaceAltNumberSwitch(enabled bool) {
+	fm.WorkspaceAltNumberSwitch = enabled
+}
+
+// ConfigureWorkspaceTabColors lets the host application match the tab strip
+// to its theme-specific panel colors.
+func (fm *frameManager) ConfigureWorkspaceTabColors(barAttr, activeAttr, accentAttr, attentionAttr uint64) {
+	fm.WorkspaceTabBarAttr = barAttr
+	fm.WorkspaceActiveAttr = activeAttr
+	fm.WorkspaceAccentAttr = accentAttr
+	fm.WorkspaceAttentionAttr = attentionAttr
+	fm.workspaceColorsSet = true
+	fm.Redraw()
+}
+
+// ResizeAllScreens reapplies the current terminal dimensions to every frame.
+func (fm *frameManager) ResizeAllScreens() {
+	if fm.scr == nil {
+		return
+	}
+	for _, screen := range fm.Screens {
+		for _, frame := range screen.Frames {
+			frame.ResizeConsole(fm.scr.width, fm.scr.height)
+		}
+	}
+}
+
 func (fm *frameManager) SyncCurrentScreen() {
 	if len(fm.Screens) > 0 {
 		fm.Screens[fm.ActiveIdx].Frames = fm.frames
 		fm.Screens[fm.ActiveIdx].CapturedFrame = fm.capturedFrame
 	}
+}
+
+func (fm *frameManager) screenIndex(target *AppScreen) int {
+	for i, screen := range fm.Screens {
+		if screen == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func (fm *frameManager) rememberActiveScreen() {
+	if fm.ActiveIdx < 0 || fm.ActiveIdx >= len(fm.Screens) {
+		return
+	}
+	active := fm.Screens[fm.ActiveIdx]
+	if n := len(fm.activationHistory); n == 0 || fm.activationHistory[n-1] != active {
+		fm.activationHistory = append(fm.activationHistory, active)
+	}
+}
+
+func (fm *frameManager) fallbackScreenIndex(defaultIdx int) int {
+	for len(fm.activationHistory) > 0 {
+		last := len(fm.activationHistory) - 1
+		screen := fm.activationHistory[last]
+		fm.activationHistory = fm.activationHistory[:last]
+		if idx := fm.screenIndex(screen); idx >= 0 {
+			return idx
+		}
+	}
+	if defaultIdx >= len(fm.Screens) {
+		defaultIdx = len(fm.Screens) - 1
+	}
+	if defaultIdx < 0 {
+		defaultIdx = 0
+	}
+	return defaultIdx
 }
 
 func (fm *frameManager) GetActiveFrames(sIdx int) []Frame {
@@ -202,13 +379,11 @@ func (fm *frameManager) SwitchScreen(idx int) {
 	}
 
 	fm.SyncCurrentScreen()
+	fm.rememberActiveScreen()
 
-	// MRU Reordering: Move the selected screen to the end of the array
-	screen := fm.Screens[idx]
-	fm.Screens = append(fm.Screens[:idx], fm.Screens[idx+1:]...)
-	fm.Screens = append(fm.Screens, screen)
-
-	fm.ActiveIdx = len(fm.Screens) - 1
+	// Workspace order is stable. Activation changes only the active index;
+	// it never moves a workspace or changes its persistent Number.
+	fm.ActiveIdx = idx
 	fm.frames = fm.Screens[fm.ActiveIdx].Frames
 	fm.capturedFrame = fm.Screens[fm.ActiveIdx].CapturedFrame
 	DebugLog("FM: Switched to Screen %d (Workspace: %s)", fm.ActiveIdx, fm.Screens[fm.ActiveIdx].GetTitle())
@@ -222,22 +397,47 @@ func (fm *frameManager) SwitchScreen(idx int) {
 }
 
 func (fm *frameManager) createScreen(f Frame, transparent bool) *AppScreen {
-	newScreen := &AppScreen{Frames: make([]Frame, 0, 10), Transparent: transparent}
+	number := 1
+	for _, screen := range fm.Screens {
+		if screen.Number >= number {
+			number = screen.Number + 1
+		}
+	}
+	newScreen := &AppScreen{Number: number, Frames: make([]Frame, 0, 10), Transparent: transparent}
 	if !transparent {
 		newScreen.Frames = append(newScreen.Frames, NewDesktop())
 	}
 	newScreen.Frames = append(newScreen.Frames, f)
 	return newScreen
 }
+
+func (fm *frameManager) insertScreenAfterActive(screen *AppScreen) int {
+	idx := fm.ActiveIdx + 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > len(fm.Screens) {
+		idx = len(fm.Screens)
+	}
+	fm.Screens = append(fm.Screens, nil)
+	copy(fm.Screens[idx+1:], fm.Screens[idx:])
+	fm.Screens[idx] = screen
+	return idx
+}
+
 func (fm *frameManager) AddScreen(f Frame) {
 	// If we are already shutting down or in an inconsistent state, bail out.
 	if fm.Screens == nil {
 		return
 	}
 
+	oldInset := fm.WorkspaceTopInset()
 	fm.SyncCurrentScreen()
-	fm.Screens = append(fm.Screens, fm.createScreen(f, false))
-	fm.SwitchScreen(len(fm.Screens) - 1)
+	newIdx := fm.insertScreenAfterActive(fm.createScreen(f, false))
+	if oldInset != fm.WorkspaceTopInset() {
+		fm.ResizeAllScreens()
+	}
+	fm.SwitchScreen(newIdx)
 	fm.Redraw()
 }
 
@@ -245,44 +445,79 @@ func (fm *frameManager) AddScreenHeadless(f Frame) {
 	if fm.Screens == nil {
 		return
 	}
+	oldInset := fm.WorkspaceTopInset()
 	fm.SyncCurrentScreen()
-	fm.Screens = append(fm.Screens, fm.createScreen(f, true))
-	fm.ActiveIdx = len(fm.Screens) - 1
+	fm.rememberActiveScreen()
+	fm.ActiveIdx = fm.insertScreenAfterActive(fm.createScreen(f, true))
 	fm.frames = fm.Screens[fm.ActiveIdx].Frames
 	fm.capturedFrame = nil
+	if oldInset != fm.WorkspaceTopInset() {
+		fm.ResizeAllScreens()
+	}
 	f.ProcessKey(&vtinput.InputEvent{Type: vtinput.FocusEventType, SetFocus: true})
 	fm.Redraw()
 }
 
 func (fm *frameManager) AddScreenBackground(f Frame) {
+	oldInset := fm.WorkspaceTopInset()
 	fm.SyncCurrentScreen()
-	// Insert at the beginning of the slice so it remains the "oldest" workspace
-	// and doesn't interfere with the MRU fallback order (which is at the end).
-	fm.Screens = append([]*AppScreen{fm.createScreen(f, false)}, fm.Screens...)
-	fm.ActiveIdx++ // Keep the user on the current active screen
-	DebugLog("FM: Added background screen at index 0. Current ActiveIdx: %d", fm.ActiveIdx)
+	// Place it next to its source workspace and leave focus unchanged.
+	newIdx := fm.insertScreenAfterActive(fm.createScreen(f, false))
+	if oldInset != fm.WorkspaceTopInset() {
+		fm.ResizeAllScreens()
+	}
+	DebugLog("FM: Added background screen at index %d. Current ActiveIdx: %d", newIdx, fm.ActiveIdx)
+	fm.Redraw()
+}
+
+// RestoreScreenNumbers restores stable display numbers in workspace order.
+// New workspaces derive their number from the current maximum when created.
+func (fm *frameManager) RestoreScreenNumbers(numbers []int) {
+	for i, number := range numbers {
+		if i >= len(fm.Screens) || number < 1 {
+			continue
+		}
+		fm.Screens[i].Number = number
+	}
 }
 
 func (fm *frameManager) CloseActiveScreen() {
+	fm.CloseScreen(fm.ActiveIdx)
+}
+
+// CloseScreen closes one workspace by index. Background workspaces can be
+// closed without activating them first, which is used by middle-click tabs.
+func (fm *frameManager) CloseScreen(idx int) {
+	if idx < 0 || idx >= len(fm.Screens) {
+		return
+	}
 	if len(fm.Screens) <= 1 {
 		fm.EmitCommand(CmQuit, nil)
 		return
 	}
 
-	screenToClose := fm.Screens[fm.ActiveIdx]
+	oldInset := fm.WorkspaceTopInset()
+	fm.SyncCurrentScreen()
+	closedIdx := idx
+	activeScreen := fm.Screens[fm.ActiveIdx]
+	closingActive := closedIdx == fm.ActiveIdx
+	screenToClose := fm.Screens[closedIdx]
 	for i := len(screenToClose.Frames) - 1; i >= 0; i-- {
 		screenToClose.Frames[i].Close()
 	}
 
-	fm.Screens = append(fm.Screens[:fm.ActiveIdx], fm.Screens[fm.ActiveIdx+1:]...)
-	newIdx := fm.ActiveIdx
-	if newIdx >= len(fm.Screens) {
-		newIdx = len(fm.Screens) - 1
+	fm.Screens = append(fm.Screens[:closedIdx], fm.Screens[closedIdx+1:]...)
+	newIdx := fm.screenIndex(activeScreen)
+	if closingActive || newIdx < 0 {
+		newIdx = fm.fallbackScreenIndex(closedIdx)
 	}
 	fm.ActiveIdx = newIdx
 	fm.frames = fm.Screens[newIdx].Frames
 	fm.capturedFrame = fm.Screens[newIdx].CapturedFrame
-	if len(fm.frames) > 0 {
+	if oldInset != fm.WorkspaceTopInset() {
+		fm.ResizeAllScreens()
+	}
+	if closingActive && len(fm.frames) > 0 {
 		fm.frames[len(fm.frames)-1].ProcessKey(&vtinput.InputEvent{Type: vtinput.FocusEventType, SetFocus: true})
 	}
 	fm.Redraw()
@@ -310,9 +545,18 @@ func (fm *frameManager) Screen() *ScreenBuf {
 func (fm *frameManager) Init(scr *ScreenBuf) {
 	fm.scr = scr
 	fm.frames = make([]Frame, 0, 10)
-	fm.Screens = []*AppScreen{{Frames: fm.frames}}
+	fm.Screens = []*AppScreen{{Number: 1, Frames: fm.frames}}
 	fm.ActiveIdx = 0
+	fm.activationHistory = nil
 	fm.mousePositionKnown = false
+	fm.WorkspaceTabMode = WorkspaceTabsMultiple
+	fm.WorkspaceCtrlTabMode = WorkspaceCtrlTabDirect
+	fm.WorkspaceAltNumberSwitch = false
+	fm.workspaceColorsSet = false
+	fm.workspaceTabHits = nil
+	fm.workspaceNewTabX = -1
+	fm.workspaceTabDrag = nil
+	fm.workspaceTabDragHits = nil
 
 	if fm.RedrawChan == nil {
 		fm.RedrawChan = make(chan struct{}, 1)
@@ -734,6 +978,266 @@ func (fm *frameManager) getScreenInfo(idx int, maxTitleLen int) (prefix, title, 
 	return
 }
 
+func (fm *frameManager) workspaceCounterText() string {
+	if len(fm.Screens) < 2 {
+		return ""
+	}
+	return fmt.Sprintf("[%d/%d]", fm.ActiveIdx+1, len(fm.Screens))
+}
+
+func withForeground(backgroundAttr, foregroundAttr uint64) uint64 {
+	if foregroundAttr&IsFgRGB != 0 {
+		return SetRGBFore(backgroundAttr, GetRGBFore(foregroundAttr))
+	}
+	return SetIndexFore(backgroundAttr, GetIndexFore(foregroundAttr))
+}
+
+func (fm *frameManager) workspaceBarAttr() uint64 {
+	if fm.workspaceColorsSet {
+		return fm.WorkspaceTabBarAttr
+	}
+	return Palette[ColMenuBarItem]
+}
+
+func (fm *frameManager) workspaceActiveAttr() uint64 {
+	if fm.workspaceColorsSet {
+		return fm.WorkspaceActiveAttr
+	}
+	return Palette[ColMenuBarSelected]
+}
+
+func (fm *frameManager) workspaceNumberAttr(backgroundAttr uint64) uint64 {
+	accentAttr := Palette[ColMenuBarHighlight]
+	if fm.workspaceColorsSet {
+		accentAttr = fm.WorkspaceAccentAttr
+	}
+	return withForeground(backgroundAttr, accentAttr)
+}
+
+func (fm *frameManager) workspaceAttentionAttr(backgroundAttr uint64) uint64 {
+	attentionAttr := Palette[ColMenuBarSelectedHighlight]
+	if fm.workspaceColorsSet {
+		attentionAttr = fm.WorkspaceAttentionAttr
+	}
+	return withForeground(backgroundAttr, attentionAttr)
+}
+
+func (fm *frameManager) hasBackgroundAttention() bool {
+	for i, screen := range fm.Screens {
+		if i != fm.ActiveIdx && screen.NeedsAttention() {
+			return true
+		}
+	}
+	return false
+}
+
+func (fm *frameManager) drawWorkspaceCounter() {
+	indicator := fm.workspaceCounterText()
+	if indicator == "" || fm.scr == nil {
+		return
+	}
+
+	baseAttr := Palette[ColMenuBarItem]
+	if fm.workspaceTabsVisible() {
+		baseAttr = fm.workspaceBarAttr()
+	}
+	currentAttr := fm.workspaceNumberAttr(baseAttr)
+	if fm.hasBackgroundAttention() {
+		currentAttr = fm.workspaceAttentionAttr(baseAttr)
+	}
+
+	current := strconv.Itoa(fm.ActiveIdx + 1)
+	total := strconv.Itoa(len(fm.Screens))
+	x := fm.scr.width - runewidth.StringWidth(indicator)
+	fm.scr.Write(x, 0, StringToCharInfo("[", baseAttr))
+	x++
+	fm.scr.Write(x, 0, StringToCharInfo(current, currentAttr))
+	x += runewidth.StringWidth(current)
+	fm.scr.Write(x, 0, StringToCharInfo("/"+total+"]", baseAttr))
+}
+
+func (fm *frameManager) workspaceTabsVisible() bool {
+	switch fm.WorkspaceTabMode {
+	case WorkspaceTabsAlways:
+		return true
+	case WorkspaceTabsMultiple:
+		return len(fm.Screens) > 1
+	case WorkspaceTabsOnCtrl:
+		return fm.ctrlPressed
+	default:
+		return false
+	}
+}
+
+func (fm *frameManager) drawWorkspaceTabs() {
+	fm.workspaceTabHits = fm.workspaceTabHits[:0]
+	fm.workspaceNewTabX = -1
+	if fm.scr == nil || !fm.workspaceTabsVisible() || len(fm.Screens) == 0 {
+		return
+	}
+
+	baseAttr := fm.workspaceBarAttr()
+	fm.scr.FillRect(0, 0, fm.scr.width-1, 0, ' ', baseAttr)
+	counterWidth := runewidth.StringWidth(fm.workspaceCounterText())
+	available := fm.scr.width - counterWidth
+	if available <= 0 {
+		return
+	}
+
+	tabsLimit := available
+	if tabsLimit >= 2 {
+		tabsLimit -= 2 // Reserve |+ after the compact tab sequence.
+	}
+
+	x := 0
+	for i, screen := range fm.Screens {
+		remaining := tabsLimit - x
+		if remaining < 1 {
+			break
+		}
+		tabsRemaining := len(fm.Screens) - i
+		separatorsWidth := tabsRemaining - 1
+		contentAvailable := remaining - separatorsWidth
+		maxTabWidth := 0
+		if contentAvailable > 0 {
+			maxTabWidth = contentAvailable / tabsRemaining
+		}
+		if maxTabWidth < 1 {
+			maxTabWidth = remaining
+		}
+
+		number := strconv.Itoa(screen.Number)
+		numberWidth := runewidth.StringWidth(number)
+		titleWidth := maxTabWidth - numberWidth - 3
+		if titleWidth < 0 {
+			titleWidth = 0
+		}
+		title := TruncateMiddle(screen.GetTabTitle(), titleWidth)
+
+		attr := baseAttr
+		if i == fm.ActiveIdx {
+			attr = fm.workspaceActiveAttr()
+		} else if screen.NeedsAttention() {
+			attr = fm.workspaceAttentionAttr(baseAttr)
+		}
+		numberAttr := fm.workspaceNumberAttr(attr)
+		if i != fm.ActiveIdx && screen.NeedsAttention() {
+			numberAttr = fm.workspaceAttentionAttr(attr)
+		}
+		tabStart := x
+		fm.scr.Write(x, 0, StringToCharInfo(" ", attr))
+		x++
+		fm.scr.Write(x, 0, StringToCharInfo(number, numberAttr))
+		x += numberWidth
+		if title != "" && x < tabsLimit {
+			fm.scr.Write(x, 0, StringToCharInfo(" "+title, attr))
+			x += 1 + runewidth.StringWidth(title)
+		}
+		if x < tabsLimit {
+			fm.scr.Write(x, 0, StringToCharInfo(" ", attr))
+			x++
+		}
+		fm.workspaceTabHits = append(fm.workspaceTabHits, workspaceTabHit{x1: tabStart, x2: x - 1, index: i})
+		if i < len(fm.Screens)-1 && x < tabsLimit {
+			fm.scr.Write(x, 0, StringToCharInfo("|", baseAttr))
+			x++
+		}
+	}
+	if x+2 <= available {
+		fm.scr.Write(x, 0, StringToCharInfo("|", baseAttr))
+		fm.scr.Write(x+1, 0, StringToCharInfo("+", fm.workspaceNumberAttr(baseAttr)))
+		fm.workspaceNewTabX = x + 1
+	}
+}
+
+func workspaceTabAt(hits []workspaceTabHit, x int) int {
+	for _, hit := range hits {
+		if x <= hit.x2 {
+			return hit.index
+		}
+	}
+	if len(hits) > 0 {
+		return hits[len(hits)-1].index
+	}
+	return -1
+}
+
+func (fm *frameManager) moveWorkspaceTab(screen *AppScreen, target int) bool {
+	from := fm.screenIndex(screen)
+	if from < 0 || target < 0 || target >= len(fm.Screens) || from == target {
+		return false
+	}
+	activeScreen := fm.Screens[fm.ActiveIdx]
+	if from < target {
+		copy(fm.Screens[from:target], fm.Screens[from+1:target+1])
+	} else {
+		copy(fm.Screens[target+1:from+1], fm.Screens[target:from])
+	}
+	fm.Screens[target] = screen
+	fm.ActiveIdx = fm.screenIndex(activeScreen)
+	fm.frames = fm.Screens[fm.ActiveIdx].Frames
+	fm.capturedFrame = fm.Screens[fm.ActiveIdx].CapturedFrame
+	// Refresh hit targets immediately so several move events arriving before
+	// the next render continue to reorder against the new visual order.
+	fm.drawWorkspaceTabs()
+	fm.drawWorkspaceCounter()
+	fm.Redraw()
+	return true
+}
+
+func (fm *frameManager) processWorkspaceTabDrag(ev *vtinput.InputEvent, mx int) bool {
+	if fm.workspaceTabDrag == nil {
+		return false
+	}
+	if ev.ButtonState == 0 {
+		fm.workspaceTabDrag = nil
+		fm.workspaceTabDragHits = nil
+		return true
+	}
+	if ev.ButtonState&vtinput.FromLeft1stButtonPressed == 0 {
+		fm.workspaceTabDrag = nil
+		fm.workspaceTabDragHits = nil
+		return true
+	}
+	if ev.MouseEventFlags&vtinput.MouseMoved != 0 {
+		// Use the slot geometry captured on mouse-down. Re-rendering after a
+		// reorder can move the boundary dramatically when a short tab trades
+		// places with a long one; using the new boundary would immediately move
+		// it back on the next one-pixel mouse event.
+		fm.moveWorkspaceTab(fm.workspaceTabDrag, workspaceTabAt(fm.workspaceTabDragHits, mx))
+	}
+	return true
+}
+
+func (fm *frameManager) cycleScreensDirect(forward bool) bool {
+	if len(fm.Screens) < 2 {
+		return false
+	}
+	idx := fm.ActiveIdx - 1
+	if forward {
+		idx = fm.ActiveIdx + 1
+	}
+	if idx < 0 {
+		idx = len(fm.Screens) - 1
+	} else if idx >= len(fm.Screens) {
+		idx = 0
+	}
+	fm.SwitchScreen(idx)
+	return true
+}
+
+func (fm *frameManager) switchScreenNumber(number int) bool {
+	for idx, screen := range fm.Screens {
+		if screen.Number == number {
+			if idx != fm.ActiveIdx {
+				fm.SwitchScreen(idx)
+			}
+			return true
+		}
+	}
+	return false
+}
+
 func (fm *frameManager) showScreensMenu() {
 	fm.SyncCurrentScreen()
 	menu := NewVMenu(" Screens ")
@@ -743,23 +1247,84 @@ func (fm *frameManager) showScreensMenu() {
 	if fm.scr != nil {
 		scrH = fm.scr.height
 	}
+	// Silent/headless screens used by embedders and tests may not have been
+	// allocated yet. Keep the popup layout valid until a real size arrives.
+	if scrW < 20 {
+		scrW = 40
+	}
 
-	menuW := (scrW * 60) / 100
+	maxNumberWidth := 1
+	maxLeftWidth := 0
+	maxRightWidth := 0
+	maxIconWidth := 1
+	infos := make([]WorkspaceMenuInfo, len(fm.Screens))
+	for _, screen := range fm.Screens {
+		if width := len(strconv.Itoa(screen.Number)); width > maxNumberWidth {
+			maxNumberWidth = width
+		}
+	}
+	for i, screen := range fm.Screens {
+		infos[i] = screen.GetMenuInfo()
+		if width := runewidth.StringWidth(infos[i].Primary); width > maxLeftWidth {
+			maxLeftWidth = width
+		}
+		if width := runewidth.StringWidth(infos[i].Secondary); width > maxRightWidth {
+			maxRightWidth = width
+		}
+		if width := runewidth.StringWidth(infos[i].Icon); width > maxIconWidth {
+			maxIconWidth = width
+		}
+	}
+
+	// number + marker + icon + primary + optional separator/secondary + frame
+	contentWidth := maxNumberWidth + 3 + maxIconWidth + 1 + maxLeftWidth
+	if maxRightWidth > 0 {
+		contentWidth += 3 + maxRightWidth
+	}
+	menuW := contentWidth + 4
 	if menuW < 40 {
 		menuW = 40
 	}
-	if menuW > 100 {
-		menuW = 100
+	maxMenuW := scrW - 4
+	if maxMenuW < 20 {
+		maxMenuW = scrW
 	}
-
-	maxTitleLen := menuW - 19
-	if maxTitleLen < 10 {
-		maxTitleLen = 10
+	if menuW > maxMenuW {
+		menuW = maxMenuW
+	}
+	availablePaths := menuW - 4 - maxNumberWidth - 3 - maxIconWidth - 1
+	if maxRightWidth > 0 {
+		availablePaths -= 3
+		if maxLeftWidth+maxRightWidth > availablePaths {
+			leftShare := availablePaths / 2
+			if leftShare < 4 {
+				leftShare = 4
+			}
+			maxLeftWidth = min(maxLeftWidth, leftShare)
+			maxRightWidth = max(0, availablePaths-maxLeftWidth)
+		}
+	} else {
+		maxLeftWidth = min(maxLeftWidth, availablePaths)
 	}
 
 	for i := range fm.Screens {
-		pre, tit, suf, _ := fm.getScreenInfo(i, maxTitleLen)
-		menu.AddItem(MenuItem{Text: pre + tit + suf, UserData: i})
+		pre, _, suf, _ := fm.getScreenInfo(i, 0)
+		info := infos[i]
+		primary := truncateMiddleCells(info.Primary, maxLeftWidth)
+		marker := strings.TrimSpace(pre)
+		line := " " + marker + strings.Repeat(" ", 1-runewidth.StringWidth(marker)) + " "
+		line += info.Icon + strings.Repeat(" ", maxIconWidth-runewidth.StringWidth(info.Icon)) + " "
+		line += primary + strings.Repeat(" ", maxLeftWidth-runewidth.StringWidth(primary))
+		if maxRightWidth > 0 {
+			secondary := truncateMiddleCells(info.Secondary, maxRightWidth)
+			line += " ↔ " + secondary
+		}
+		line += suf
+		menu.AddItem(MenuItem{
+			AccentPrefix: fmt.Sprintf("%*d", maxNumberWidth, fm.Screens[i].Number),
+			Text:         line,
+			UserData:     i,
+		})
 	}
 
 	menu.OnAction = func(idx int) {
@@ -776,8 +1341,41 @@ func (fm *frameManager) showScreensMenu() {
 	fm.Push(menu)
 }
 
+func truncateMiddleCells(value string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if runewidth.StringWidth(value) <= width {
+		return value
+	}
+	if width == 1 {
+		return "…"
+	}
+	leftWidth := (width - 1) / 2
+	rightWidth := width - 1 - leftWidth
+	left := runewidth.Truncate(value, leftWidth, "")
+	runes := []rune(value)
+	start := len(runes)
+	used := 0
+	for start > 0 {
+		cellWidth := runewidth.RuneWidth(runes[start-1])
+		if used+cellWidth > rightWidth {
+			break
+		}
+		start--
+		used += cellWidth
+	}
+	return left + "…" + string(runes[start:])
+}
+
 func (fm *frameManager) cleanupDoneFrames() {
+	oldInset := fm.WorkspaceTopInset()
 	fm.SyncCurrentScreen()
+	oldActiveIdx := fm.ActiveIdx
+	var activeScreen *AppScreen
+	if fm.ActiveIdx >= 0 && fm.ActiveIdx < len(fm.Screens) {
+		activeScreen = fm.Screens[fm.ActiveIdx]
+	}
 
 	var oldTop Frame
 	if len(fm.frames) > 0 {
@@ -810,15 +1408,14 @@ func (fm *frameManager) cleanupDoneFrames() {
 		if isDead {
 			DebugLog("FM: Removing dead Screen %d (Total screens: %d)", sIdx, len(fm.Screens))
 			fm.Screens = append(fm.Screens[:sIdx], fm.Screens[sIdx+1:]...)
-			if fm.ActiveIdx >= sIdx && fm.ActiveIdx > 0 {
-				fm.ActiveIdx--
-			}
 		}
 	}
 
 	if len(fm.Screens) > 0 {
-		if fm.ActiveIdx >= len(fm.Screens) {
-			fm.ActiveIdx = len(fm.Screens) - 1
+		if idx := fm.screenIndex(activeScreen); idx >= 0 {
+			fm.ActiveIdx = idx
+		} else {
+			fm.ActiveIdx = fm.fallbackScreenIndex(oldActiveIdx)
 		}
 		fm.frames = fm.Screens[fm.ActiveIdx].Frames
 		fm.capturedFrame = fm.Screens[fm.ActiveIdx].CapturedFrame
@@ -829,6 +1426,9 @@ func (fm *frameManager) cleanupDoneFrames() {
 		}
 		if newTop != nil && newTop != oldTop {
 			newTop.ProcessKey(&vtinput.InputEvent{Type: vtinput.FocusEventType, SetFocus: true})
+		}
+		if oldInset != fm.WorkspaceTopInset() {
+			fm.ResizeAllScreens()
 		}
 	} else {
 		fm.Shutdown()
@@ -1290,30 +1890,12 @@ func (fm *frameManager) renderPhase() {
 		if fm.OnRender != nil {
 			fm.OnRender(fm.scr)
 		}
+		fm.drawWorkspaceTabs()
+		fm.drawWorkspaceCounter()
 
 		fm.scr.Graphics().EndFrame()
 		if semanticRenderer, ok := fm.scr.Renderer.(SemanticSceneRenderer); ok {
 			semanticRenderer.SetSemanticScene(fm.ExportSemanticScene())
-		}
-
-		// Draw Workspace count [N] and highlight if background needs attention
-		if len(fm.Screens) > 1 {
-			hasAttention := false
-			for i, s := range fm.Screens {
-				if i != fm.ActiveIdx && s.NeedsAttention() {
-					hasAttention = true
-					break
-				}
-			}
-
-			// Orange (0xFF8700) for attention, otherwise light gray
-			attr := SetRGBBoth(0, 0xD3D7CF, 0x2E3436)
-			if hasAttention {
-				attr = SetRGBFore(attr, 0xFF8700)
-			}
-
-			indicator := fmt.Sprintf("[%d]", len(fm.Screens))
-			fm.scr.Write(fm.scr.width-len(indicator), 0, StringToCharInfo(indicator, attr))
 		}
 
 		fm.scr.Flush()
@@ -1502,11 +2084,15 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 
 	// Track Ctrl state for Switcher logic
 	if ev.Type == vtinput.KeyEventType {
+		wasCtrlPressed := fm.ctrlPressed
 		ctrl := (ev.ControlKeyState & (vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed)) != 0
 		if ev.VirtualKeyCode == vtinput.VK_CONTROL || ev.VirtualKeyCode == vtinput.VK_LCONTROL || ev.VirtualKeyCode == vtinput.VK_RCONTROL {
 			ctrl = ev.KeyDown
 		}
 		fm.ctrlPressed = ctrl
+		if wasCtrlPressed != fm.ctrlPressed && fm.WorkspaceTabMode == WorkspaceTabsOnCtrl {
+			fm.Redraw()
+		}
 
 		// Commit Switcher selection on Ctrl release
 		if !fm.ctrlPressed && fm.switcherMenu != nil {
@@ -1556,6 +2142,27 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 		DebugLog("INPUT: KeyRelease VK=%s Char=%d (Stack: %d frames, ActiveIdx: %d)", vtinput.VKString(ev.VirtualKeyCode), ev.Char, len(fm.frames), fm.ActiveIdx)
 	}
 
+	// Alt+1..9 selects the workspace whose stable displayed number matches the
+	// digit. In the transient Ctrl-only tab-bar mode, Ctrl+Alt+1..9 does the
+	// same: Ctrl is already being held to reveal the bar, so requiring its
+	// release before choosing a tab would make the visible shortcuts awkward.
+	// Menus retain priority above, and a missing number falls through so
+	// applications and terminals can keep using that combination.
+	if fm.WorkspaceAltNumberSwitch && ev.Type == vtinput.KeyEventType && ev.KeyDown &&
+		ev.VirtualKeyCode >= vtinput.VK_1 && ev.VirtualKeyCode <= vtinput.VK_9 {
+		mods := ev.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed |
+			vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed | vtinput.ShiftPressed)
+		alt := mods&(vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0
+		ctrl := mods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0
+		shift := mods&vtinput.ShiftPressed != 0
+		validModifiers := alt && !shift && (!ctrl || fm.WorkspaceTabMode == WorkspaceTabsOnCtrl)
+		if validModifiers {
+			if fm.switchScreenNumber(int(ev.VirtualKeyCode - vtinput.VK_0)) {
+				return
+			}
+		}
+	}
+
 	// 3. Regular Dispatch (MDI Hit-Testing)
 	handled := false
 
@@ -1566,6 +2173,13 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 		mx, my := int(ev.MouseX), int(ev.MouseY)
 		if ev.ButtonState != 0 || ev.WheelDirection != 0 {
 			DebugLog("FM: Mouse Event at (%d,%d) State:%X Wheel:%d", mx, my, ev.ButtonState, ev.WheelDirection)
+		}
+		// Workspace-tab dragging is global capture: once a press starts on a
+		// tab, no part of the held gesture may leak into a frame or menu. Handle
+		// it before bounds checks so releasing outside the window still clears
+		// the capture.
+		if fm.processWorkspaceTabDrag(ev, mx) {
+			return
 		}
 
 		if mx < -1 || my < -1 {
@@ -1584,12 +2198,34 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 				fm.capturedFrame = nil // Release capture
 			}
 		} else {
-			// 3.1.2. Hit test for workspace counter [N] at top right
+			if my == 0 && ev.KeyDown && ev.ButtonState&vtinput.FromLeft2ndButtonPressed != 0 {
+				for _, hit := range fm.workspaceTabHits {
+					if mx >= hit.x1 && mx <= hit.x2 {
+						fm.CloseScreen(hit.index)
+						return
+					}
+				}
+			}
+			// 3.1.2. Hit test for workspace counter [current/total] and tabs.
 			if len(fm.Screens) > 1 && my == 0 {
-				indicatorLen := len(fmt.Sprintf("[%d]", len(fm.Screens)))
+				indicatorLen := runewidth.StringWidth(fm.workspaceCounterText())
 				if mx >= fm.scr.width-indicatorLen && mx < fm.scr.width {
 					if ev.ButtonState == vtinput.FromLeft1stButtonPressed && ev.KeyDown {
 						fm.showScreensMenu()
+						return
+					}
+				}
+			}
+			if my == 0 && ev.ButtonState == vtinput.FromLeft1stButtonPressed && ev.KeyDown {
+				if mx == fm.workspaceNewTabX {
+					fm.EmitCommand(CmResize, "fork")
+					return
+				}
+				for _, hit := range fm.workspaceTabHits {
+					if mx >= hit.x1 && mx <= hit.x2 {
+						fm.workspaceTabDrag = fm.Screens[hit.index]
+						fm.workspaceTabDragHits = append(fm.workspaceTabDragHits[:0], fm.workspaceTabHits...)
+						fm.SwitchScreen(hit.index)
 						return
 					}
 				}
@@ -1686,11 +2322,16 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 	// 3. Fallbacks (F9, Alt+Hotkey, Global Shortcuts) if top frame didn't want the key
 	if !handled && ev.Type == vtinput.KeyEventType && ev.KeyDown {
 
-		// Window Cycling (Ctrl+Tab / Ctrl+Shift+Tab)
+		// Workspace cycling (Ctrl+Tab / Ctrl+Shift+Tab).
 		if ev.VirtualKeyCode == vtinput.VK_TAB && (fm.ctrlPressed || fm.switcherMenu != nil) {
 			shift := (ev.ControlKeyState & vtinput.ShiftPressed) != 0
-			// Only consume the event if cycling is actually possible
-			if fm.CycleWindows(!shift) {
+			cycled := false
+			if fm.WorkspaceCtrlTabMode == WorkspaceCtrlTabMenu {
+				cycled = fm.CycleWindows(!shift)
+			} else {
+				cycled = fm.cycleScreensDirect(!shift)
+			}
+			if cycled {
 				return
 			}
 		}

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -1,9 +1,11 @@
 package vtui
 
 import (
+	"github.com/mattn/go-runewidth"
 	"github.com/unxed/vtinput"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,8 @@ type mockFrame struct {
 	BaseFrame
 	onProcessMouse     func(e *vtinput.InputEvent) bool
 	onProcessKey       func(e *vtinput.InputEvent) bool
+	onHandleCommand    func(cmd int, args any) bool
+	tabTitle           string
 	resizedW, resizedH int
 }
 
@@ -41,8 +45,16 @@ func (m *mockFrame) ProcessMouse(e *vtinput.InputEvent) bool {
 	return false
 }
 
-func (m *mockFrame) GetType() FrameType { return TypeUser }
-func (m *mockFrame) GetTitle() string   { return "MockFrame" }
+func (m *mockFrame) HandleCommand(cmd int, args any) bool {
+	if m.onHandleCommand != nil {
+		return m.onHandleCommand(cmd, args)
+	}
+	return m.BaseFrame.HandleCommand(cmd, args)
+}
+
+func (m *mockFrame) GetType() FrameType           { return TypeUser }
+func (m *mockFrame) GetTitle() string             { return "MockFrame" }
+func (m *mockFrame) GetWorkspaceTabTitle() string { return m.tabTitle }
 
 func TestFrameManager_DuplicateMouseMoveDoesNotHoverNewMenu(t *testing.T) {
 	oldFM := FrameManager
@@ -309,39 +321,41 @@ func TestFrameManager_GetTopFrameType(t *testing.T) {
 		t.Errorf("Expected TopFrameType to be TypeUser, got %d", fm.GetTopFrameType())
 	}
 }
-func TestFrameManager_SwitchScreen_MRU(t *testing.T) {
+func TestFrameManager_SwitchScreenPreservesOrderAndNumbers(t *testing.T) {
 	fm := &frameManager{}
 	fm.Init(NewSilentScreenBuf())
 	defer fm.Shutdown()
-	fm.Push(NewDesktop())                       // Screen 0: Desktop
-	fm.AddScreen(NewWindow(0, 0, 10, 10, "W1")) // Screen 1: W1
-	fm.AddScreen(NewWindow(0, 0, 10, 10, "W2")) // Screen 2: W2
+	fm.Push(NewDesktop())
+	fm.AddScreen(NewWindow(0, 0, 10, 10, "W1"))
+	fm.AddScreen(NewWindow(0, 0, 10, 10, "W2"))
 
 	if len(fm.Screens) != 3 {
 		t.Fatalf("Expected 3 screens, got %d", len(fm.Screens))
 	}
+	if got := []int{fm.Screens[0].Number, fm.Screens[1].Number, fm.Screens[2].Number}; !reflect.DeepEqual(got, []int{1, 2, 3}) {
+		t.Fatalf("initial workspace numbers = %v, want [1 2 3]", got)
+	}
 
-	// Текущий порядок в массиве: [S0:Desktop, S1:W1, S2:W2]. Активен S2.
-
-	// Переключаемся на Screen 0 (Desktop).
-	// Он должен быть извлечен из начала и вставлен в конец.
 	fm.SwitchScreen(0)
 
-	// Новый порядок в массиве: [S1:W1, S2:W2, S0:Desktop].
-	if fm.ActiveIdx != 2 {
-		t.Errorf("ActiveIdx should be 2, got %d", fm.ActiveIdx)
+	if fm.ActiveIdx != 0 {
+		t.Errorf("ActiveIdx should be 0, got %d", fm.ActiveIdx)
+	}
+	if got := []string{fm.Screens[0].GetTitle(), fm.Screens[1].GetTitle(), fm.Screens[2].GetTitle()}; !reflect.DeepEqual(got, []string{"Desktop", "W1", "W2"}) {
+		t.Errorf("workspace order changed after switch: %v", got)
+	}
+	if got := []int{fm.Screens[0].Number, fm.Screens[1].Number, fm.Screens[2].Number}; !reflect.DeepEqual(got, []int{1, 2, 3}) {
+		t.Errorf("workspace numbers changed after switch: %v", got)
 	}
 
-	lastScreen := fm.Screens[fm.ActiveIdx]
-	if lastScreen.Frames[0].GetType() != TypeDesktop {
-		t.Errorf("Expected Desktop to move to the end (active), got title: %q", lastScreen.GetTitle())
+	// New numbers are derived from the largest number still in use.
+	fm.SwitchScreen(2)
+	fm.CloseActiveScreen()
+	fm.AddScreen(NewWindow(0, 0, 10, 10, "W3"))
+	if got := []int{fm.Screens[0].Number, fm.Screens[1].Number, fm.Screens[2].Number}; !reflect.DeepEqual(got, []int{1, 3, 2}) {
+		t.Errorf("workspace number did not follow the live maximum: %v", got)
 	}
 
-	if fm.Screens[0].GetTitle() != "W1" {
-		t.Errorf("Expected W1 to shift to index 0, got %q", fm.Screens[0].GetTitle())
-	}
-
-	// Проверка безопасности индексов
 	fm.SwitchScreen(-1)
 	fm.SwitchScreen(100)
 }
@@ -1439,6 +1453,13 @@ type titleFrame struct {
 
 func (t *titleFrame) GetTitle() string { return t.title }
 
+type workspaceInfoFrame struct {
+	titleFrame
+	info WorkspaceMenuInfo
+}
+
+func (f *workspaceInfoFrame) GetWorkspaceMenuInfo() WorkspaceMenuInfo { return f.info }
+
 func TestFrameManager_F12ScreensMenu(t *testing.T) {
 	fm := &frameManager{}
 	scr := NewSilentScreenBuf()
@@ -1481,8 +1502,48 @@ func TestFrameManager_F12ScreensMenu(t *testing.T) {
 		t.Fatalf("Expected 2 menu items, got %d", len(menu.Items))
 	}
 
-	if menu.Items[1].Text != "* Editor B" {
-		t.Errorf("Expected active item to have '*' prefix, got %q", menu.Items[1].Text)
+	if menu.Items[1].AccentPrefix != "2" || menu.Items[1].Text != " * ▣ Editor B" {
+		t.Errorf("unexpected active Screens item: accent=%q text=%q", menu.Items[1].AccentPrefix, menu.Items[1].Text)
+	}
+}
+
+func TestFrameManager_ScreensMenuUsesStructuredAlignedWorkspaceInfo(t *testing.T) {
+	SetDefaultPalette()
+	fm := &frameManager{}
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(120, 25)
+	fm.Init(scr)
+	defer fm.Shutdown()
+
+	first := &workspaceInfoFrame{titleFrame: titleFrame{title: "Panels"}, info: WorkspaceMenuInfo{
+		Icon: "📁", Primary: `C:\short`, Secondary: `D:\a\much\longer\right\path`,
+	}}
+	second := &workspaceInfoFrame{titleFrame: titleFrame{title: "Panels"}, info: WorkspaceMenuInfo{
+		Icon: "📁", Primary: `C:\a\much\longer\left\path`, Secondary: `D:\right`,
+	}}
+	fm.Push(first)
+	fm.AddScreen(second)
+	fm.showScreensMenu()
+
+	menu := fm.frames[len(fm.frames)-1].(*VMenu)
+	if len(menu.Items) != 2 {
+		t.Fatalf("Screens items = %d, want 2", len(menu.Items))
+	}
+	if menu.Items[0].AccentPrefix != "1" || menu.Items[1].AccentPrefix != "2" {
+		t.Fatalf("workspace accents = %q, %q", menu.Items[0].AccentPrefix, menu.Items[1].AccentPrefix)
+	}
+	if !strings.Contains(menu.Items[0].Text, `C:\short`) || !strings.Contains(menu.Items[0].Text, `D:\a\much\longer\right\path`) {
+		t.Fatalf("full panel paths missing from first item: %q", menu.Items[0].Text)
+	}
+	if strings.Index(menu.Items[0].Text, "↔") != strings.Index(menu.Items[1].Text, "↔") {
+		t.Fatalf("panel separators are not aligned: %q / %q", menu.Items[0].Text, menu.Items[1].Text)
+	}
+
+	menu.Show(scr)
+	accentCell := scr.GetCell(menu.X1+2, menu.Y1+2) // active second item
+	wantAccent := Palette[menu.ColorSelectedHighlightIdx]
+	if GetRGBFore(accentCell.Attributes) != GetRGBFore(wantAccent) {
+		t.Fatalf("active workspace index attr = %#x, want selected highlight %#x", accentCell.Attributes, Palette[menu.ColorSelectedHighlightIdx])
 	}
 }
 
@@ -1601,6 +1662,551 @@ func TestFrameManager_SwitcherLogic(t *testing.T) {
 	// Теперь Desktop должен стать активным (переехать в конец массива)
 	if fm.Screens[fm.ActiveIdx].GetTitle() != "Desktop" {
 		t.Errorf("Screen Desktop was not moved to active. Top title: %q", fm.Screens[fm.ActiveIdx].GetTitle())
+	}
+}
+
+func TestFrameManager_WorkspaceTopInsetModes(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	fm := &frameManager{}
+	fm.Init(scr)
+	frame := newMockFrame(0, 0, 80, 25, false)
+	fm.Push(frame)
+
+	if got := fm.WorkspaceTopInset(); got != 0 {
+		t.Fatalf("multiple mode with one screen inset = %d, want 0", got)
+	}
+	fm.AddScreenBackground(newMockFrame(0, 0, 80, 25, false))
+	if got := fm.WorkspaceTopInset(); got != 1 {
+		t.Fatalf("multiple mode with two screens inset = %d, want 1", got)
+	}
+	if frame.resizedW != 80 || frame.resizedH != 25 {
+		t.Fatalf("screen was not relaid out after tab row appeared: %dx%d", frame.resizedW, frame.resizedH)
+	}
+
+	fm.ConfigureWorkspaceTabs(WorkspaceTabsOnCtrl, WorkspaceCtrlTabDirect)
+	if got := fm.WorkspaceTopInset(); got != 0 {
+		t.Fatalf("Ctrl overlay mode inset = %d, want 0", got)
+	}
+	fm.ConfigureWorkspaceTabs(WorkspaceTabsAlways, WorkspaceCtrlTabDirect)
+	if got := fm.WorkspaceTopInset(); got != 1 {
+		t.Fatalf("always mode inset = %d, want 1", got)
+	}
+}
+
+func TestFrameManager_WorkspaceTabsAndCounterRendering(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(60, 10)
+	fm := &frameManager{}
+	fm.Init(scr)
+	fm.Push(NewWindow(0, 0, 20, 5, "Panels"))
+	fm.AddScreen(NewWindow(0, 0, 20, 5, "Editor"))
+	fm.ConfigureWorkspaceTabs(WorkspaceTabsMultiple, WorkspaceCtrlTabDirect)
+	fm.ConfigureWorkspaceTabColors(
+		SetRGBBoth(0, 0xAAAAAA, 0x111111),
+		SetRGBBoth(0, 0xAAAAAA, 0x222222),
+		SetRGBBoth(0, 0xFFD75F, 0),
+		SetRGBBoth(0, 0xFF5F5F, 0),
+	)
+
+	fm.drawWorkspaceTabs()
+	fm.drawWorkspaceCounter()
+	var row strings.Builder
+	for x := 0; x < scr.width; x++ {
+		row.WriteRune(rune(scr.GetCell(x, 0).Char))
+	}
+	text := row.String()
+	if !strings.Contains(text, "1 Panels") || !strings.Contains(text, "2 Editor") {
+		t.Fatalf("tab row does not contain both workspaces: %q", text)
+	}
+	if !strings.Contains(text, "Panels | 2 Editor") {
+		t.Fatalf("tabs are not compact and pipe-separated: %q", text)
+	}
+	if !strings.Contains(text, "Editor |+") {
+		t.Fatalf("new-workspace control is missing after tabs: %q", text)
+	}
+	if !strings.HasSuffix(text, "[2/2]") {
+		t.Fatalf("workspace counter = %q, want suffix [2/2]", text)
+	}
+	counterX := scr.width - runewidth.StringWidth("[2/2]")
+	if got := GetRGBFore(scr.GetCell(counterX, 0).Attributes); got != 0xAAAAAA {
+		t.Fatalf("workspace counter decoration foreground = %#x, want tab bar text color", got)
+	}
+	if len(fm.workspaceTabHits) != 2 {
+		t.Fatalf("tab hit targets = %d, want 2", len(fm.workspaceTabHits))
+	}
+	if got := GetRGBBack(scr.GetCell(fm.workspaceTabHits[0].x1, 0).Attributes); got != 0x111111 {
+		t.Fatalf("inactive tab background = %#x, want dark bar background", got)
+	}
+	if got := GetRGBBack(scr.GetCell(fm.workspaceTabHits[1].x2, 0).Attributes); got != 0x222222 {
+		t.Fatalf("active tab background = %#x, want panel background", got)
+	}
+	counterCurrentX := scr.width - runewidth.StringWidth("[2/2]") + 1
+	if tabFG, counterFG := GetRGBFore(scr.GetCell(fm.workspaceTabHits[0].x1+1, 0).Attributes), GetRGBFore(scr.GetCell(counterCurrentX, 0).Attributes); tabFG != counterFG {
+		t.Fatalf("tab number foreground = %#x, counter current foreground = %#x", tabFG, counterFG)
+	} else if tabFG != 0xFFD75F {
+		t.Fatalf("workspace accent foreground = %#x, want configured %#x", tabFG, uint32(0xFFD75F))
+	}
+
+	// Attention has its own color and must not replace the ordinary accent on
+	// unrelated controls such as the new-tab button.
+	fm.Screens[0].Frames = []Frame{newMockFrame(0, 1, 20, 5, true)}
+	fm.drawWorkspaceTabs()
+	fm.drawWorkspaceCounter()
+	if got := GetRGBFore(scr.GetCell(fm.workspaceTabHits[0].x1+1, 0).Attributes); got != 0xFF5F5F {
+		t.Fatalf("attention tab foreground = %#x, want configured attention color", got)
+	}
+	if got := GetRGBFore(scr.GetCell(fm.workspaceNewTabX, 0).Attributes); got != 0xFFD75F {
+		t.Fatalf("new-tab accent foreground = %#x after attention, want ordinary accent", got)
+	}
+	if got := GetRGBFore(scr.GetCell(counterCurrentX, 0).Attributes); got != 0xFF5F5F {
+		t.Fatalf("attention counter foreground = %#x, want configured attention color", got)
+	}
+	first := fm.workspaceTabHits[0]
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      int16(first.x1),
+		MouseY:      0,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+	}, false)
+	if fm.ActiveIdx != 0 {
+		t.Fatalf("clicking first workspace tab selected %d, want 0", fm.ActiveIdx)
+	}
+}
+
+func TestFrameManager_WorkspacePlusEmitsForkCommand(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(60, 10)
+	fm := &frameManager{}
+	fm.Init(scr)
+	fm.Push(newMockFrame(0, 0, 20, 5, false))
+	forked := false
+	active := newMockFrame(0, 0, 20, 5, false)
+	active.onHandleCommand = func(cmd int, args any) bool {
+		forked = cmd == CmResize && args == "fork"
+		return forked
+	}
+	fm.AddScreen(active)
+	fm.drawWorkspaceTabs()
+	if fm.workspaceNewTabX < 0 {
+		t.Fatal("workspace plus hit target was not created")
+	}
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      int16(fm.workspaceNewTabX),
+		MouseY:      0,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+	}, false)
+	if !forked {
+		t.Fatal("clicking workspace plus did not emit the Ctrl+N fork command")
+	}
+}
+
+func TestFrameManager_DragWorkspaceTabReordersScreens(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 10)
+	fm := &frameManager{}
+	fm.Init(scr)
+	fm.Push(newMockFrame(0, 1, 20, 5, false))
+	fm.AddScreen(newMockFrame(0, 1, 20, 5, false))
+	fm.AddScreen(newMockFrame(0, 1, 20, 5, false))
+	fm.drawWorkspaceTabs()
+
+	dragged := fm.Screens[0]
+	first := fm.workspaceTabHits[0]
+	third := fm.workspaceTabHits[2]
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      int16(first.x1 + 1),
+		MouseY:      0,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+	}, false)
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		KeyDown:         true,
+		MouseX:          int16(third.x1 + 1),
+		MouseY:          5,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.MouseMoved,
+	}, false)
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:    vtinput.MouseEventType,
+		MouseX:  500,
+		MouseY:  500,
+		KeyDown: false,
+	}, false)
+
+	if got := []int{fm.Screens[0].Number, fm.Screens[1].Number, fm.Screens[2].Number}; !reflect.DeepEqual(got, []int{2, 3, 1}) {
+		t.Fatalf("workspace order = %v, want [2 3 1]", got)
+	}
+	if fm.Screens[fm.ActiveIdx] != dragged || fm.ActiveIdx != 2 {
+		t.Fatalf("dragged workspace is not active at its new position: active=%d", fm.ActiveIdx)
+	}
+	if fm.workspaceTabDrag != nil {
+		t.Fatal("workspace tab capture was not released")
+	}
+}
+
+func TestFrameManager_DragShortTabPastLongTabDoesNotOscillate(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(100, 10)
+	fm := &frameManager{}
+	fm.Init(scr)
+
+	short := newMockFrame(0, 1, 20, 5, false)
+	short.tabTitle = "A"
+	long := newMockFrame(0, 1, 20, 5, false)
+	long.tabTitle = "A much longer workspace title"
+	last := newMockFrame(0, 1, 20, 5, false)
+	last.tabTitle = "C"
+	fm.Push(short)
+	fm.AddScreen(long)
+	fm.AddScreen(last)
+	fm.drawWorkspaceTabs()
+
+	dragged := fm.Screens[0]
+	first := fm.workspaceTabHits[0]
+	second := fm.workspaceTabHits[1]
+	dragX := second.x1 + 1
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      int16(first.x1 + 1),
+		MouseY:      0,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+	}, false)
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		KeyDown:         true,
+		MouseX:          int16(dragX),
+		MouseY:          0,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.MouseMoved,
+	}, false)
+	if fm.Screens[1] != dragged {
+		t.Fatal("short tab did not move into the second slot")
+	}
+
+	// The long tab now occupies the beginning of the row and its freshly
+	// rendered hit region covers dragX. A dynamic hit test would therefore
+	// bounce the dragged tab back to slot zero on this one-pixel move.
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		KeyDown:         true,
+		MouseX:          int16(dragX + 1),
+		MouseY:          0,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.MouseMoved,
+	}, false)
+	if fm.Screens[1] != dragged {
+		t.Fatal("short tab oscillated back after the long tab changed the rendered boundary")
+	}
+}
+
+func TestFrameManager_RestoreScreenNumbersKeepsFutureNumbersUnique(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 10)
+	fm := &frameManager{}
+	fm.Init(scr)
+	fm.Push(newMockFrame(0, 1, 20, 5, false))
+	fm.AddScreenBackground(newMockFrame(0, 1, 20, 5, false))
+	fm.AddScreenBackground(newMockFrame(0, 1, 20, 5, false))
+
+	fm.RestoreScreenNumbers([]int{2, 3, 1})
+	fm.AddScreenBackground(newMockFrame(0, 1, 20, 5, false))
+	if got := fm.Screens[1].Number; got != 4 {
+		t.Fatalf("new workspace number = %d, want 4 after restoring [2 3 1]", got)
+	}
+}
+
+func TestFrameManager_NewWorkspaceAppearsAfterActiveAndUsesCurrentMaxNumber(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 10)
+	fm := &frameManager{}
+	fm.Init(scr)
+	fm.Push(newMockFrame(0, 1, 20, 5, false))
+	fm.AddScreen(newMockFrame(0, 1, 20, 5, false))
+	fm.AddScreen(newMockFrame(0, 1, 20, 5, false))
+
+	// Remove the highest number. A stale monotonic counter would allocate 4;
+	// the current maximum is now 2, so the replacement must be number 3.
+	fm.SwitchScreen(0)
+	fm.CloseScreen(2)
+	fm.AddScreen(newMockFrame(0, 1, 20, 5, false))
+
+	if fm.ActiveIdx != 1 {
+		t.Fatalf("new workspace index = %d, want 1 immediately after the active tab", fm.ActiveIdx)
+	}
+	if got := []int{fm.Screens[0].Number, fm.Screens[1].Number, fm.Screens[2].Number}; !reflect.DeepEqual(got, []int{1, 3, 2}) {
+		t.Fatalf("workspace numbers/order = %v, want [1 3 2]", got)
+	}
+}
+
+func TestFrameManager_NewBackgroundWorkspaceAppearsAfterActive(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 10)
+	fm := &frameManager{}
+	fm.Init(scr)
+	fm.Push(newMockFrame(0, 1, 20, 5, false))
+	fm.AddScreen(newMockFrame(0, 1, 20, 5, false))
+	fm.AddScreen(newMockFrame(0, 1, 20, 5, false))
+	fm.SwitchScreen(0)
+
+	active := fm.Screens[0]
+	fm.AddScreenBackground(newMockFrame(0, 1, 20, 5, false))
+	if fm.ActiveIdx != 0 || fm.Screens[0] != active {
+		t.Fatal("background workspace changed the active tab")
+	}
+	if got := []int{fm.Screens[0].Number, fm.Screens[1].Number, fm.Screens[2].Number, fm.Screens[3].Number}; !reflect.DeepEqual(got, []int{1, 4, 2, 3}) {
+		t.Fatalf("background workspace order = %v, want [1 4 2 3]", got)
+	}
+}
+
+func TestFrameManager_MiddleClickClosesBackgroundWorkspace(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 10)
+	fm := &frameManager{}
+	fm.Init(scr)
+	fm.Push(newMockFrame(0, 0, 20, 5, false))
+	fm.AddScreen(newMockFrame(0, 0, 20, 5, false))
+	fm.AddScreen(newMockFrame(0, 0, 20, 5, false))
+	active := fm.Screens[fm.ActiveIdx]
+	fm.drawWorkspaceTabs()
+	first := fm.workspaceTabHits[0]
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      int16(first.x1 + 1),
+		MouseY:      0,
+		ButtonState: vtinput.FromLeft2ndButtonPressed,
+	}, false)
+	if len(fm.Screens) != 2 {
+		t.Fatalf("middle-click left %d workspaces, want 2", len(fm.Screens))
+	}
+	if fm.Screens[fm.ActiveIdx] != active {
+		t.Fatal("closing a background tab changed the active workspace")
+	}
+	if fm.Screens[0].Number != 2 || fm.Screens[1].Number != 3 {
+		t.Fatalf("remaining workspace numbers = [%d %d], want [2 3]", fm.Screens[0].Number, fm.Screens[1].Number)
+	}
+}
+
+func TestFrameManager_WorkspaceTabsSemanticModelAndActions(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(60, 10)
+	fm := &frameManager{}
+	fm.Init(scr)
+	forked := false
+	makeFrame := func(title string) *mockFrame {
+		frame := newMockFrame(0, 0, 20, 5, false)
+		frame.tabTitle = title
+		frame.onHandleCommand = func(cmd int, args any) bool {
+			forked = cmd == CmResize && args == "fork"
+			return forked
+		}
+		return frame
+	}
+	fm.Push(makeFrame("Left ↔ Right"))
+	fm.AddScreen(makeFrame("Python"))
+	fm.drawWorkspaceTabs()
+	fm.drawWorkspaceCounter()
+
+	scene := fm.ExportSemanticScene()
+	bar, ok := scene["workspaceTabs"].(map[string]any)
+	if !ok {
+		t.Fatalf("workspaceTabs semantic node missing: %#v", scene["workspaceTabs"])
+	}
+	if bar["kind"] != "tablist" || bar["visible"] != true || bar["activeIndex"] != 1 {
+		t.Fatalf("workspace tablist metadata = %#v", bar)
+	}
+	tabs, ok := bar["tabs"].([]map[string]any)
+	if !ok || len(tabs) != 2 {
+		t.Fatalf("workspace semantic tabs = %#v, want two tabs", bar["tabs"])
+	}
+	if tabs[0]["text"] != "Left ↔ Right" || tabs[0]["active"] != false || tabs[0]["w"] == nil {
+		t.Fatalf("first workspace semantic tab = %#v", tabs[0])
+	}
+	if tabs[1]["text"] != "Python" || tabs[1]["selected"] != true {
+		t.Fatalf("active workspace semantic tab = %#v", tabs[1])
+	}
+	if tabs[1]["closable"] != true || tabs[1]["closeAction"] != "workspace.close" {
+		t.Fatalf("workspace close semantics missing: %#v", tabs[1])
+	}
+	newTab := bar["newTab"].(map[string]any)
+	if newTab["kind"] != "button" || newTab["action"] != "workspace.new" || newTab["visible"] != true {
+		t.Fatalf("workspace new semantic node = %#v", newTab)
+	}
+	counter := bar["counter"].(map[string]any)
+	if counter["text"] != "[2/2]" || counter["current"] != 2 || counter["total"] != 2 {
+		t.Fatalf("workspace counter semantic node = %#v", counter)
+	}
+
+	if !fm.HandleSemanticAction(map[string]any{"action": "activate", "target": tabs[0]["id"]}) || fm.ActiveIdx != 0 {
+		t.Fatalf("semantic tab activation selected workspace %d, want 0", fm.ActiveIdx)
+	}
+	if !fm.HandleSemanticAction(map[string]any{"action": "workspace.new", "target": "workspace-new"}) || !forked {
+		t.Fatal("semantic workspace.new did not emit the Ctrl+N fork command")
+	}
+	if !fm.HandleSemanticAction(map[string]any{"action": "workspace.close", "target": tabs[1]["id"]}) || len(fm.Screens) != 1 {
+		t.Fatalf("semantic workspace.close left %d workspaces, want 1", len(fm.Screens))
+	}
+}
+
+func TestFrameManager_CtrlTabDirectAndMenuModes(t *testing.T) {
+	newManager := func() *frameManager {
+		scr := NewSilentScreenBuf()
+		scr.AllocBuf(80, 25)
+		fm := &frameManager{}
+		fm.Init(scr)
+		fm.Push(newMockFrame(0, 0, 80, 25, false))
+		fm.AddScreen(newMockFrame(0, 0, 80, 25, false))
+		return fm
+	}
+
+	direct := newManager()
+	direct.ConfigureWorkspaceTabs(WorkspaceTabsOnCtrl, WorkspaceCtrlTabDirect)
+	direct.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_TAB,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	}, false)
+	if direct.ActiveIdx != 0 || direct.switcherMenu != nil {
+		t.Fatalf("direct Ctrl+Tab active=%d menu=%v, want active=0 without menu", direct.ActiveIdx, direct.switcherMenu != nil)
+	}
+
+	menu := newManager()
+	menu.ConfigureWorkspaceTabs(WorkspaceTabsMultiple, WorkspaceCtrlTabMenu)
+	menu.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_TAB,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	}, false)
+	if menu.ActiveIdx != 1 || menu.switcherMenu == nil {
+		t.Fatalf("menu Ctrl+Tab active=%d menu=%v, want active=1 with menu", menu.ActiveIdx, menu.switcherMenu != nil)
+	}
+}
+
+func TestFrameManager_AltNumberSelectsStableWorkspaceNumber(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	fm := &frameManager{}
+	fm.Init(scr)
+	first := newMockFrame(0, 0, 80, 25, false)
+	forwarded := 0
+	first.onProcessKey = func(*vtinput.InputEvent) bool {
+		forwarded++
+		return false
+	}
+	fm.Push(first)
+	fm.AddScreen(newMockFrame(0, 0, 80, 25, false))
+	fm.AddScreen(newMockFrame(0, 0, 80, 25, false))
+	fm.RestoreScreenNumbers([]int{7, 2, 9})
+	fm.ConfigureWorkspaceAltNumberSwitch(true)
+
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_2,
+		ControlKeyState: vtinput.LeftAltPressed,
+	}, false)
+	if fm.ActiveIdx != 1 || fm.Screens[fm.ActiveIdx].Number != 2 {
+		t.Fatalf("Alt+2 selected index=%d number=%d, want stable workspace number 2", fm.ActiveIdx, fm.Screens[fm.ActiveIdx].Number)
+	}
+
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_7,
+		ControlKeyState: vtinput.RightAltPressed,
+	}, false)
+	if fm.ActiveIdx != 0 || fm.Screens[fm.ActiveIdx].Number != 7 {
+		t.Fatalf("right Alt+7 selected index=%d number=%d, want stable workspace number 7", fm.ActiveIdx, fm.Screens[fm.ActiveIdx].Number)
+	}
+	forwarded = 0 // Ignore focus events generated by the workspace switches.
+
+	// Missing numbers and modified variants are not consumed.
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_1,
+		ControlKeyState: vtinput.LeftAltPressed,
+	}, false)
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_2,
+		ControlKeyState: vtinput.LeftAltPressed | vtinput.ShiftPressed,
+	}, false)
+	if fm.ActiveIdx != 0 || forwarded != 2 {
+		t.Fatalf("fall-through Alt-number variants: active=%d forwarded=%d, want 0/2", fm.ActiveIdx, forwarded)
+	}
+
+	fm.ConfigureWorkspaceAltNumberSwitch(false)
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_2,
+		ControlKeyState: vtinput.LeftAltPressed,
+	}, false)
+	if fm.ActiveIdx != 0 || forwarded != 3 {
+		t.Fatalf("disabled Alt-number shortcut: active=%d forwarded=%d, want 0/3", fm.ActiveIdx, forwarded)
+	}
+}
+
+func TestFrameManager_CtrlAltNumberSelectsWorkspaceOnlyInOnCtrlTabMode(t *testing.T) {
+	newManager := func(mode WorkspaceTabMode) (*frameManager, *int) {
+		scr := NewSilentScreenBuf()
+		scr.AllocBuf(80, 25)
+		fm := &frameManager{}
+		fm.Init(scr)
+		forwarded := 0
+		first := newMockFrame(0, 0, 80, 25, false)
+		first.onProcessKey = func(*vtinput.InputEvent) bool {
+			forwarded++
+			return false
+		}
+		fm.Push(first)
+		fm.AddScreen(newMockFrame(0, 0, 80, 25, false))
+		fm.RestoreScreenNumbers([]int{1, 2})
+		fm.ConfigureWorkspaceTabs(mode, WorkspaceCtrlTabDirect)
+		fm.ConfigureWorkspaceAltNumberSwitch(true)
+		fm.SwitchScreen(0)
+		forwarded = 0 // Ignore focus events generated while arranging the fixture.
+		return fm, &forwarded
+	}
+
+	event := func() *vtinput.InputEvent {
+		return &vtinput.InputEvent{
+			Type:            vtinput.KeyEventType,
+			KeyDown:         true,
+			VirtualKeyCode:  vtinput.VK_2,
+			ControlKeyState: vtinput.LeftCtrlPressed | vtinput.LeftAltPressed,
+		}
+	}
+
+	onCtrl, _ := newManager(WorkspaceTabsOnCtrl)
+	onCtrl.dispatchEvent(event(), false)
+	if onCtrl.ActiveIdx != 1 {
+		t.Fatalf("Ctrl+Alt+2 in Ctrl-only tab mode selected index %d, want 1", onCtrl.ActiveIdx)
+	}
+	onCtrl.SwitchScreen(0)
+	onCtrl.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_2,
+		ControlKeyState: vtinput.RightCtrlPressed | vtinput.RightAltPressed,
+	}, false)
+	if onCtrl.ActiveIdx != 1 {
+		t.Fatalf("right Ctrl+Alt+2 in Ctrl-only tab mode selected index %d, want 1", onCtrl.ActiveIdx)
+	}
+
+	for _, mode := range []WorkspaceTabMode{WorkspaceTabsAlways, WorkspaceTabsMultiple} {
+		fm, forwarded := newManager(mode)
+		fm.dispatchEvent(event(), false)
+		if fm.ActiveIdx != 0 || *forwarded != 1 {
+			t.Fatalf("Ctrl+Alt+2 in tab mode %d: active=%d forwarded=%d, want 0/1", mode, fm.ActiveIdx, *forwarded)
+		}
 	}
 }
 

--- a/help_view.go
+++ b/help_view.go
@@ -12,12 +12,20 @@ import (
 type HelpView struct {
 	BaseWindow
 	engine      *HelpEngine
-	history     []string
+	history     []helpHistoryEntry
 	current     *HelpTopic
 	scrollTop   int
 	selectedIdx int // Index of selected link in current.Links
 	scrollBar   *ScrollBar
 }
+
+type helpHistoryEntry struct {
+	topic       string
+	selectedIdx int
+	scrollTop   int
+}
+
+const helpBackButton = "[←]"
 
 func NewHelpView(engine *HelpEngine, startTopic string) *HelpView {
 	hv := &HelpView{
@@ -71,7 +79,11 @@ func (hv *HelpView) SwitchTopic(name string) {
 		return
 	}
 	if hv.current != nil {
-		hv.history = append(hv.history, hv.current.Name)
+		hv.history = append(hv.history, helpHistoryEntry{
+			topic:       hv.current.Name,
+			selectedIdx: hv.selectedIdx,
+			scrollTop:   hv.scrollTop,
+		})
 	}
 	hv.current = topic
 	hv.scrollTop = 0
@@ -87,15 +99,21 @@ func (hv *HelpView) PopTopic() {
 		hv.Close()
 		return
 	}
-	name := hv.history[len(hv.history)-1]
+	entry := hv.history[len(hv.history)-1]
 	hv.history = hv.history[:len(hv.history)-1]
-	hv.current = hv.engine.GetTopic(name)
-	hv.scrollTop = 0
-	hv.selectedIdx = -1
+	hv.current = hv.engine.GetTopic(entry.topic)
+	if hv.current == nil {
+		return
+	}
+	hv.scrollTop = entry.scrollTop
+	hv.selectedIdx = entry.selectedIdx
 }
 
 func (hv *HelpView) Show(scr *ScreenBuf) {
 	hv.BaseWindow.Show(scr)
+	if len(hv.history) > 0 {
+		scr.Write(hv.X1+2, hv.Y1, StringToCharInfo(helpBackButton, Palette[hv.ColorBoxIdx]))
+	}
 	if hv.current == nil {
 		return
 	}
@@ -350,6 +368,23 @@ func (hv *HelpView) ensureLinkVisible() {
 
 func (hv *HelpView) GetType() FrameType { return TypeUser }
 
+func (hv *HelpView) scrollBy(delta int) {
+	if hv.current == nil || delta == 0 {
+		return
+	}
+	viewHeight := (hv.Y2 - hv.Y1 + 1) - 2 - hv.current.StickyRows
+	maxScroll := (len(hv.current.Lines) - hv.current.StickyRows) - viewHeight
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	hv.scrollTop += delta
+	if hv.scrollTop < 0 {
+		hv.scrollTop = 0
+	} else if hv.scrollTop > maxScroll {
+		hv.scrollTop = maxScroll
+	}
+}
+
 func (hv *HelpView) ProcessMouse(e *vtinput.InputEvent) bool {
 	if e.Type != vtinput.MouseEventType {
 		return false
@@ -359,11 +394,17 @@ func (hv *HelpView) ProcessMouse(e *vtinput.InputEvent) bool {
 		return true
 	}
 
+	if len(hv.history) > 0 && e.KeyDown && e.ButtonState&vtinput.FromLeft1stButtonPressed != 0 &&
+		int(e.MouseY) == hv.Y1 && int(e.MouseX) >= hv.X1+2 && int(e.MouseX) <= hv.X1+4 {
+		hv.PopTopic()
+		return true
+	}
+
 	if e.WheelDirection != 0 {
 		if e.WheelDirection > 0 {
-			hv.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_UP})
+			hv.scrollBy(-1)
 		} else {
-			hv.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_DOWN})
+			hv.scrollBy(1)
 		}
 		return true
 	}

--- a/help_view_mouse_test.go
+++ b/help_view_mouse_test.go
@@ -86,3 +86,63 @@ func TestHelpView_MouseNavigation(t *testing.T) {
 		t.Errorf("Middle-click failed to navigate: expected 'NextTopic', got %q", hv.current.Name)
 	}
 }
+
+func TestHelpView_MouseWheelScrollsWithoutChangingSelectedLink(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 12)
+	FrameManager.Init(scr)
+
+	engine := NewHelpEngine(&mockHelpVFS{})
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = "Help text"
+	}
+	lines[1] = "~First~First@"
+	lines[20] = "~Second~Second@"
+	engine.AddTopic(&HelpTopic{
+		Name:  "Wheel",
+		Lines: lines,
+		Links: []HelpLink{{Line: 1, Target: "First"}, {Line: 20, Target: "Second"}},
+	})
+
+	hv := NewHelpView(engine, "Wheel")
+	hv.ResizeConsole(80, 12)
+	selected := hv.selectedIdx
+
+	if !hv.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, WheelDirection: -1}) {
+		t.Fatal("wheel down was not handled")
+	}
+	if hv.scrollTop != 1 {
+		t.Fatalf("wheel down scrollTop = %d, want 1", hv.scrollTop)
+	}
+	if hv.selectedIdx != selected {
+		t.Fatalf("wheel down selected link = %d, want unchanged %d", hv.selectedIdx, selected)
+	}
+
+	hv.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, WheelDirection: 1})
+	if hv.scrollTop != 0 {
+		t.Fatalf("wheel up scrollTop = %d, want 0", hv.scrollTop)
+	}
+	if hv.selectedIdx != selected {
+		t.Fatalf("wheel up selected link = %d, want unchanged %d", hv.selectedIdx, selected)
+	}
+
+	// The viewport stays clamped at the top and bottom even if the wheel
+	// keeps producing events there.
+	hv.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, WheelDirection: 1})
+	if hv.scrollTop != 0 {
+		t.Fatalf("wheel scrolled above top to %d", hv.scrollTop)
+	}
+	for range 100 {
+		hv.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, WheelDirection: -1})
+	}
+	viewHeight := (hv.Y2 - hv.Y1 + 1) - 2 - hv.current.StickyRows
+	wantBottom := len(lines) - hv.current.StickyRows - viewHeight
+	if hv.scrollTop != wantBottom {
+		t.Fatalf("wheel bottom scrollTop = %d, want %d", hv.scrollTop, wantBottom)
+	}
+	if hv.selectedIdx != selected {
+		t.Fatalf("wheel scrolling changed selected link to %d, want %d", hv.selectedIdx, selected)
+	}
+}

--- a/help_view_test.go
+++ b/help_view_test.go
@@ -39,7 +39,7 @@ Success
 	if hv.current.Name != "NextTopic" {
 		t.Errorf("Jump failed, current is %s", hv.current.Name)
 	}
-	if len(hv.history) != 1 || hv.history[0] != "Contents" {
+	if len(hv.history) != 1 || hv.history[0].topic != "Contents" || hv.history[0].selectedIdx != 0 {
 		t.Error("History not updated after jump")
 	}
 
@@ -47,6 +47,77 @@ Success
 	hv.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_BACK})
 	if hv.current.Name != "Contents" {
 		t.Error("History Back failed")
+	}
+}
+
+func TestHelpView_BackRestoresOriginatingLinkAndViewport(t *testing.T) {
+	engine := NewHelpEngine(&mockHelpVFS{})
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = "Help text"
+	}
+	lines[1] = "~First~First@"
+	lines[15] = "~Nested~Nested@"
+	engine.AddTopic(&HelpTopic{
+		Name:  "Root",
+		Lines: lines,
+		Links: []HelpLink{{Text: "First", Target: "First", Line: 1}, {Text: "Nested", Target: "Nested", Line: 15}},
+	})
+	engine.AddTopic(&HelpTopic{Name: "Nested", Lines: []string{"Nested content"}})
+
+	hv := NewHelpView(engine, "Root")
+	hv.SetPosition(0, 0, 40, 7)
+	hv.selectedIdx = 1
+	hv.ensureLinkVisible()
+	wantScroll := hv.scrollTop
+	hv.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN})
+	if hv.current.Name != "Nested" {
+		t.Fatalf("current topic = %q, want Nested", hv.current.Name)
+	}
+
+	hv.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_BACK})
+	if hv.current.Name != "Root" {
+		t.Fatalf("Backspace returned to %q, want Root", hv.current.Name)
+	}
+	if hv.selectedIdx != 1 {
+		t.Fatalf("restored link index = %d, want 1", hv.selectedIdx)
+	}
+	if hv.scrollTop != wantScroll {
+		t.Fatalf("restored scrollTop = %d, want %d", hv.scrollTop, wantScroll)
+	}
+}
+
+func TestHelpView_BackButtonReturnsToOriginatingLink(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	FrameManager.Init(scr)
+	engine := NewHelpEngine(&mockHelpVFS{})
+	engine.AddTopic(&HelpTopic{
+		Name:  "Root",
+		Lines: []string{"~Nested~Nested@"},
+		Links: []HelpLink{{Text: "Nested", Target: "Nested", Line: 0}},
+	})
+	engine.AddTopic(&HelpTopic{Name: "Nested", Lines: []string{"Nested content"}})
+	hv := NewHelpView(engine, "Root")
+	hv.ResizeConsole(80, 25)
+	hv.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN})
+	hv.Show(scr)
+
+	if got := rune(scr.GetCell(hv.X1+3, hv.Y1).Char); got != '←' {
+		t.Fatalf("Back button center = %q, want ←", got)
+	}
+	if !hv.ProcessMouse(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		MouseX:      int16(hv.X1 + 3),
+		MouseY:      int16(hv.Y1),
+	}) {
+		t.Fatal("Back button click was not handled")
+	}
+	if hv.current.Name != "Root" || hv.selectedIdx != 0 {
+		t.Fatalf("Back button restored topic=%q link=%d, want Root/0", hv.current.Name, hv.selectedIdx)
 	}
 }
 

--- a/label.go
+++ b/label.go
@@ -3,7 +3,7 @@ package vtui
 // NewLabel creates a Text object and links it to a focusable element.
 // This is a convenience wrapper for NewText(x, y, content, color) + FocusLink.
 func NewLabel(x, y int, content string, link UIElement) *Text {
-	t := NewText(x, y, content, Palette[ColDialogText])
+	t := NewText(x, y, content, 0)
 	t.FocusLink = link
 	return t
 }

--- a/label_test.go
+++ b/label_test.go
@@ -17,8 +17,9 @@ func TestNewLabel_Linkage(t *testing.T) {
 		t.Errorf("Expected hotkey 'n', got %c", label.GetHotkey())
 	}
 
-	// Check the color (should be ColDialogText by default)
-	if label.color != Palette[ColDialogText] {
-		t.Error("Label did not use default ColDialogText color")
+	// A zero color means that the label resolves ColDialogText when it is
+	// painted, so an already open dialog follows runtime theme changes.
+	if label.color != 0 {
+		t.Errorf("Label stored a fixed color %#x instead of the live Dialog.Text color", label.color)
 	}
 }

--- a/semantic.go
+++ b/semantic.go
@@ -51,6 +51,7 @@ func (fm *frameManager) ExportSemanticScene() map[string]any {
 		}
 		screens = append(screens, map[string]any{
 			"index":       i,
+			"number":      screen.Number,
 			"active":      i == fm.ActiveIdx,
 			"title":       screen.GetTitle(),
 			"progress":    screen.GetProgress(),
@@ -85,6 +86,7 @@ func (fm *frameManager) ExportSemanticScene() map[string]any {
 	if len(fm.Screens) > 1 {
 		scene["workspaceCount"] = len(fm.Screens)
 	}
+	scene["workspaceTabs"] = fm.semanticWorkspaceTabs()
 
 	if AppSceneAdapter != nil {
 		if adapted := AppSceneAdapter(ctx, scene); adapted != nil {
@@ -94,6 +96,107 @@ func (fm *frameManager) ExportSemanticScene() map[string]any {
 	return scene
 }
 
+func (fm *frameManager) semanticWorkspaceTabs() map[string]any {
+	mode := "multiple"
+	switch fm.WorkspaceTabMode {
+	case WorkspaceTabsAlways:
+		mode = "always"
+	case WorkspaceTabsOnCtrl:
+		mode = "ctrl"
+	}
+
+	hits := make(map[int]workspaceTabHit, len(fm.workspaceTabHits))
+	for _, hit := range fm.workspaceTabHits {
+		hits[hit.index] = hit
+	}
+	tabs := make([]map[string]any, 0, len(fm.Screens))
+	for i, screen := range fm.Screens {
+		tab := map[string]any{
+			"id":          fmt.Sprintf("workspace-tab-%d", screen.Number),
+			"kind":        "tab",
+			"index":       i,
+			"number":      screen.Number,
+			"text":        screen.GetTabTitle(),
+			"active":      i == fm.ActiveIdx,
+			"selected":    i == fm.ActiveIdx,
+			"attention":   screen.NeedsAttention(),
+			"progress":    screen.GetProgress(),
+			"visible":     fm.workspaceTabsVisible(),
+			"action":      "workspace.activate",
+			"closable":    true,
+			"closeAction": "workspace.close",
+		}
+		if hit, ok := hits[i]; ok {
+			tab["x"] = hit.x1
+			tab["y"] = 0
+			tab["w"] = hit.x2 - hit.x1 + 1
+			tab["h"] = 1
+		}
+		tabs = append(tabs, tab)
+	}
+
+	counterText := fm.workspaceCounterText()
+	counterWidth := runewidth.StringWidth(counterText)
+	counter := map[string]any{
+		"id":      "workspace-counter",
+		"kind":    "status",
+		"text":    counterText,
+		"current": fm.ActiveIdx + 1,
+		"total":   len(fm.Screens),
+		"visible": len(fm.Screens) > 1,
+		"action":  "workspace.menu",
+		"y":       0,
+		"h":       1,
+	}
+	if fm.scr != nil && counterWidth > 0 {
+		counter["x"] = fm.scr.width - counterWidth
+		counter["w"] = counterWidth
+	}
+
+	newTab := map[string]any{
+		"id":      "workspace-new",
+		"kind":    "button",
+		"text":    "+",
+		"visible": fm.workspaceTabsVisible() && fm.workspaceNewTabX >= 0,
+		"action":  "workspace.new",
+		"y":       0,
+		"w":       1,
+		"h":       1,
+	}
+	if fm.workspaceNewTabX >= 0 {
+		newTab["x"] = fm.workspaceNewTabX
+	}
+
+	width := 0
+	if fm.scr != nil {
+		width = fm.scr.width - counterWidth
+		if width < 0 {
+			width = 0
+		}
+	}
+	return map[string]any{
+		"id":          "workspace-tabs",
+		"kind":        "tablist",
+		"visible":     fm.workspaceTabsVisible(),
+		"mode":        mode,
+		"reserved":    fm.WorkspaceTopInset() > 0,
+		"x":           0,
+		"y":           0,
+		"w":           width,
+		"h":           1,
+		"activeIndex": fm.ActiveIdx,
+		"activeNumber": func() int {
+			if fm.ActiveIdx >= 0 && fm.ActiveIdx < len(fm.Screens) {
+				return fm.Screens[fm.ActiveIdx].Number
+			}
+			return 0
+		}(),
+		"tabs":    tabs,
+		"newTab":  newTab,
+		"counter": counter,
+	}
+}
+
 // HandleSemanticAction глобально маршрутизирует семантические действия во vtui
 func (fm *frameManager) HandleSemanticAction(action map[string]any) bool {
 	if fm == nil || action == nil {
@@ -101,6 +204,53 @@ func (fm *frameManager) HandleSemanticAction(action map[string]any) bool {
 	}
 	if kind, _ := action["kind"].(string); kind == "command" {
 		return fm.EmitCommand(semanticInt(action["command"]), action["args"])
+	}
+	actionName := semanticString(action["action"])
+	target := semanticString(action["target"])
+	if actionName == "workspace.new" || ((actionName == "activate" || actionName == "control.activate") && target == "workspace-new") {
+		return fm.EmitCommand(CmResize, "fork")
+	}
+	if actionName == "workspace.menu" || ((actionName == "activate" || actionName == "control.activate") && target == "workspace-counter") {
+		fm.showScreensMenu()
+		fm.Redraw()
+		return true
+	}
+	if actionName == "workspace.close" || actionName == "tab.close" || (actionName == "close" && strings.HasPrefix(target, "workspace-tab-")) {
+		idx := -1
+		if raw, ok := action["index"]; ok {
+			idx = semanticInt(raw)
+		} else {
+			for i, screen := range fm.Screens {
+				if target == fmt.Sprintf("workspace-tab-%d", screen.Number) {
+					idx = i
+					break
+				}
+			}
+		}
+		if idx >= 0 && idx < len(fm.Screens) {
+			fm.CloseScreen(idx)
+			return true
+		}
+		return false
+	}
+	if actionName == "workspace.activate" || actionName == "tab.activate" ||
+		((actionName == "activate" || actionName == "control.activate") && strings.HasPrefix(target, "workspace-tab-")) {
+		idx := -1
+		if raw, ok := action["index"]; ok {
+			idx = semanticInt(raw)
+		} else {
+			for i, screen := range fm.Screens {
+				if target == fmt.Sprintf("workspace-tab-%d", screen.Number) {
+					idx = i
+					break
+				}
+			}
+		}
+		if idx >= 0 && idx < len(fm.Screens) {
+			fm.SwitchScreen(idx)
+			return true
+		}
+		return false
 	}
 	if semanticString(action["action"]) == "menu_bar_activate" || semanticString(action["action"]) == "menuBar.activate" {
 		if mb := fm.GetActiveMenuBar(); mb != nil {
@@ -117,7 +267,7 @@ func (fm *frameManager) HandleSemanticAction(action map[string]any) bool {
 	activeIdx := fm.ActiveIdx
 	frames := fm.GetActiveFrames(activeIdx)
 
-	target := semanticString(action["target"])
+	target = semanticString(action["target"])
 	for i := len(frames) - 1; i >= 0; i-- {
 		if target == "" {
 			if h, ok := frames[i].(SemanticActionHandler); ok && h.HandleSemanticAction(action) {
@@ -438,11 +588,11 @@ func (cb *ComboBox) SemanticNode(ctx *SemanticContext) map[string]any {
 	var items []map[string]any
 	if cb.Menu != nil {
 		for i, item := range cb.Menu.Items {
-			clean, hotkey, _ := ParseAmpersandString(item.Text)
+			clean, hotkey, _ := ParseAmpersandString(item.AccentPrefix + item.Text)
 			items = append(items, map[string]any{
 				"index":     i,
 				"text":      clean,
-				"rawText":   item.Text,
+				"rawText":   item.AccentPrefix + item.Text,
 				"hotkey":    stringOrEmpty(hotkey),
 				"shortcut":  item.Shortcut,
 				"command":   item.Command,

--- a/text.go
+++ b/text.go
@@ -11,6 +11,13 @@ type Text struct {
 }
 
 func NewText(x, y int, content string, color uint64) *Text {
+	// Passing the current Dialog.Text value has historically meant "ordinary
+	// dialog text", not a permanently frozen custom color. Normalize it to the
+	// zero/default sentinel so an already open dialog follows runtime theme
+	// changes. Non-default explicit colors remain fixed.
+	if color == Palette[ColDialogText] {
+		color = 0
+	}
 	t := &Text{color: color}
 	t.X1, t.Y1 = x, y
 	t.Y2 = y // Single line height
@@ -35,7 +42,7 @@ func (t *Text) DisplayObject(scr *ScreenBuf) {
 	}
 
 	attr, highAttr := t.GetStateAttrs(ColDialogText, ColDialogText, ColDialogHighlightText, ColDialogHighlightText)
-	if t.color != 0 && t.color != Palette[ColDialogText] && !t.IsDisabled() {
+	if t.color != 0 && !t.IsDisabled() {
 		attr = t.color
 	}
 

--- a/text_test.go
+++ b/text_test.go
@@ -2,6 +2,47 @@ package vtui
 
 import "testing"
 
+func TestDialogTextAndLabelFollowRuntimePaletteChanges(t *testing.T) {
+	SetDefaultPalette()
+	original := Palette[ColDialogText]
+	defer func() { Palette[ColDialogText] = original }()
+
+	Palette[ColDialogText] = SetRGBBoth(0, 0xAAAAAA, 0x111111)
+	text := NewText(1, 1, "Text", Palette[ColDialogText])
+	label := NewLabel(1, 2, "Label", nil)
+
+	Palette[ColDialogText] = SetRGBBoth(0, 0xBBBBBB, 0x222222)
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(20, 5)
+	text.Show(scr)
+	label.Show(scr)
+
+	for _, y := range []int{1, 2} {
+		cell := scr.GetCell(1, y)
+		if fg, bg := GetRGBFore(cell.Attributes), GetRGBBack(cell.Attributes); fg != 0xBBBBBB || bg != 0x222222 {
+			t.Fatalf("runtime-themed text at y=%d = %06X on %06X, want BBBBBB on 222222", y, fg, bg)
+		}
+	}
+}
+
+func TestTextExplicitCustomColorStaysFixedAcrossPaletteChanges(t *testing.T) {
+	SetDefaultPalette()
+	original := Palette[ColDialogText]
+	defer func() { Palette[ColDialogText] = original }()
+
+	custom := SetRGBBoth(0, 0x123456, 0x654321)
+	text := NewText(1, 1, "Custom", custom)
+	Palette[ColDialogText] = SetRGBBoth(0, 0xBBBBBB, 0x222222)
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(20, 4)
+	text.Show(scr)
+
+	cell := scr.GetCell(1, 1)
+	if fg, bg := GetRGBFore(cell.Attributes), GetRGBBack(cell.Attributes); fg != 0x123456 || bg != 0x654321 {
+		t.Fatalf("custom text changed to %06X on %06X", fg, bg)
+	}
+}
+
 func TestText_Truncation(t *testing.T) {
 	SetDefaultPalette()
 	scr := NewSilentScreenBuf()

--- a/vmenu.go
+++ b/vmenu.go
@@ -9,12 +9,15 @@ import (
 
 // MenuItem represents a single menu item.
 type MenuItem struct {
-	Text      string
-	Shortcut  string // Optional right-aligned hotkey hint (e.g. "F3")
-	Command   int    // TV-style Command ID to emit when selected
-	OnClick   func() // Closure called when selected
-	UserData  any
-	Separator bool
+	// AccentPrefix is drawn immediately before Text using the menu highlight
+	// color. It is useful for non-hotkey metadata such as stable item numbers.
+	AccentPrefix string
+	Text         string
+	Shortcut     string // Optional right-aligned hotkey hint (e.g. "F3")
+	Command      int    // TV-style Command ID to emit when selected
+	OnClick      func() // Closure called when selected
+	UserData     any
+	Separator    bool
 }
 
 // VMenu implements a vertical menu with navigation support.
@@ -367,7 +370,14 @@ func (m *VMenu) DisplayObject(scr *ScreenBuf) {
 
 		// Draw background and text
 		p.Fill(m.X1+1, currY, m.X2-1, currY, ' ', itemAttr)
-		p.DrawControlText(m.X1+1, currY, " "+item.Text, itemAttr, hiAttr)
+		textX := m.X1 + 1
+		p.DrawString(textX, currY, " ", itemAttr)
+		textX++
+		if item.AccentPrefix != "" {
+			p.DrawString(textX, currY, item.AccentPrefix, hiAttr)
+			textX += runewidth.StringWidth(item.AccentPrefix)
+		}
+		p.DrawControlText(textX, currY, item.Text, itemAttr, hiAttr)
 		if shortcutText != "" {
 			p.DrawString(m.X2-vLenShortcut, currY, shortcutText, itemAttr)
 		}

--- a/vtui_test.go
+++ b/vtui_test.go
@@ -144,10 +144,23 @@ func TestFrame_CloseButtonRendering(t *testing.T) {
 	frame.ShowClose = true
 	frame.DisplayObject(scr)
 
-	colBox := Palette[ColDialogBox]
-	checkCell(t, scr, 21, 5, uint64(UIStrings.CloseBrackets[0]), colBox)
-	checkCell(t, scr, 22, 5, uint64(UIStrings.CloseSymbol), colBox)
-	checkCell(t, scr, 23, 5, uint64(UIStrings.CloseBrackets[1]), colBox)
+	controlAttr := withForeground(Palette[ColDialogBox], Palette[ColDialogBoxTitle])
+	checkCell(t, scr, 21, 5, uint64(UIStrings.CloseBrackets[0]), controlAttr)
+	checkCell(t, scr, 22, 5, uint64(UIStrings.CloseSymbol), controlAttr)
+	checkCell(t, scr, 23, 5, uint64(UIStrings.CloseBrackets[1]), controlAttr)
+}
+
+func TestWindow_ZoomButtonUsesTitleForeground(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(40, 10)
+	window := NewWindow(5, 5, 25, 9, "Window")
+	window.Show(scr)
+
+	controlAttr := withForeground(Palette[ColDialogBox], Palette[ColDialogBoxTitle])
+	checkCell(t, scr, 18, 5, uint64(UIStrings.CloseBrackets[0]), controlAttr)
+	checkCell(t, scr, 19, 5, uint64(UIStrings.ZoomSymbol), controlAttr)
+	checkCell(t, scr, 20, 5, uint64(UIStrings.CloseBrackets[1]), controlAttr)
 }
 
 func TestFrame_IsBorderClick(t *testing.T) {


### PR DESCRIPTION
## Summary
- add configurable workspace tab bar rendering, semantic model, mouse hit testing, close/add actions, drag reordering, and direct workspace switching
- support Ctrl+Alt+number switching while the transient Ctrl-only tab bar is visible
- improve workspace switcher presentation and preserve stable workspace numbering
- make help scrolling/navigation and menu hover tracking respond only to real input events
- make existing dialog labels follow runtime palette changes immediately
- render title-bar controls with the dialog title foreground

## Tests
- focused workspace, help, dialog palette, semantic, and input tests pass
- go test ./... reaches only the pre-existing Windows cleanup lock in TestDebugLog_Rotation; the test process keeps otation.log open during TempDir cleanup