### PR TITLE
Improve workspace tab separators

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -996,6 +996,26 @@ func withForeground(backgroundAttr, foregroundAttr uint64) uint64 {
 	return SetIndexFore(backgroundAttr, GetIndexFore(foregroundAttr))
 }
 
+func workspaceTitleSeparatorAttr(attr uint64) uint64 {
+	if attr&IsFgRGB == 0 {
+		return DimColor(attr)
+	}
+
+	foreground := GetRGBFore(attr)
+	background := uint32(0)
+	if attr&IsBgRGB != 0 {
+		background = GetRGBBack(attr)
+	}
+	blend := func(foreground, background uint32) uint32 {
+		return (foreground + background) / 2
+	}
+	return SetRGBFore(attr,
+		blend((foreground>>16)&0xFF, (background>>16)&0xFF)<<16|
+			blend((foreground>>8)&0xFF, (background>>8)&0xFF)<<8|
+			blend(foreground&0xFF, background&0xFF),
+	)
+}
+
 func (fm *frameManager) workspaceBarAttr() uint64 {
 	if fm.workspaceColorsSet {
 		return fm.WorkspaceTabBarAttr
@@ -1090,7 +1110,7 @@ func (fm *frameManager) drawWorkspaceTabs() {
 
 	tabsLimit := available
 	if tabsLimit >= 2 {
-		tabsLimit -= 2 // Reserve |+ after the compact tab sequence.
+		tabsLimit -= 2 // Reserve │+ after the compact tab sequence.
 	}
 
 	x := 0
@@ -1134,8 +1154,17 @@ func (fm *frameManager) drawWorkspaceTabs() {
 		fm.scr.Write(x, 0, StringToCharInfo(number, numberAttr))
 		x += numberWidth
 		if title != "" && x < tabsLimit {
-			fm.scr.Write(x, 0, StringToCharInfo(" "+title, attr))
-			x += 1 + runewidth.StringWidth(title)
+			parts := strings.Split(" "+title, "─")
+			for partIndex, part := range parts {
+				if part != "" {
+					fm.scr.Write(x, 0, StringToCharInfo(part, attr))
+					x += runewidth.StringWidth(part)
+				}
+				if partIndex < len(parts)-1 && x < tabsLimit {
+					fm.scr.Write(x, 0, StringToCharInfo("─", workspaceTitleSeparatorAttr(attr)))
+					x++
+				}
+			}
 		}
 		if x < tabsLimit {
 			fm.scr.Write(x, 0, StringToCharInfo(" ", attr))
@@ -1143,12 +1172,12 @@ func (fm *frameManager) drawWorkspaceTabs() {
 		}
 		fm.workspaceTabHits = append(fm.workspaceTabHits, workspaceTabHit{x1: tabStart, x2: x - 1, index: i})
 		if i < len(fm.Screens)-1 && x < tabsLimit {
-			fm.scr.Write(x, 0, StringToCharInfo("|", baseAttr))
+			fm.scr.Write(x, 0, StringToCharInfo("│", baseAttr))
 			x++
 		}
 	}
 	if x+2 <= available {
-		fm.scr.Write(x, 0, StringToCharInfo("|", baseAttr))
+		fm.scr.Write(x, 0, StringToCharInfo("│", baseAttr))
 		fm.scr.Write(x+1, 0, StringToCharInfo("+", fm.workspaceNumberAttr(baseAttr)))
 		fm.workspaceNewTabX = x + 1
 	}
@@ -1321,7 +1350,7 @@ func (fm *frameManager) showScreensMenu() {
 		line += primary + strings.Repeat(" ", maxLeftWidth-runewidth.StringWidth(primary))
 		if maxRightWidth > 0 {
 			secondary := truncateMiddleCells(info.Secondary, maxRightWidth)
-			line += " ↔ " + secondary
+			line += " ─ " + secondary
 		}
 		line += suf
 		menu.AddItem(MenuItem{

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -1712,7 +1712,7 @@ func TestFrameManager_WorkspaceTabsAndCounterRendering(t *testing.T) {
 	scr.AllocBuf(60, 10)
 	fm := &frameManager{}
 	fm.Init(scr)
-	fm.Push(NewWindow(0, 0, 20, 5, "Panels"))
+	fm.Push(NewWindow(0, 0, 20, 5, "Panels ─ Files"))
 	fm.AddScreen(NewWindow(0, 0, 20, 5, "Editor"))
 	fm.ConfigureWorkspaceTabs(WorkspaceTabsMultiple, WorkspaceCtrlTabDirect)
 	fm.ConfigureWorkspaceTabColors(
@@ -1732,10 +1732,10 @@ func TestFrameManager_WorkspaceTabsAndCounterRendering(t *testing.T) {
 	if !strings.Contains(text, "1 Panels") || !strings.Contains(text, "2 Editor") {
 		t.Fatalf("tab row does not contain both workspaces: %q", text)
 	}
-	if !strings.Contains(text, "Panels | 2 Editor") {
-		t.Fatalf("tabs are not compact and pipe-separated: %q", text)
+	if !strings.Contains(text, "Files │ 2 Editor") {
+		t.Fatalf("tabs are not compact and box-drawing-separated: %q", text)
 	}
-	if !strings.Contains(text, "Editor |+") {
+	if !strings.Contains(text, "Editor │+") {
 		t.Fatalf("new-workspace control is missing after tabs: %q", text)
 	}
 	if !strings.HasSuffix(text, "[2/2]") {
@@ -1753,6 +1753,13 @@ func TestFrameManager_WorkspaceTabsAndCounterRendering(t *testing.T) {
 	}
 	if got := GetRGBBack(scr.GetCell(fm.workspaceTabHits[1].x2, 0).Attributes); got != 0x222222 {
 		t.Fatalf("active tab background = %#x, want panel background", got)
+	}
+	titleSeparatorX := strings.IndexRune(text, '─')
+	if titleSeparatorX < 0 {
+		t.Fatalf("workspace title separator is missing: %q", text)
+	}
+	if got := GetRGBFore(scr.GetCell(titleSeparatorX, 0).Attributes); got != 0x5D5D5D {
+		t.Fatalf("workspace title separator foreground = %#x, want half-brightness %#x", got, uint32(0x5D5D5D))
 	}
 	counterCurrentX := scr.width - runewidth.StringWidth("[2/2]") + 1
 	if tabFG, counterFG := GetRGBFore(scr.GetCell(fm.workspaceTabHits[0].x1+1, 0).Attributes), GetRGBFore(scr.GetCell(counterCurrentX, 0).Attributes); tabFG != counterFG {


### PR DESCRIPTION
## Summary
- use full-height box-drawing separators between workspace tabs
- use a widely supported horizontal separator between panel paths
- dim the in-title separator relative to each tab's own text and background colors

## Tests
- go test . -run 'TestFrameManager_(WorkspaceTabsAndCounterRendering|ScreensMenuUsesStructuredAlignedWorkspaceInfo)$'