### PR TITLE
Fix workspace-tab menu layout and combo dropdown borders

### DIFF
--- a/cmd/test-app/main.go
+++ b/cmd/test-app/main.go
@@ -359,7 +359,8 @@ func main() {
 			}},
 			{Label: "&Right", SubItems: []vtui.MenuItem{{Text: "Command &2"}}},
 		}
-		topMenu.SetPosition(0, 0, width-1, 0)
+		menuY := vtui.FrameManager.WorkspaceTopInset()
+		topMenu.SetPosition(0, menuY, width-1, menuY)
 
 		// --- Status Line ---
 		kb := vtui.NewKeyBar()

--- a/combobox.go
+++ b/combobox.go
@@ -34,6 +34,7 @@ func NewComboBox(x, y, width int, items []string) *ComboBox {
 	cb.Menu.ColorSelectedHighlightIdx = ColDialogComboSelectedHighlight
 	cb.Menu.ColorBoxIdx = ColDialogComboBox
 	cb.Menu.ColorTitleIdx = ColDialogComboTitle
+	cb.Menu.BoxType = SingleBox
 	if cb.Menu.ScrollBar != nil {
 		cb.Menu.ScrollBar.ColorIdx = ColDialogComboScrollbar
 	}

--- a/combobox_color_test.go
+++ b/combobox_color_test.go
@@ -6,6 +6,9 @@ import "testing"
 // menu group, so that a theme can keep it distinct from the dialog behind it.
 func TestComboBox_DropdownUsesComboPalette(t *testing.T) {
 	cb := NewComboBox(0, 0, 10, []string{"one", "two"})
+	if cb.Menu.BoxType != SingleBox {
+		t.Fatalf("dropdown box type = %d, want SingleBox", cb.Menu.BoxType)
+	}
 
 	cases := []struct {
 		name      string
@@ -46,6 +49,20 @@ func TestComboBox_DropdownStandsApartFromDialog(t *testing.T) {
 	cb := NewComboBox(0, 0, 10, []string{"one", "two"})
 	cb.Menu.SetPosition(0, 0, 10, 4)
 	cb.Menu.Show(scr)
+	single := getBoxSymbols(SingleBox)
+	for _, corner := range []struct {
+		x, y int
+		want rune
+	}{
+		{0, 0, single[bsTL]},
+		{10, 0, single[bsTR]},
+		{0, 4, single[bsBL]},
+		{10, 4, single[bsBR]},
+	} {
+		if got := rune(scr.GetCell(corner.x, corner.y).Char); got != corner.want {
+			t.Errorf("dropdown corner (%d,%d) = %q, want %q", corner.x, corner.y, got, corner.want)
+		}
+	}
 
 	// A menu selects its first item on construction, so row 1 is the selected
 	// one and row 2 an ordinary item. Both must come from the combo group;
@@ -61,6 +78,9 @@ func TestComboBox_DropdownStandsApartFromDialog(t *testing.T) {
 // A plain menu keeps the Menu.* group.
 func TestVMenu_DefaultsToMenuPalette(t *testing.T) {
 	m := NewVMenu("Menu")
+	if m.BoxType != DoubleBox {
+		t.Fatalf("plain menu box type = %d, want DoubleBox", m.BoxType)
+	}
 	if m.ColorTextIdx != ColMenuText || m.ColorBoxIdx != ColMenuBox || m.ColorTitleIdx != ColMenuTitle {
 		t.Errorf("plain menu should default to the Menu.* entries, got %d/%d/%d",
 			m.ColorTextIdx, m.ColorBoxIdx, m.ColorTitleIdx)

--- a/framemanager.go
+++ b/framemanager.go
@@ -309,6 +309,10 @@ func (fm *frameManager) ResizeAllScreens() {
 			frame.ResizeConsole(fm.scr.width, fm.scr.height)
 		}
 	}
+	if fm.MenuBar != nil {
+		top := fm.WorkspaceTopInset()
+		fm.MenuBar.SetPosition(0, top, fm.scr.width-1, top)
+	}
 }
 
 func (fm *frameManager) SyncCurrentScreen() {
@@ -1623,7 +1627,8 @@ func (fm *frameManager) Run(reader *vtinput.Reader) {
 			// This ensures they stay at the top/bottom regardless of whether
 			// the active frame also tries to resize them.
 			if fm.MenuBar != nil {
-				fm.MenuBar.SetPosition(0, 0, width-1, 0)
+				top := fm.WorkspaceTopInset()
+				fm.MenuBar.SetPosition(0, top, width-1, top)
 			}
 			if fm.KeyBar != nil {
 				fm.KeyBar.SetPosition(0, height-1, width-1, height-1)

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -1672,6 +1672,9 @@ func TestFrameManager_WorkspaceTopInsetModes(t *testing.T) {
 	fm.Init(scr)
 	frame := newMockFrame(0, 0, 80, 25, false)
 	fm.Push(frame)
+	menuBar := NewMenuBar(nil)
+	menuBar.SetPosition(0, 0, 79, 0)
+	fm.MenuBar = menuBar
 
 	if got := fm.WorkspaceTopInset(); got != 0 {
 		t.Fatalf("multiple mode with one screen inset = %d, want 0", got)
@@ -1683,14 +1686,23 @@ func TestFrameManager_WorkspaceTopInsetModes(t *testing.T) {
 	if frame.resizedW != 80 || frame.resizedH != 25 {
 		t.Fatalf("screen was not relaid out after tab row appeared: %dx%d", frame.resizedW, frame.resizedH)
 	}
+	if _, y1, _, y2 := menuBar.GetPosition(); y1 != 1 || y2 != 1 {
+		t.Fatalf("menu bar position with persistent tabs = %d..%d, want 1..1", y1, y2)
+	}
 
 	fm.ConfigureWorkspaceTabs(WorkspaceTabsOnCtrl, WorkspaceCtrlTabDirect)
 	if got := fm.WorkspaceTopInset(); got != 0 {
 		t.Fatalf("Ctrl overlay mode inset = %d, want 0", got)
 	}
+	if _, y1, _, y2 := menuBar.GetPosition(); y1 != 0 || y2 != 0 {
+		t.Fatalf("menu bar position with overlay tabs = %d..%d, want 0..0", y1, y2)
+	}
 	fm.ConfigureWorkspaceTabs(WorkspaceTabsAlways, WorkspaceCtrlTabDirect)
 	if got := fm.WorkspaceTopInset(); got != 1 {
 		t.Fatalf("always mode inset = %d, want 1", got)
+	}
+	if _, y1, _, y2 := menuBar.GetPosition(); y1 != 1 || y2 != 1 {
+		t.Fatalf("menu bar position with always-visible tabs = %d..%d, want 1..1", y1, y2)
 	}
 }
 

--- a/vmenu.go
+++ b/vmenu.go
@@ -30,6 +30,7 @@ type VMenu struct {
 	OnAction   func(int)
 	OnKeyDown  func(*vtinput.InputEvent) bool
 	HideShadow bool
+	BoxType    int
 
 	// Palette entries the menu paints with. They default to the Menu.* group;
 	// a ComboBox points them at Dialog.Combo.* so its dropdown stands apart
@@ -54,6 +55,7 @@ func NewVMenu(title string) *VMenu {
 		ColorSelectedHighlightIdx: ColMenuSelectedHighlight,
 		ColorBoxIdx:               ColMenuBox,
 		ColorTitleIdx:             ColMenuTitle,
+		BoxType:                   DoubleBox,
 	}
 	m.canFocus = true
 	m.Wrap = true
@@ -302,7 +304,7 @@ func (m *VMenu) DisplayObject(scr *ScreenBuf) {
 
 	// 1. Frame and Background
 	p.Fill(m.X1, m.Y1, m.X2, m.Y2, ' ', Palette[m.ColorTextIdx])
-	p.DrawBox(m.X1, m.Y1, m.X2, m.Y2, Palette[m.ColorBoxIdx], DoubleBox)
+	p.DrawBox(m.X1, m.Y1, m.X2, m.Y2, Palette[m.ColorBoxIdx], m.BoxType)
 
 	// far2l paints a menu title with Menu.Title whether the menu holds focus
 	// or not, so there is no separate focused variant here.
@@ -341,7 +343,14 @@ func (m *VMenu) DisplayObject(scr *ScreenBuf) {
 		}
 
 		if item.Separator {
-			p.DrawLine(m.X1, currY, m.X2, currY, boxSymbols[bsH], colBox, true, true)
+			if m.BoxType == SingleBox {
+				symbols := getBoxSymbols(SingleBox)
+				p.DrawLine(m.X1, currY, m.X2, currY, symbols[bsH], colBox, false, false)
+				scr.Write(m.X1, currY, []CharInfo{{Char: uint64(symbols[bsHCrossLeft]), Attributes: colBox}})
+				scr.Write(m.X2, currY, []CharInfo{{Char: uint64(symbols[bsHCrossRight]), Attributes: colBox}})
+			} else {
+				p.DrawLine(m.X1, currY, m.X2, currY, boxSymbols[bsH], colBox, true, true)
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- keep the global menu bar below a persistent workspace tab row
- preserve the correct menu position after resize and workspace tab mode/count changes
- update the VTUI test app to respect the workspace top inset
- render ComboBox dropdowns with a single-line outline while regular and main menus retain their double-line border
- render single-line separators consistently inside combo dropdowns

## Testing
- go test . -run 'TestFrameManager_WorkspaceTopInsetModes|TestFrameManager_ResizeAllScreens' -count=10
- go test . -run 'TestComboBox_Dropdown|TestVMenu_DefaultsToMenuPalette|TestFrameManager_WorkspaceTopInsetModes' -count=10
- go test ./cmd/test-app -count=1
- go build -o vtui-test-app.exe ./cmd/test-app
- launched the GUI test app on Windows