### PR TITLE
Use single border for edit history dropdown

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -911,6 +911,7 @@ func (e *Edit) OpenHistory() {
 		return
 	}
 	menu := NewVMenu(Msg("vtui.History"))
+	menu.BoxType = SingleBox
 	for _, h := range e.History {
 		menu.AddItem(MenuItem{Text: h})
 	}

--- a/edit_test.go
+++ b/edit_test.go
@@ -217,6 +217,9 @@ func TestEdit_HistoryMenu_Interactions(t *testing.T) {
 	if !ok {
 		t.Fatal("OpenHistory did not push a VMenu")
 	}
+	if menu.BoxType != SingleBox {
+		t.Fatalf("history dropdown box type = %d, want SingleBox", menu.BoxType)
+	}
 
 	// 1. Проверка Shift+Enter (только подстановка текста)
 	menu.ProcessKey(&vtinput.InputEvent{


### PR DESCRIPTION
## Summary
- render Edit history popups as dropdowns with a single-line border
- add a regression assertion for the history menu border style

## Tests
- `go test . -run TestEdit_HistoryMenu_Interactions` 
- `go test ./cmd/test-app` 

## Note
The full Windows test run still hits the pre-existing `TestDebugLog_Rotation` temporary-file lock during cleanup.