### PR TITLE
exported fuzzy matcher & rich autocomplete

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -206,3 +206,22 @@ of them at once, to fix a bug that was about code points versus UTF-16 units.
 If a highlighter turns up that genuinely works in bytes, the honest move is a
 second mapper next to the first, not a redefinition of the contract underneath
 code that already relies on it.
+
+## Touchpad scroll deltas below one notch are dropped in gogpu
+
+`gogpu_host.go` converts the fractional `OnScroll` delta into whole wheel
+events with `int(math.Abs(dy))` and returns early when that truncates to
+zero. A precision touchpad produces a stream of small deltas, so smooth
+scrolling is effectively dead there; ebiten clamps any nonzero delta up to
+one event instead, which is jumpy in the other direction. The fix is an
+accumulator per host that carries the remainder into the next event. It was
+not done when the system-lines multiplication moved out of the hosts because
+nobody had a precision touchpad complaint on file.
+
+## Clipboard tests leak through the global clipboard
+
+`TestClipboard_RoundTripsThroughInternalBuffer` fails intermittently in a
+full `go test .` run with a value set by another test ("secret text"),
+because the internal clipboard buffer is package global and tests run in
+source order share it. It passes in isolation. Not a wheel/scroll regression;
+observed on Windows while touching unrelated code.

--- a/autocomplete.go
+++ b/autocomplete.go
@@ -7,11 +7,73 @@ import (
 	"github.com/unxed/vtinput"
 )
 
+// AutoCompleteItem is a single entry of the autocomplete list.
+type AutoCompleteItem struct {
+	Text string
+	// Display is shown instead of Text when non-empty (e.g. the final path
+	// element instead of the full path). MatchStart/MatchEnd then refer to
+	// Display. Text is still what gets inserted on accept.
+	Display string
+	// Cells renders the item as multiple columns (panel-style). Cells[0] is
+	// the main text (falls back to Display/Text when shorter); extra cells
+	// get fixed columns sized to their widest content.
+	Cells []string
+	// Attr overrides the item foreground (file-highlight colors); 0 uses the
+	// default list colors.
+	Attr uint64
+	// Separator draws a non-selectable divider line between item groups.
+	Separator bool
+	// MatchStart/MatchEnd mark the needle span in the displayed string (rune
+	// indices, end inclusive) that gets highlighted. MatchStart -1 means no
+	// highlight.
+	MatchStart int
+	MatchEnd   int
+	// ReplaceFrom/ReplaceTo define the rune span of the Edit text replaced
+	// when the item is accepted. The zero span (both 0) keeps the legacy
+	// behavior: the whole text is replaced.
+	ReplaceFrom int
+	ReplaceTo   int
+}
+
+// PathHintProvider is installed by the host application (f4) to contribute
+// file path suggestions to the autocomplete menu. word is the whitespace
+// bounded token under the cursor, from/to its rune span in the edit text.
+// Returning nil or an empty slice means "no path suggestions".
+var PathHintProvider func(edit *Edit, word string, from, to int) []AutoCompleteItem
+
+// maxAutoCompleteVisible caps the visible rows in total mode; longer lists
+// scroll. In per-category mode each separator-delimited group (path hints of
+// each panel, then history) contributes up to this many rows.
+var autoCompleteMaxVisible = 5
+
+// autoCompletePerCategory selects how the visible height is computed:
+// false = the whole list shares one window of autoCompleteMaxVisible rows,
+// true = each category shows up to autoCompleteMaxVisible rows of its own.
+var autoCompletePerCategory bool
+
+// SetAutoCompleteMaxVisible sets the visible row cap. Values below 1 are
+// ignored.
+func SetAutoCompleteMaxVisible(n int) {
+	if n >= 1 {
+		autoCompleteMaxVisible = n
+	}
+}
+
+// SetAutoCompletePerCategory switches between one shared window and a
+// per-category row budget (see autoCompletePerCategory).
+func SetAutoCompletePerCategory(on bool) {
+	autoCompletePerCategory = on
+}
+
 type AutoCompleteMenu struct {
 	Window
 	Edit    *Edit
 	lb      *ListBox
-	Matches []string
+	Matches []string // texts of items ("" for separators), kept for API compatibility
+	items   []AutoCompleteItem
+	// hasPathItems marks that the leading group came from PathHintProvider;
+	// the menu then anchors to the trigger separator instead of the cursor.
+	hasPathItems bool
 }
 
 func NewAutoCompleteMenu(edit *Edit) *AutoCompleteMenu {
@@ -27,20 +89,14 @@ func NewAutoCompleteMenu(edit *Edit) *AutoCompleteMenu {
 	ac.lb = NewListBox(0, 0, 10, 10, nil)
 	ac.lb.ColorTextIdx = ColDialogText
 	ac.lb.ColorSelectedTextIdx = ColDialogSelectedButton
+	ac.lb.ShowScrollBar = true
+	ac.lb.IsSelectable = func(i int) bool {
+		return i >= 0 && i < len(ac.items) && !ac.items[i].Separator
+	}
 	ac.lb.OnAction = func(idx int) {
-		if idx >= 0 && idx < len(ac.Matches) {
-			ac.Edit.SetText(ac.Matches[idx])
-			ac.Edit.curPos = len(ac.Edit.text)
-			ac.Edit.clearFlag = false
-			ac.Edit.HistoryPos = -1
-			// Inject Enter to execute chosen command immediately
-			if FrameManager != nil {
-				FrameManager.InjectEvents([]*vtinput.InputEvent{
-					{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN},
-				})
-			}
-		}
-		ac.Close()
+		// A click on a path item only inserts it; a click on a history item
+		// (whole-text legacy) also executes, as before.
+		ac.accept(idx, true)
 	}
 	ac.AddItem(ac.lb)
 
@@ -63,71 +119,340 @@ func (ac *AutoCompleteMenu) SetPosition(x1, y1, x2, y2 int) {
 	}
 	if ac.lb != nil {
 		ac.lb.SetPosition(x1+1, y1+1, x2-1, y2-1)
+		// ListBox.SetPosition pins the first column to the full width;
+		// restore the multi-column layout.
+		ac.applyColumns()
 	}
+}
+
+// applyColumns rebuilds the list box columns from the items: column 0 is
+// flexible, extra columns (from AutoCompleteItem.Cells) are fixed to their
+// widest content.
+func (ac *AutoCompleteMenu) applyColumns() {
+	n := 1
+	for i := range ac.items {
+		if len(ac.items[i].Cells) > n {
+			n = len(ac.items[i].Cells)
+		}
+	}
+	cols := make([]TableColumn, n)
+	cols[0] = TableColumn{MinWidth: 8} // flexible
+	for c := 1; c < n; c++ {
+		w := 0
+		for i := range ac.items {
+			if c < len(ac.items[i].Cells) {
+				if cw := StringWidth(ac.items[i].Cells[c]); cw > w {
+					w = cw
+				}
+			}
+		}
+		cols[c] = TableColumn{Width: w}
+	}
+	ac.lb.Columns = cols
+	ac.lb.ShowSeparators = n > 1
 }
 
 func (ac *AutoCompleteMenu) HasMatches() bool {
 	return len(ac.Matches) > 0
 }
 
-func (ac *AutoCompleteMenu) UpdateMatches() {
-	text := ac.Edit.GetText()
-	ac.Matches = nil
-	if text == "" {
-		return
+// capAutoCompleteGroups keeps at most n non-separator items in each
+// separator-delimited group.
+func capAutoCompleteGroups(items []AutoCompleteItem, n int) []AutoCompleteItem {
+	out := make([]AutoCompleteItem, 0, len(items))
+	count := 0
+	for _, it := range items {
+		if it.Separator {
+			count = 0
+			out = append(out, it)
+			continue
+		}
+		if count < n {
+			out = append(out, it)
+			count++
+		}
 	}
-	textLower := strings.ToLower(text)
+	return out
+}
 
-	seen := make(map[string]bool)
+// acRow adapts AutoCompleteItem to the ListBox table model.
+type acRow struct {
+	ac  *AutoCompleteMenu
+	idx int
+}
 
-	for _, h := range ac.Edit.History {
-		if strings.HasPrefix(strings.ToLower(h), textLower) {
-			if !seen[h] {
-				ac.Matches = append(ac.Matches, h)
-				seen[h] = true
+func (r acRow) GetCellText(col int) string {
+	it := r.ac.items[r.idx]
+	if it.Separator {
+		if col == 0 {
+			return strings.Repeat("─", 64) // truncated to the cell width on draw
+		}
+		return ""
+	}
+	if col < len(it.Cells) {
+		return it.Cells[col]
+	}
+	if col == 0 {
+		if it.Display != "" {
+			return it.Display
+		}
+		return it.Text
+	}
+	return ""
+}
+
+func (r acRow) GetCellAttr(col int, def uint64) uint64 {
+	it := r.ac.items[r.idx]
+	if it.Separator {
+		return DimColor(def)
+	}
+	if it.Attr == 0 {
+		return def
+	}
+	// Keep the state background (cursor/selection), take the item foreground.
+	if it.Attr&IsFgRGB != 0 {
+		return SetRGBFore(def, GetRGBFore(it.Attr))
+	}
+	return SetIndexFore(def, GetIndexFore(it.Attr))
+}
+
+func (ac *AutoCompleteMenu) UpdateMatches() {
+	ac.items = nil
+	ac.Matches = nil
+
+	// Path suggestions come first when the host provider has any.
+	ac.hasPathItems = false
+	if ac.Edit.PathHintsEnabled && PathHintProvider != nil {
+		from, to, word := ac.Edit.WordUnderCursor()
+		ac.items = append(ac.items, PathHintProvider(ac.Edit, word, from, to)...)
+		ac.hasPathItems = len(ac.items) > 0
+	}
+	pathCount := len(ac.items)
+
+	// Legacy history: case-insensitive prefix match, deduplicated.
+	text := ac.Edit.GetText()
+	if text != "" {
+		textLower := strings.ToLower(text)
+		needleEnd := len([]rune(text)) - 1
+		seen := make(map[string]bool)
+		for _, h := range ac.Edit.History {
+			if !strings.HasPrefix(strings.ToLower(h), textLower) || seen[h] {
+				continue
 			}
+			seen[h] = true
+			if pathCount > 0 && len(ac.items) == pathCount {
+				ac.items = append(ac.items, AutoCompleteItem{Separator: true, MatchStart: -1, MatchEnd: -1})
+			}
+			ac.items = append(ac.items, AutoCompleteItem{Text: h, MatchStart: 0, MatchEnd: needleEnd})
 		}
 	}
 
-	if len(ac.Matches) == 0 {
+	for _, it := range ac.items {
+		ac.Matches = append(ac.Matches, it.Text)
+	}
+
+	if autoCompletePerCategory {
+		ac.items = capAutoCompleteGroups(ac.items, autoCompleteMaxVisible)
+		ac.Matches = ac.Matches[:0]
+		for _, it := range ac.items {
+			ac.Matches = append(ac.Matches, it.Text)
+		}
+	}
+
+	if len(ac.items) == 0 {
 		return
 	}
 
+	rows := make([]TableRow, len(ac.items))
+	for i := range ac.items {
+		rows[i] = acRow{ac: ac, idx: i}
+	}
 	ac.lb.Items = ac.Matches
-	ac.lb.UpdateRows()
+	ac.lb.SetRows(rows)
 
-	if ac.lb.SelectPos >= len(ac.Matches) {
-		ac.lb.SetSelectPos(len(ac.Matches) - 1)
-	} else if ac.lb.SelectPos < 0 {
-		ac.lb.SetSelectPos(0)
+	// Keep the selection on a selectable row.
+	if ac.lb.SelectPos < 0 || ac.lb.SelectPos >= len(ac.items) || !ac.lb.IsSelectable(ac.lb.SelectPos) {
+		sel := -1
+		for i := range ac.items {
+			if ac.lb.IsSelectable(i) {
+				sel = i
+				break
+			}
+		}
+		if sel < 0 {
+			ac.Matches = nil
+			return
+		}
+		ac.lb.SetSelectPos(sel)
 	}
 
-	scrW := 80
+	ac.reposition()
+}
+
+// reposition places the menu next to the text cursor: below the edit line,
+// flipped above when there is more room there; clamped to the screen.
+func (ac *AutoCompleteMenu) reposition() {
+	scrW, scrH := 80, 25
 	if FrameManager != nil && FrameManager.scr != nil {
 		scrW = FrameManager.scr.width
+		scrH = FrameManager.scr.height
 	}
 
-	h := len(ac.Matches) + 2
-	if h > 12 {
-		h = 12
+	vis := len(ac.items)
+	limit := autoCompleteMaxVisible
+	if autoCompletePerCategory {
+		// Each of the three possible categories (active panel, passive
+		// panel, history) gets its own budget, plus up to two separators.
+		limit = 3*autoCompleteMaxVisible + 2
+	}
+	if vis > limit {
+		vis = limit
+	}
+	h := vis + 2
+
+	w := 24
+	for i := range ac.items {
+		if iw := runewidth.StringWidth(ac.items[i].Text) + 2; iw > w {
+			w = iw
+		}
+	}
+	if w > scrW {
+		w = scrW
 	}
 
-	x1 := 0
-	x2 := scrW - 1
-
-	y2 := ac.Edit.Y1 - 1
-	y1 := y2 - h + 1
-
-	if y1 < 0 {
-		y1 = 0
-		h = y2 - y1 + 1
+	cur := ac.Edit.curPos
+	if cur > len(ac.Edit.text) {
+		cur = len(ac.Edit.text)
 	}
+	if ac.Edit.leftPos > cur {
+		ac.Edit.leftPos = cur
+	}
+	cursorX := ac.Edit.X1 + runewidth.StringWidth(string(ac.Edit.text[ac.Edit.leftPos:cur]))
+	if ac.hasPathItems {
+		// Anchor to the trigger separator of the current token, so the menu
+		// does not drift right as the user keeps typing.
+		from, _, _ := ac.Edit.WordUnderCursor()
+		sep := -1
+		for i := cur - 1; i >= from && i < len(ac.Edit.text); i-- {
+			if ac.Edit.text[i] == '/' || ac.Edit.text[i] == '\\' {
+				sep = i
+				break
+			}
+		}
+		if sep >= 0 {
+			anchor := sep
+			if anchor < ac.Edit.leftPos {
+				anchor = ac.Edit.leftPos
+			}
+			cursorX = ac.Edit.X1 + runewidth.StringWidth(string(ac.Edit.text[ac.Edit.leftPos:anchor]))
+		}
+	}
+
+	x1 := cursorX
+	if x1+w > scrW {
+		x1 = scrW - w
+	}
+	if x1 < 0 {
+		x1 = 0
+	}
+	x2 := x1 + w - 1
+
+	y1 := ac.Edit.Y1 + 1
+	if y1+h > scrH && ac.Edit.Y1 >= h {
+		y1 = ac.Edit.Y1 - h // flip above the edit line
+	} else if y1+h > scrH {
+		h = scrH - y1
+		if h < 3 {
+			h = 3
+		}
+	}
+	y2 := y1 + h - 1
 
 	ac.SetPosition(x1, y1, x2, y2)
 }
 
+// accept applies the chosen item: it replaces either the item's rune span of
+// the edit text (path hints) or the whole text (legacy history). Directory
+// paths keep the menu open for drill-down; injectEnter only applies to
+// legacy whole-text items.
+func (ac *AutoCompleteMenu) accept(idx int, injectEnter bool) {
+	if idx < 0 || idx >= len(ac.items) {
+		ac.Close()
+		return
+	}
+	it := ac.items[idx]
+	if it.Separator {
+		return
+	}
+	e := ac.Edit
+	legacy := it.ReplaceTo <= it.ReplaceFrom
+	if legacy {
+		e.SetText(it.Text)
+		e.curPos = len(e.text)
+	} else {
+		newText := make([]rune, 0, len(e.text)+len([]rune(it.Text)))
+		newText = append(newText, e.text[:it.ReplaceFrom]...)
+		newText = append(newText, []rune(it.Text)...)
+		newText = append(newText, e.text[it.ReplaceTo:]...)
+		e.SetText(string(newText))
+		e.curPos = it.ReplaceFrom + len([]rune(it.Text))
+	}
+	e.clearFlag = false
+	e.HistoryPos = -1
+
+	if !legacy && (strings.HasSuffix(it.Text, "/") || strings.HasSuffix(it.Text, "\\")) {
+		// Directory selected: refresh the hint for the new token.
+		ac.UpdateMatches()
+		if !ac.HasMatches() {
+			ac.Close()
+		}
+		return
+	}
+
+	ac.Close()
+	if legacy && injectEnter && FrameManager != nil {
+		FrameManager.InjectEvents([]*vtinput.InputEvent{
+			{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN},
+		})
+	}
+}
+
 func (ac *AutoCompleteMenu) Show(scr *ScreenBuf) {
 	ac.Window.Show(scr)
+
+	// Needle highlight over the plain rows drawn by the list box.
+	for i := 0; i < ac.lb.ViewHeight; i++ {
+		idx := ac.lb.TopPos + i
+		if idx >= len(ac.items) {
+			break
+		}
+		it := &ac.items[idx]
+		if it.Separator || it.MatchStart < 0 {
+			continue
+		}
+		disp := it.Text
+		if it.Display != "" {
+			disp = it.Display
+		}
+		if len(it.Cells) > 0 {
+			disp = it.Cells[0]
+		}
+		runes := []rune(disp)
+		if it.MatchStart >= len(runes) {
+			continue
+		}
+		end := it.MatchEnd
+		if end >= len(runes) {
+			end = len(runes) - 1
+		}
+		x := ac.lb.X1 + runewidth.StringWidth(string(runes[:it.MatchStart]))
+		w := runewidth.StringWidth(string(runes[it.MatchStart : end+1]))
+		for cx := x; cx < x+w && cx <= ac.lb.X2; cx++ {
+			cell := scr.GetCell(cx, ac.lb.Y1+i)
+			cell.Attributes = InvertColors(cell.Attributes)
+			scr.Write(cx, ac.lb.Y1+i, []CharInfo{cell})
+		}
+	}
 
 	footer := " Up/Down Enter Esc Tab Shift+Del "
 	p := NewPainter(scr)
@@ -163,46 +488,32 @@ func (ac *AutoCompleteMenu) ProcessKey(e *vtinput.InputEvent) bool {
 		ac.Close()
 		return true
 	case vtinput.VK_TAB:
-		if ac.lb.SelectPos >= 0 && ac.lb.SelectPos < len(ac.Matches) {
-			ac.Edit.SetText(ac.Matches[ac.lb.SelectPos])
-			ac.Edit.curPos = len(ac.Edit.text)
-			ac.Edit.clearFlag = false
-			ac.Edit.HistoryPos = -1
-		}
-		ac.Close()
+		ac.accept(ac.lb.SelectPos, false)
 		return true
 	case vtinput.VK_RETURN:
-		if ac.lb.SelectPos >= 0 && ac.lb.SelectPos < len(ac.Matches) {
-			ac.Edit.SetText(ac.Matches[ac.lb.SelectPos])
-			ac.Edit.curPos = len(ac.Edit.text)
-			ac.Edit.clearFlag = false
-			ac.Edit.HistoryPos = -1
-		}
-		ac.Close()
-		if FrameManager != nil {
-			// Only inject if not Shift+Enter (Shift+Enter just fills the line)
-			if (e.ControlKeyState & vtinput.ShiftPressed) == 0 {
-				FrameManager.InjectEvents([]*vtinput.InputEvent{e})
-			}
-		}
+		inject := (e.ControlKeyState & vtinput.ShiftPressed) == 0
+		ac.accept(ac.lb.SelectPos, inject)
 		return true
 	case vtinput.VK_DELETE:
 		if (e.ControlKeyState & vtinput.ShiftPressed) != 0 {
-			if ac.lb.SelectPos >= 0 && ac.lb.SelectPos < len(ac.Matches) {
-				itemToRemove := ac.Matches[ac.lb.SelectPos]
-				newHist := []string{}
-				for _, h := range ac.Edit.History {
-					if h != itemToRemove {
-						newHist = append(newHist, h)
+			if ac.lb.SelectPos >= 0 && ac.lb.SelectPos < len(ac.items) {
+				it := ac.items[ac.lb.SelectPos]
+				// Only legacy history items can be removed from history.
+				if !it.Separator && it.ReplaceTo <= it.ReplaceFrom {
+					newHist := []string{}
+					for _, h := range ac.Edit.History {
+						if h != it.Text {
+							newHist = append(newHist, h)
+						}
 					}
-				}
-				ac.Edit.History = newHist
-				if ac.Edit.HistoryID != "" && GlobalHistoryProvider != nil {
-					GlobalHistoryProvider.SaveHistory(ac.Edit.HistoryID, newHist)
-				}
-				ac.UpdateMatches()
-				if !ac.HasMatches() {
-					ac.Close()
+					ac.Edit.History = newHist
+					if ac.Edit.HistoryID != "" && GlobalHistoryProvider != nil {
+						GlobalHistoryProvider.SaveHistory(ac.Edit.HistoryID, newHist)
+					}
+					ac.UpdateMatches()
+					if !ac.HasMatches() {
+						ac.Close()
+					}
 				}
 			}
 			return true

--- a/autocomplete_test.go
+++ b/autocomplete_test.go
@@ -163,3 +163,320 @@ func TestAutoComplete_EmptyOnDelete(t *testing.T) {
 		t.Error("AutoComplete menu should close when text becomes empty")
 	}
 }
+
+func TestEdit_WordUnderCursor(t *testing.T) {
+	SetDefaultPalette()
+	e := NewEdit(0, 0, 40, `copy C:\Program Files\app "D:\My Docs"`)
+	e.curPos = len([]rune(`copy C:\Program Files\app`)) - 2 // inside the second token
+
+	from, to, word := e.WordUnderCursor()
+	if word != `Files\app` && word != `C:\Program` {
+		// sanity fallback, real assertion below
+		t.Logf("word=%q from=%d to=%d", word, from, to)
+	}
+	// cursor sits in the token after the space inside the path
+	if word != `Files\app` {
+		t.Errorf("Expected token %q, got %q (from=%d to=%d)", `Files\app`, word, from, to)
+	}
+
+	// Cursor right after a separator inside a quoted path
+	e2 := NewEdit(0, 0, 40, `"D:\My Docs\`)
+	e2.curPos = len([]rune(e2.GetText()))
+	_, _, word2 := e2.WordUnderCursor()
+	if word2 != `"D:\My` && word2 != `Docs\` {
+		t.Logf("word2=%q", word2)
+	}
+	if word2 != `Docs\` {
+		t.Errorf("Expected quoted token tail %q, got %q", `Docs\`, word2)
+	}
+
+	// Empty text
+	e3 := NewEdit(0, 0, 40, "")
+	from3, to3, word3 := e3.WordUnderCursor()
+	if word3 != "" || from3 != 0 || to3 != 0 {
+		t.Errorf("Empty edit: got (%d,%d,%q)", from3, to3, word3)
+	}
+}
+
+func TestAutoComplete_PathHintMerge(t *testing.T) {
+	SetDefaultPalette()
+	FrameManager.Init(NewSilentScreenBuf())
+
+	old := PathHintProvider
+	defer func() { PathHintProvider = old }()
+	PathHintProvider = func(edit *Edit, word string, from, to int) []AutoCompleteItem {
+		return []AutoCompleteItem{
+			{Text: `C:\tools\`, MatchStart: 3, MatchEnd: 7, ReplaceFrom: from, ReplaceTo: to},
+			{Text: `C:\temp\`, MatchStart: 3, MatchEnd: 6, ReplaceFrom: from, ReplaceTo: to},
+		}
+	}
+
+	edit := NewEdit(0, 10, 40, `C:\t`)
+	edit.History = []string{`C:\tools old`, `cd home`}
+	edit.PathHintsEnabled = true
+
+	ac := NewAutoCompleteMenu(edit)
+	FrameManager.Push(ac)
+	defer ac.Close()
+
+	// paths first, separator, then history prefix matches
+	if len(ac.items) != 4 {
+		t.Fatalf("Expected 4 items (2 paths + separator + 1 history), got %d", len(ac.items))
+	}
+	if !ac.items[2].Separator {
+		t.Error("Item 2 should be the separator")
+	}
+	if ac.items[3].Text != `C:\tools old` {
+		t.Errorf("History item after separator: got %q", ac.items[3].Text)
+	}
+	if ac.lb.IsSelectable(2) {
+		t.Error("Separator must not be selectable")
+	}
+
+	// Down from 1 must skip the separator and land on the history item
+	ac.lb.SetSelectPos(1)
+	ac.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_DOWN})
+	if ac.lb.SelectPos != 3 {
+		t.Errorf("Down should skip the separator: SelectPos=%d, want 3", ac.lb.SelectPos)
+	}
+}
+
+func TestAutoComplete_PathSpanReplaceAndDrillDown(t *testing.T) {
+	SetDefaultPalette()
+	FrameManager.Init(NewSilentScreenBuf())
+
+	old := PathHintProvider
+	defer func() { PathHintProvider = old }()
+
+	var lastWord string
+	PathHintProvider = func(edit *Edit, word string, from, to int) []AutoCompleteItem {
+		lastWord = word
+		if word == `C:\t` {
+			return []AutoCompleteItem{{Text: `C:\tools\`, MatchStart: -1, MatchEnd: -1, ReplaceFrom: from, ReplaceTo: to}}
+		}
+		if word == `C:\tools\` {
+			return []AutoCompleteItem{{Text: `C:\tools\app.exe`, MatchStart: -1, MatchEnd: -1, ReplaceFrom: from, ReplaceTo: to}}
+		}
+		return nil
+	}
+
+	edit := NewEdit(0, 10, 40, `run C:\t --flag`)
+	edit.curPos = 6 // right after the typed separator... place cursor inside token
+	edit.curPos = len([]rune(`run C:\t`))
+	edit.PathHintsEnabled = true
+
+	ac := NewAutoCompleteMenu(edit)
+	FrameManager.Push(ac)
+
+	// Tab-accept the directory: replaces only the token, keeps the tail
+	ac.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_TAB})
+	if edit.GetText() != `run C:\tools\ --flag` {
+		t.Fatalf("Span replace failed: %q", edit.GetText())
+	}
+	if ac.IsDone() {
+		t.Fatal("Menu should stay open for directory drill-down")
+	}
+	if lastWord != `C:\tools\` {
+		t.Errorf("Provider should be re-queried with the new token, got %q", lastWord)
+	}
+
+	// Accept the file: menu closes, no Enter injected
+	fm := FrameManager
+	fm.injectedEvents = nil
+	ac.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_TAB})
+	if edit.GetText() != `run C:\tools\app.exe --flag` {
+		t.Fatalf("File accept failed: %q", edit.GetText())
+	}
+	if !ac.IsDone() {
+		t.Error("Menu should close after accepting a file")
+	}
+	if len(fm.injectedEvents) != 0 {
+		t.Error("Path item accept must not inject Enter")
+	}
+}
+
+func TestAutoComplete_NearCursorPosition(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(100, 40)
+	FrameManager.Init(scr)
+
+	edit := NewEdit(20, 30, 40, "git")
+	edit.History = []string{"git status", "git pull"}
+	ac := NewAutoCompleteMenu(edit)
+	defer ac.Close()
+
+	ax1, ay1, ax2, ay2 := ac.GetPosition()
+	// Below the edit, at the cursor column (end of "git" -> X1+3)
+	if ay1 != edit.Y1+1 {
+		t.Errorf("Menu should open below the edit: y1=%d, want %d", ay1, edit.Y1+1)
+	}
+	if ax1 != edit.X1+3 {
+		t.Errorf("Menu should open at the cursor column: x1=%d, want %d", ax1, edit.X1+3)
+	}
+	// Height: 2 items + frame, capped at 5 visible rows
+	if ay2-ay1+1 != 4 {
+		t.Errorf("Menu height: got %d, want 4", ay2-ay1+1)
+	}
+	if ax2-ax1+1 < 24 {
+		t.Errorf("Menu width below minimum: %d", ax2-ax1+1)
+	}
+
+	// Near the bottom edge: flip above the edit
+	edit2 := NewEdit(0, 38, 40, "git")
+	edit2.History = []string{"git status", "git pull", "git push", "git log", "git diff", "git tag", "git add"}
+	ac2 := NewAutoCompleteMenu(edit2)
+	defer ac2.Close()
+	_, ay21, _, _ := ac2.GetPosition()
+	if ay21 >= edit2.Y1 {
+		t.Errorf("Menu should flip above the edit near the bottom edge: y1=%d, edit y=%d", ay21, edit2.Y1)
+	}
+}
+
+func TestAutoComplete_DisplayAndColumns(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(100, 40)
+	FrameManager.Init(scr)
+
+	old := PathHintProvider
+	defer func() { PathHintProvider = old }()
+	PathHintProvider = func(edit *Edit, word string, from, to int) []AutoCompleteItem {
+		return []AutoCompleteItem{
+			{
+				Text:    `C:\tools\app.exe`,
+				Display: "app.exe",
+				Cells:   []string{"app.exe", "12 KB"},
+				// span relative to the displayed string
+				MatchStart: 0, MatchEnd: 2,
+				ReplaceFrom: from, ReplaceTo: to,
+			},
+		}
+	}
+
+	edit := NewEdit(5, 10, 40, `C:\ap`)
+	edit.PathHintsEnabled = true
+	ac := NewAutoCompleteMenu(edit)
+	defer ac.Close()
+
+	// Multi-column layout was picked up: main column flexible + one fixed
+	if len(ac.lb.Columns) != 2 {
+		t.Fatalf("Expected 2 columns, got %d", len(ac.lb.Columns))
+	}
+	if ac.lb.Columns[0].Width != 0 {
+		t.Errorf("Main column should be flexible (Width 0), got %d", ac.lb.Columns[0].Width)
+	}
+	if ac.lb.Columns[1].Width != 5 { // "12 KB"
+		t.Errorf("Second column width: got %d, want 5", ac.lb.Columns[1].Width)
+	}
+	if !ac.lb.ShowSeparators {
+		t.Error("Multi-column list should show separators")
+	}
+
+	// Display text is rendered, needle span refers to it
+	row := acRow{ac: ac, idx: 0}
+	if got := row.GetCellText(0); got != "app.exe" {
+		t.Errorf("Cell 0 should show Display: %q", got)
+	}
+	if got := row.GetCellText(1); got != "12 KB" {
+		t.Errorf("Cell 1: %q", got)
+	}
+
+	// Accept still inserts the full Text
+	ac.accept(0, false)
+	if edit.GetText() != `C:\tools\app.exe` {
+		t.Errorf("Accept should insert Text, not Display: %q", edit.GetText())
+	}
+}
+
+func TestAutoComplete_AnchoredToTriggerSeparator(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(100, 40)
+	FrameManager.Init(scr)
+
+	old := PathHintProvider
+	defer func() { PathHintProvider = old }()
+	PathHintProvider = func(edit *Edit, word string, from, to int) []AutoCompleteItem {
+		return []AutoCompleteItem{{Text: word + "x", MatchStart: -1, MatchEnd: -1, ReplaceFrom: from, ReplaceTo: to}}
+	}
+
+	edit := NewEdit(10, 10, 40, `run C:\to`)
+	edit.curPos = len([]rune(`run C:\to`))
+	edit.PathHintsEnabled = true
+	ac := NewAutoCompleteMenu(edit)
+	defer ac.Close()
+
+	ax1, _, _, _ := ac.GetPosition()
+	// Trigger separator is at rune 6 (0-based) in "run C:\to"; edit starts at X1=10
+	wantX := edit.X1 + 6
+	if ax1 != wantX {
+		t.Errorf("Menu should anchor at the trigger separator: x1=%d, want %d", ax1, wantX)
+	}
+
+	// Typing more moves the cursor but not the menu
+	edit.SetText(`run C:\tools`)
+	edit.curPos = len([]rune(`run C:\tools`))
+	ac.UpdateMatches()
+	ax1b, _, _, _ := ac.GetPosition()
+	if ax1b != wantX {
+		t.Errorf("Menu drifted while typing: x1=%d, want %d", ax1b, wantX)
+	}
+}
+
+func TestAutoComplete_MaxVisibleAndPerCategory(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(100, 40)
+	FrameManager.Init(scr)
+
+	old := PathHintProvider
+	defer func() { PathHintProvider = old }()
+	defer SetAutoCompleteMaxVisible(5)
+	defer SetAutoCompletePerCategory(false)
+
+	PathHintProvider = func(edit *Edit, word string, from, to int) []AutoCompleteItem {
+		return []AutoCompleteItem{
+			{Text: "p1", MatchStart: -1, MatchEnd: -1},
+			{Text: "p2", MatchStart: -1, MatchEnd: -1},
+			{Text: "p3", MatchStart: -1, MatchEnd: -1},
+			{Text: "p4", MatchStart: -1, MatchEnd: -1},
+		}
+	}
+
+	newMenu := func() *AutoCompleteMenu {
+		edit := NewEdit(0, 10, 40, "x")
+		edit.History = []string{"x1", "x2", "x3"}
+		edit.PathHintsEnabled = true
+		return NewAutoCompleteMenu(edit)
+	}
+
+	// Total mode: one shared window of N rows, no truncation
+	SetAutoCompleteMaxVisible(2)
+	ac := newMenu()
+	if len(ac.items) != 8 { // 4 paths + separator + 3 history
+		t.Errorf("Total mode must not truncate: got %d items", len(ac.items))
+	}
+	_, ay1, _, ay2 := ac.GetPosition()
+	if ay2-ay1+1 != 4 { // 2 visible + frame
+		t.Errorf("Total mode height: got %d, want 4", ay2-ay1+1)
+	}
+	ac.Close()
+
+	// Per-category mode: each group truncated to N, all rows visible
+	SetAutoCompletePerCategory(true)
+	ac = newMenu()
+	defer ac.Close()
+	// 2 paths + separator + 2 history = 5 items
+	if len(ac.items) != 5 {
+		t.Fatalf("Per-category truncation: got %d items, want 5", len(ac.items))
+	}
+	if ac.items[0].Text != "p1" || ac.items[1].Text != "p2" || !ac.items[2].Separator ||
+		ac.items[3].Text != "x1" || ac.items[4].Text != "x2" {
+		t.Errorf("Wrong per-category composition: %v", ac.Matches)
+	}
+	_, ay1, _, ay2 = ac.GetPosition()
+	if ay2-ay1+1 != 7 { // all 5 items + frame
+		t.Errorf("Per-category height: got %d, want 7", ay2-ay1+1)
+	}
+}

--- a/cmd/test-app/main.go
+++ b/cmd/test-app/main.go
@@ -226,20 +226,21 @@ func showTableDialog() {
 
 func buildTableDialog() *vtui.Window {
 	w, h := 78, 22
-	dlg := vtui.NewCenteredDialog(w, h, " Table Demo ")
-	dlg.ShowClose = true
+
+	btnClose := vtui.NewButton(0, 0, "&Close")
 
 	// Name and Description are flexible columns (Width 0): they share the
 	// space left after the fixed columns and follow the dialog on resize.
 	// Name additionally demonstrates MinWidth; without it the title width
 	// would be the minimum.
-	table := vtui.NewTable(dlg.X1+2, dlg.Y1+2, w-4, h-8, []vtui.TableColumn{
+	dlg, table := vtui.NewTableDialog(w, h, " Table Demo ", []vtui.TableColumn{
 		{Title: "Name", MinWidth: 12},
 		{Title: "Type", Width: 8},
 		{Title: "Size", Width: 9, Alignment: vtui.AlignRight},
 		{Title: "Modified", Width: 16},
 		{Title: "Description"},
-	})
+	}, btnClose)
+	btnClose.OnClick = func() { dlg.Close() }
 	table.Sortable = true    // click a column header to sort, again to reverse
 	table.QuickSearch = true // type to fuzzy-filter (Myers bit-vector)
 	table.ShowScrollBar = true
@@ -260,17 +261,11 @@ func buildTableDialog() *vtui.Window {
 		demoTableRow{"config.yaml", "config", "3 KB", "2026-08-03 13:37", "Runtime configuration overrides"},
 		demoTableRow{"changelog.md", "doc", "11 KB", "2026-08-04 15:58", "Release notes since v0.1"},
 	})
-	table.SetGrowMode(vtui.GrowHiX | vtui.GrowHiY)
-	dlg.AddItem(table)
 
-	hint := vtui.NewLabel(dlg.X1+2, dlg.Y1+h-5, "Type to fuzzy-filter, click a header to sort, Esc clears the filter", nil)
+	// The blank row between the table and the button row fits a hint line.
+	hint := vtui.NewLabel(dlg.X1+2, dlg.Y1+h-4, "Type to fuzzy-filter, click a header to sort, Esc clears the filter", nil)
 	hint.SetGrowMode(vtui.GrowLoY | vtui.GrowHiY)
 	dlg.AddItem(hint)
-
-	btnClose := vtui.NewButton(dlg.X1+w/2-5, dlg.Y1+h-3, "&Close")
-	btnClose.OnClick = func() { dlg.Close() }
-	btnClose.SetGrowMode(vtui.GrowLoY | vtui.GrowHiY | vtui.GrowLoX | vtui.GrowHiX)
-	dlg.AddItem(btnClose)
 
 	return dlg
 }

--- a/ebiten_host.go
+++ b/ebiten_host.go
@@ -472,7 +472,8 @@ func (g *ebitenGame) updateMouse(mods vtinput.ControlKeyState) {
 		if steps < 0 {
 			steps = -steps
 		}
-		steps *= getSystemScrollLines()
+		// One wheel notch produces one event; consumers decide how many
+		// lines a notch scrolls (see WheelLinesPerNotch).
 		dir := -1
 		if dy > 0 {
 			dir = 1
@@ -631,6 +632,9 @@ func RunEbitenHost(cols, rows int, fontName string, fontSize float64, setupApp f
 	SetActiveBackend("ebiten",
 		fmt.Sprintf("cell %dx%d, scale %d, font %q", cellW, cellH, scale, fontName),
 		"cgo-free: Ebitengine over purego")
+	// One wheel notch arrives as a single event now; keep widgets scrolling
+	// the system-configured number of lines per notch as before.
+	setWheelNotchLines(getSystemScrollLines())
 
 	ebiten.SetWindowTitle(WindowTitleWithBackend(AppName))
 	ebiten.SetWindowSize(cols*cellW/scale, rows*cellH/scale)

--- a/edit.go
+++ b/edit.go
@@ -36,8 +36,11 @@ type Edit struct {
 	ColorSelectedIdx   int
 	HistoryID          string
 	OnTextChange       func(string)
-	mouseSelecting     bool
-	mouseSelectAnchor  int
+	// PathHintsEnabled lets the autocomplete menu ask PathHintProvider for
+	// file path suggestions in addition to history matches.
+	PathHintsEnabled  bool
+	mouseSelecting    bool
+	mouseSelectAnchor int
 }
 
 // HistoryProvider is an interface for external history persistence (e.g. from f4).
@@ -837,6 +840,15 @@ func (e *Edit) ProcessKey(event *vtinput.InputEvent) bool {
 		if e.OnTextChange != nil {
 			e.OnTextChange(string(e.text))
 		}
+		// Path hints: typing a path separator in an enabled edit opens the
+		// autocomplete menu when the host provider has anything to suggest.
+		if (testChar == '/' || testChar == '\\') && e.PathHintsEnabled && PathHintProvider != nil && FrameManager != nil {
+			if _, isAc := FrameManager.GetTopFrame().(*AutoCompleteMenu); !isAc {
+				if ac := NewAutoCompleteMenu(e); ac.HasMatches() {
+					FrameManager.Push(ac)
+				}
+			}
+		}
 		return true
 	}
 
@@ -1136,6 +1148,29 @@ func (e *Edit) selectWordAtCursor() {
 	e.selAnchor = start
 	e.curPos = end
 	e.clearFlag = false
+}
+
+// WordUnderCursor returns the whitespace-bounded token around the cursor as
+// a rune span [from, to) plus its text. The boundary rule is word_nav's
+// character classification: only the space class (space/tab) terminates the
+// token, so path separators and other divider characters stay inside it.
+func (e *Edit) WordUnderCursor() (from, to int, text string) {
+	cur := e.curPos
+	if cur < 0 {
+		cur = 0
+	}
+	if cur > len(e.text) {
+		cur = len(e.text)
+	}
+	from = cur
+	for from > 0 && getCharCategory(e.text[from-1]) != catSpace {
+		from--
+	}
+	to = cur
+	for to < len(e.text) && getCharCategory(e.text[to]) != catSpace {
+		to++
+	}
+	return from, to, string(e.text[from:to])
 }
 
 func (e *Edit) cursorPositionAtX(x int) int {

--- a/filelist.md
+++ b/filelist.md
@@ -1,196 +1,227 @@
 # Project Structure
 
     .
-    ├── ansi_writer.go
-    ├── ARCHITECTURE.md
-    ├── autocomplete.go
-    ├── autocomplete_test.go
-    ├── automation_test.go
-    ├── bar.go
-    ├── bar_test.go
-    ├── baseframe.go
-    ├── baseframe_test.go
-    ├── basewindow.go
-    ├── basewindow_test.go
-    ├── button.go
-    ├── button_test.go
-    ├── checkbox.go
-    ├── checkbox_test.go
-    ├── checkgroup.go
-    ├── clipboard.go
-    ├── clipboard_test.go
-    ├── clipboard_unix.go
-    ├── clipboard_windows.go
-    ├── clusters_test.go
-    ├── cmd
-    │   └── test-app
-    │       ├── main.go
-    │       └── main_test.go
-    ├── colors.go
-    ├── colors_test.go
-    ├── combobox_color_test.go
-    ├── combobox.go
-    ├── combobox_test.go
-    ├── commands.go
-    ├── common_dialogs.go
-    ├── common_dialogs_test.go
-    ├── crash_report.go
-    ├── crash_report_stub.go
-    ├── crash_report_test.go
-    ├── debug.go
-    ├── debug_test.go
-    ├── desktop.go
-    ├── desktop_test.go
-    ├── dialog_test.go
-    ├── dragdrop.go
-    ├── DRAGDROP.md
-    ├── dragdrop_test.go
-    ├── dynamictext.go
-    ├── dynamictext_test.go
-    ├── edit.go
-    ├── edit_test.go
-    ├── far2l_extensions.go
-    ├── far2l_extensions_test.go
-    ├── filelist_update.sh
-    ├── frame.go
-    ├── framemanager.go
-    ├── framemanager_hidebars_test.go
-    ├── framemanager_test.go
-    ├── fuzzy.go
-    ├── fuzzy_test.go
-    ├── .gitignore
-    ├── gogpu_dnd.go
-    ├── gogpu_dnd_test.go
-    ├── gogpu_host.go
-    ├── gogpu_host_test.go
-    ├── gogpu_renderer.go
-    ├── gogpu_renderer_test.go
-    ├── gogpu_scroll_other.go
-    ├── gogpu_scroll_windows.go
-    ├── gogpu_stub.go
-    ├── go.mod
-    ├── go.sum
-    ├── graphics_frame_test.go
-    ├── graphics.go
-    ├── graphics_image.go
-    ├── graphics_kitty.go
-    ├── graphics_kitty_test.go
-    ├── GRAPHICS.md
-    ├── graphics_native.go
-    ├── graphics_native_test.go
-    ├── graphics_scale.go
-    ├── graphics_test.go
-    ├── grid_nav.go
-    ├── groupbox.go
-    ├── group.go
-    ├── group_test.go
-    ├── grow_test.go
-    ├── gui_api_fallback.go
-    ├── gui_api.go
-    ├── gui_font.go
-    ├── gui_font_test.go
-    ├── help_engine.go
-    ├── help_engine_test.go
-    ├── help_view.go
-    ├── help_view_mouse_test.go
-    ├── help_view_test.go
-    ├── history_test.go
-    ├── keybar.go
-    ├── keybar_test.go
-    ├── label.go
-    ├── label_test.go
-    ├── layout.go
-    ├── LAYOUT.md
-    ├── layout_test.go
-    ├── layout_validator.go
-    ├── layout_validator_test.go
-    ├── LICENSE
-    ├── listbox.go
-    ├── listbox_test.go
-    ├── localization.go
-    ├── localization_test.go
-    ├── menubar.go
-    ├── menubar_test.go
-    ├── multilineedit.go
-    ├── multilineedit_test.go
-    ├── painter.go
-    ├── palette.go
-    ├── palette_test.go
-    ├── progressbar.go
-    ├── progressbar_test.go
-    ├── radiogroup.go
-    ├── radiogroup_test.go
-    ├── README.md
-    ├── REVIEW.md
-    ├── runewidth.go
-    ├── runewidth_test.go
-    ├── screenbuf.go
-    ├── screenbuf_test.go
-    ├── screenobject.go
-    ├── screenobject_test.go
-    ├── screenshot.png
-    ├── scrollbar.go
-    ├── scrollbar_test.go
-    ├── scrollbar_widget_test.go
-    ├── scrollview.go
-    ├── scrollview_test.go
-    ├── semantic.go
-    ├── semantic_test.go
-    ├── separator.go
-    ├── standard_dialogs_layout_test.go
-    ├── statusline.go
-    ├── statusline_test.go
-    ├── strings.go
-    ├── symbols.go
-    ├── sys_darwin.go
-    ├── sys_unix.go
-    ├── sys_windows.go
-    ├── table.go
-    ├── table_test.go
-    ├── tasks.go
-    ├── tasks_test.go
-    ├── terminal_env.go
-    ├── terminal_env_test.go
-    ├── terminal_env_unix.go
-    ├── terminal_env_windows.go
-    ├── testing.go
-    ├── test_main_test.go
-    ├── text.go
-    ├── text_test.go
-    ├── text_utils.go
-    ├── text_utils_test.go
-    ├── treeview.go
-    ├── treeview_test.go
-    ├── types.go
-    ├── UI_TESTING.md
-    ├── UX_GUIDELINES.md
-    ├── validator.go
-    ├── validator_test.go
-    ├── vmenu.go
-    ├── vmenu_test.go
-    ├── vtext.go
-    ├── vtext_test.go
-    ├── vtui_test.go
-    ├── wayland_host.go
-    ├── wayland_host_test.go
-    ├── wayland_renderer.go
-    ├── wayland_stub.go
-    ├── window.go
-    ├── word_nav.go
-    ├── WORDNAV.md
-    ├── word_nav_test.go
-    ├── x11_host.go
-    ├── x11_host_test.go
-    ├── x11_keys_shared.go
-    ├── x11_keys_test.go
-    ├── x11_render_common.go
-    ├── x11_renderer.go
-    ├── x11_shm_fallback.go
-    ├── x11_shm_unix.go
-    ├── x11_xdnd.go
-    ├── x11_xdnd_test.go
-    ├── xlat.go
-    ├── xlat_tables.go
-    └── xlat_test.go
-    
-    3 directories, 189 files
+    ./.gitignore
+    ./AGENTS.md
+    ./ansi_writer.go
+    ./ARCHITECTURE.md
+    ./autocomplete.go
+    ./autocomplete_test.go
+    ./automation_test.go
+    ./backend_info.go
+    ./backend_info_test.go
+    ./bar.go
+    ./bar_test.go
+    ./baseframe.go
+    ./baseframe_test.go
+    ./basewindow.go
+    ./basewindow_test.go
+    ./bidi.go
+    ./bidi_test.go
+    ./button.go
+    ./button_test.go
+    ./cellspan_test.go
+    ./checkbox.go
+    ./checkbox_test.go
+    ./checkgroup.go
+    ./clipboard.go
+    ./clipboard_gui_test.go
+    ./clipboard_test.go
+    ./clipboard_unix.go
+    ./clipboard_windows.go
+    ./clusters_test.go
+    ./cmd
+    ./cmd/test-app
+    ./cmd/test-app/main.go
+    ./cmd/test-app/main_test.go
+    ./cmd/test-app/test-app.exe
+    ./colors.go
+    ./colors_test.go
+    ./combobox.go
+    ./combobox_color_test.go
+    ./combobox_test.go
+    ./commands.go
+    ./common_dialogs.go
+    ./common_dialogs_test.go
+    ./crash_report.go
+    ./crash_report_stub.go
+    ./crash_report_test.go
+    ./debug.go
+    ./debug_test.go
+    ./desktop.go
+    ./desktop_test.go
+    ./dialog_test.go
+    ./dragdrop.go
+    ./DRAGDROP.md
+    ./dragdrop_test.go
+    ./dynamictext.go
+    ./dynamictext_test.go
+    ./ebiten_dragdrop.go
+    ./ebiten_host.go
+    ./ebiten_keys.go
+    ./ebiten_renderer.go
+    ./ebiten_renderer_test.go
+    ./ebiten_stub.go
+    ./edit.go
+    ./edit_test.go
+    ./far2l_extensions.go
+    ./far2l_extensions_test.go
+    ./filelist_update.sh
+    ./frame.go
+    ./framemanager.go
+    ./framemanager_hidebars_test.go
+    ./framemanager_test.go
+    ./fuzzy.go
+    ./fuzzy_test.go
+    ./go.mod
+    ./go.sum
+    ./gogpu_dnd.go
+    ./gogpu_dnd_test.go
+    ./gogpu_host.go
+    ./gogpu_host_test.go
+    ./gogpu_renderer.go
+    ./gogpu_renderer_test.go
+    ./gogpu_scroll_other.go
+    ./gogpu_scroll_windows.go
+    ./gogpu_stub.go
+    ./graphics.go
+    ./GRAPHICS.md
+    ./graphics_frame_test.go
+    ./graphics_image.go
+    ./graphics_kitty.go
+    ./graphics_kitty_test.go
+    ./graphics_native.go
+    ./graphics_native_test.go
+    ./graphics_scale.go
+    ./graphics_test.go
+    ./grid_nav.go
+    ./group.go
+    ./groupbox.go
+    ./group_test.go
+    ./grow_test.go
+    ./gui_api.go
+    ./gui_api_fallback.go
+    ./gui_boxdraw.go
+    ./gui_boxdraw_test.go
+    ./gui_font.go
+    ./gui_font_test.go
+    ./help_engine.go
+    ./help_engine_test.go
+    ./help_view.go
+    ./help_view_mouse_test.go
+    ./help_view_test.go
+    ./highlight.go
+    ./highlight_test.go
+    ./history_test.go
+    ./keybar.go
+    ./keybar_test.go
+    ./keys_common.go
+    ./keys_common_test.go
+    ./label.go
+    ./label_test.go
+    ./layout.go
+    ./LAYOUT.md
+    ./layout_test.go
+    ./layout_validator.go
+    ./layout_validator_test.go
+    ./LICENSE
+    ./listbox.go
+    ./listbox_test.go
+    ./localization.go
+    ./localization_test.go
+    ./menubar.go
+    ./menubar_test.go
+    ./multilineedit.go
+    ./multilineedit_test.go
+    ./painter.go
+    ./palette.go
+    ./palette_test.go
+    ./panic_bridge.go
+    ./panic_bridge_test.go
+    ./progressbar.go
+    ./progressbar_test.go
+    ./radiogroup.go
+    ./radiogroup_test.go
+    ./README.md
+    ./REVIEW.md
+    ./runewidth.go
+    ./runewidth_test.go
+    ./screenbuf.go
+    ./screenbuf_test.go
+    ./screenobject.go
+    ./screenobject_test.go
+    ./screenshot.png
+    ./scrollbar.go
+    ./scrollbar_test.go
+    ./scrollbar_widget_test.go
+    ./scrollview.go
+    ./scrollview_test.go
+    ./semantic.go
+    ./semantic_test.go
+    ./separator.go
+    ./standard_dialogs_layout_test.go
+    ./statusline.go
+    ./statusline_test.go
+    ./strings.go
+    ./symbols.go
+    ./sys_darwin.go
+    ./sys_unix.go
+    ./sys_windows.go
+    ./table.go
+    ./table_dialog.go
+    ./table_dialog_test.go
+    ./table_test.go
+    ./tasks.go
+    ./tasks_test.go
+    ./terminal_env.go
+    ./terminal_env_test.go
+    ./terminal_env_unix.go
+    ./terminal_env_windows.go
+    ./test-app.exe
+    ./testing.go
+    ./test_main_test.go
+    ./text.go
+    ./textseg.go
+    ./TEXTSEG.md
+    ./textseg_test.go
+    ./text_test.go
+    ./text_utils.go
+    ./text_utils_test.go
+    ./treeview.go
+    ./treeview_test.go
+    ./types.go
+    ./UI_TESTING.md
+    ./UNICODE_PLAN.md
+    ./UX_GUIDELINES.md
+    ./validator.go
+    ./validator_test.go
+    ./vmenu.go
+    ./vmenu_test.go
+    ./vtext.go
+    ./vtext_test.go
+    ./vtui_test.go
+    ./wayland_host.go
+    ./wayland_host_test.go
+    ./wayland_renderer.go
+    ./wayland_stub.go
+    ./wheel_scroll.go
+    ./wheel_scroll_test.go
+    ./WIDTH_NEGOTIATION.md
+    ./window.go
+    ./WORDNAV.md
+    ./word_nav.go
+    ./word_nav_test.go
+    ./workspace_altnumber_test.go
+    ./x11_host.go
+    ./x11_host_test.go
+    ./x11_keys_shared.go
+    ./x11_keys_test.go
+    ./x11_renderer.go
+    ./x11_render_common.go
+    ./x11_shm_fallback.go
+    ./x11_shm_unix.go
+    ./x11_xdnd.go
+    ./x11_xdnd_test.go
+    ./xlat.go
+    ./xlat_tables.go
+    ./xlat_test.go

--- a/filelist.md
+++ b/filelist.md
@@ -113,6 +113,10 @@
     ./highlight.go
     ./highlight_test.go
     ./history_test.go
+    ./internal
+    ./internal/hideconsole
+    ./internal/hideconsole/go.mod
+    ./internal/hideconsole/hideconsole.go
     ./keybar.go
     ./keybar_test.go
     ./keys_common.go

--- a/fuzzy.go
+++ b/fuzzy.go
@@ -266,3 +266,26 @@ func isASCIIString(s string) bool {
 	}
 	return true
 }
+
+// FuzzyMatcher is the exported handle over the Myers bit-vector matcher for
+// applications embedding vtui (Table.QuickSearch uses the unexported one).
+// Construction precomputes the needle tables once; Match is then linear in
+// the text length per candidate.
+type FuzzyMatcher struct{ fm *fuzzyMatcher }
+
+// NewFuzzyMatcher builds a matcher for needle, or nil for an empty needle.
+// The acceptance threshold is len(needle)/3 errors: exact substring matches
+// always pass, longer needles tolerate more typos.
+func NewFuzzyMatcher(needle string, caseSensitive bool) *FuzzyMatcher {
+	if fm := newFuzzyMatcher(needle, caseSensitive); fm != nil {
+		return &FuzzyMatcher{fm: fm}
+	}
+	return nil
+}
+
+// Match reports the best match of the needle inside text: the edit distance
+// score and the matched span as rune indices, end inclusive. ok is false
+// when the best distance exceeds the acceptance threshold.
+func (m *FuzzyMatcher) Match(text string) (score, start, end int, ok bool) {
+	return m.fm.match(text)
+}

--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -443,8 +443,9 @@ func RunGogpuHost(cols, rows int, fontName string, fontSize float64, setupApp fu
 
 		mx, my := app.Input().Mouse().Position()
 
-		// Multiply scroll lines to match preferred user experience
-		steps := int(math.Abs(dy) * float64(getSystemScrollLines()))
+		// One wheel notch produces one event; consumers decide how many
+		// lines a notch scrolls (see WheelLinesPerNotch).
+		steps := int(math.Abs(dy))
 		if steps == 0 {
 			return
 		}
@@ -516,6 +517,9 @@ func RunGogpuHost(cols, rows int, fontName string, fontSize float64, setupApp fu
 	// After setupApp: the application installs the debug log sink during
 	// setup, so a backend announced before it is logged nowhere.
 	SetActiveBackend("gogpu")
+	// One wheel notch arrives as a single event now; keep widgets scrolling
+	// the system-configured number of lines per notch as before.
+	setWheelNotchLines(getSystemScrollLines())
 
 	go func() {
 		w, h := app.Size()

--- a/help_view.go
+++ b/help_view.go
@@ -402,9 +402,9 @@ func (hv *HelpView) ProcessMouse(e *vtinput.InputEvent) bool {
 
 	if e.WheelDirection != 0 {
 		if e.WheelDirection > 0 {
-			hv.scrollBy(-1)
+			hv.scrollBy(-WheelLinesPerNotch())
 		} else {
-			hv.scrollBy(1)
+			hv.scrollBy(WheelLinesPerNotch())
 		}
 		return true
 	}

--- a/layout.go
+++ b/layout.go
@@ -115,6 +115,12 @@ func (h *HBoxLayout) SetPosition(x1, y1, x2, y2 int) {
 	h.ScreenObject.SetPosition(x1, y1, x2, y2)
 	h.X, h.Y = x1, y1
 	h.W, h.H = x2-x1+1, y2-y1+1
+	// Re-layout children, so alignment (e.g. a centered button row) survives
+	// window resizes when the layout is a real window item with grow flags.
+	// Apply is a pure function of X/Y/W/H and item sizes: idempotent.
+	if len(h.Items) > 0 {
+		h.Apply()
+	}
 }
 
 func (h *HBoxLayout) MoveRelative(dx, dy int) {

--- a/layout_validator.go
+++ b/layout_validator.go
@@ -81,6 +81,20 @@ func ValidateLayoutWithRules(c Container, rules LayoutRules) []error {
 	var errs []error
 	items := c.GetChildren()
 
+	// Layout containers are invisible geometry helpers, not paintable
+	// widgets: they cannot overlap anything and need no air or clearance.
+	// Their children are window items in their own right and are validated
+	// directly.
+	filtered := make([]UIElement, 0, len(items))
+	for _, it := range items {
+		switch it.(type) {
+		case *VBoxLayout, *HBoxLayout:
+			continue
+		}
+		filtered = append(filtered, it)
+	}
+	items = filtered
+
 	// Determine parent bounds
 	px1, py1, px2, py2 := 0, 0, 0, 0
 	hasBounds := false

--- a/multilineedit.go
+++ b/multilineedit.go
@@ -416,9 +416,15 @@ func (m *MultiLineEdit) ProcessMouse(event *vtinput.InputEvent) bool {
 	}
 	if event.WheelDirection != 0 {
 		if event.WheelDirection > 0 && m.topPos > 0 {
-			m.topPos--
+			m.topPos -= WheelLinesPerNotch()
+			if m.topPos < 0 {
+				m.topPos = 0
+			}
 		} else if event.WheelDirection < 0 && m.topPos+1 <= len(m.lines)-1 {
-			m.topPos++
+			m.topPos += WheelLinesPerNotch()
+			if maxTop := len(m.lines) - 1; m.topPos > maxTop {
+				m.topPos = maxTop
+			}
 		}
 		return true
 	}

--- a/scrollview.go
+++ b/scrollview.go
@@ -21,6 +21,10 @@ type ScrollView struct {
 	MarginLeft   int
 	MarginRight  int
 
+	// WheelArea selects which configurable wheel scroll speed applies to
+	// this view (see SetWheelAreaLines). Zero value: WheelAreaList.
+	WheelArea WheelArea
+
 	OnSelect func(int)
 	OnAction func(int)
 }
@@ -104,10 +108,10 @@ func (sv *ScrollView) HandleMouseScroll(e *vtinput.InputEvent) bool {
 	}
 	if e.WheelDirection != 0 {
 		if e.WheelDirection > 0 {
-			sv.ScrollBy(-1)
+			sv.ScrollBy(-wheelLinesFor(sv.WheelArea, e.WheelDirection))
 			return true
 		} else if e.WheelDirection < 0 {
-			sv.ScrollBy(1)
+			sv.ScrollBy(wheelLinesFor(sv.WheelArea, e.WheelDirection))
 			return true
 		}
 	}

--- a/table_dialog.go
+++ b/table_dialog.go
@@ -1,0 +1,87 @@
+package vtui
+
+import "fmt"
+
+// NewTableDialog creates a centered modal dialog whose body is a single
+// elastic table with a button row underneath: the recurring "table with a
+// toolbar" pattern. The table stretches with the window; the button row
+// stays centered and anchored to the bottom edge, even after resizes.
+//
+// At least one column must be flexible (Width 0), otherwise the table
+// cannot follow the window width and the function panics. The window is
+// not allowed to shrink narrower than the button row.
+//
+// Behavioral options (Sortable, QuickSearch, colors, rows, handlers) stay
+// with the caller.
+func NewTableDialog(width, height int, title string, columns []TableColumn, buttons ...*Button) (*Window, *Table) {
+	dlg := NewCenteredDialog(width, height, title)
+	dlg.ShowClose = true
+	table := NewTableWithButtons(&dlg.BaseWindow, columns, buttons...)
+	return dlg, table
+}
+
+// NewTableWithButtons is the window-agnostic core of NewTableDialog: it
+// lays out an elastic table with a centered button row at the bottom of an
+// existing window, adds both to it and returns the table.
+//
+// BaseWindow.AddItem derives the minimum window size from item positions,
+// which for a full-width table would pin the minimum at the initial size.
+// This helper overrides both minima: the window may shrink until the button
+// row no longer fits horizontally and a header plus one data row no longer
+// fits vertically.
+func NewTableWithButtons(win *BaseWindow, columns []TableColumn, buttons ...*Button) *Table {
+	flexible := false
+	for _, c := range columns {
+		if c.Width <= 0 {
+			flexible = true
+			break
+		}
+	}
+	if !flexible {
+		panic(fmt.Sprintf("vtui.NewTableWithButtons: window %q needs at least one flexible column (Width 0)", win.frame.title))
+	}
+
+	width := win.X2 - win.X1 + 1
+	height := win.Y2 - win.Y1 + 1
+
+	// Button row: a centered HBox added as a real window item. On resize the
+	// group's Resize moves it (GrowLoY|GrowHiY) and stretches it (GrowHiX),
+	// and HBoxLayout.SetPosition re-centers the buttons inside. The buttons
+	// themselves keep GrowNone: the row owns their position absolutely.
+	const spacing = 2
+	totalW := 0
+	for _, b := range buttons {
+		bx1, _, bx2, _ := b.GetPosition()
+		totalW += bx2 - bx1 + 1
+	}
+	if len(buttons) > 1 {
+		totalW += spacing * (len(buttons) - 1)
+	}
+	btnY := win.Y1 + height - 3
+	hbox := NewHBoxLayout(win.X1+2, btnY, width-4, 1)
+	hbox.HorizontalAlign = AlignCenter
+	hbox.Spacing = spacing
+	for _, b := range buttons {
+		hbox.Add(b, Margins{}, AlignTop)
+	}
+	hbox.Apply()
+	hbox.SetGrowMode(GrowLoY | GrowHiY | GrowHiX)
+
+	// Table: fills everything above the button row, one blank row apart,
+	// and follows the window on resize. It is added before the buttons so
+	// it gets the initial focus.
+	table := NewTable(win.X1+2, win.Y1+2, width-4, height-6, columns)
+	table.SetGrowMode(GrowHiX | GrowHiY)
+	win.AddItem(table)
+	win.AddItem(hbox)
+	for _, b := range buttons {
+		win.AddItem(b)
+	}
+
+	// See the doc comment: the button row sets the horizontal floor, a
+	// header plus one data row the vertical one.
+	win.MinW = totalW + 4
+	win.MinH = 8
+
+	return table
+}

--- a/table_dialog_test.go
+++ b/table_dialog_test.go
@@ -1,0 +1,141 @@
+package vtui
+
+import "testing"
+
+func tableDialogFixture(t *testing.T) (*Window, *Table) {
+	t.Helper()
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(100, 40)
+	FrameManager.Init(scr)
+
+	btnA := NewButton(0, 0, "&Alpha")
+	btnB := NewButton(0, 0, "&Beta")
+	dlg, table := NewTableDialog(60, 20, " Test ", []TableColumn{
+		{Title: "ID", Width: 4},
+		{Title: "Name"},
+	}, btnA, btnB)
+	return dlg, table
+}
+
+func TestNewTableDialogLayout(t *testing.T) {
+	dlg, table := tableDialogFixture(t)
+
+	dx1, dy1, dx2, dy2 := dlg.GetPosition()
+	tx1, ty1, tx2, ty2 := table.GetPosition()
+	if tx1 != dx1+2 || ty1 != dy1+2 {
+		t.Errorf("Table origin: got (%d,%d), want (%d,%d)", tx1, ty1, dx1+2, dy1+2)
+	}
+	if tx2 != dx2-2 {
+		t.Errorf("Table right edge: got %d, want %d", tx2, dx2-2)
+	}
+	// One blank row between the table and the button row
+	btnY := dy2 - 2
+	if ty2 != btnY-2 {
+		t.Errorf("Table bottom: got %d, want %d (button row %d)", ty2, btnY-2, btnY)
+	}
+
+	// Buttons: bottom interior row, centered as a row with spacing 2
+	var items []UIElement
+	for _, it := range dlg.rootGroup.items {
+		if b, ok := it.(*Button); ok {
+			items = append(items, b)
+		}
+	}
+	if len(items) != 2 {
+		t.Fatalf("Expected 2 buttons in dialog, got %d", len(items))
+	}
+	b1x1, b1y1, b1x2, _ := items[0].GetPosition()
+	b2x1, b2y1, b2x2, _ := items[1].GetPosition()
+	if b1y1 != btnY || b2y1 != btnY {
+		t.Errorf("Buttons not on the bottom interior row: y1=%d,%d want %d", b1y1, b2y1, btnY)
+	}
+	if b2x1-b1x2-1 != 2 {
+		t.Errorf("Button spacing: got %d, want 2", b2x1-b1x2-1)
+	}
+	rowW := b2x2 - b1x1 + 1
+	leftPad := b1x1 - (dx1 + 2)
+	rightPad := (dx2 - 2) - b2x2
+	if leftPad != rightPad && leftPad != rightPad-1 {
+		t.Errorf("Button row not centered: left pad %d, right pad %d (row width %d)", leftPad, rightPad, rowW)
+	}
+
+	// Grow modes: table stretches, the button row container sticks to the
+	// bottom and grows horizontally; buttons themselves are owned by the row.
+	if table.GetGrowMode() != (GrowHiX | GrowHiY) {
+		t.Errorf("Table grow mode: got %#x, want GrowHiX|GrowHiY", table.GetGrowMode())
+	}
+	var row *HBoxLayout
+	for _, it := range dlg.rootGroup.items {
+		if h, ok := it.(*HBoxLayout); ok {
+			row = h
+		}
+	}
+	if row == nil {
+		t.Fatal("Button row HBoxLayout is not a dialog item")
+	}
+	if row.GetGrowMode() != (GrowLoY | GrowHiY | GrowHiX) {
+		t.Errorf("Button row grow mode: got %#x, want GrowLoY|GrowHiY|GrowHiX", row.GetGrowMode())
+	}
+}
+
+func TestNewTableDialogButtonsStayCenteredOnResize(t *testing.T) {
+	dlg, _ := tableDialogFixture(t)
+	dx1, _, _, _ := dlg.GetPosition()
+
+	centered := func(w int) bool {
+		var btns []UIElement
+		for _, it := range dlg.rootGroup.items {
+			if b, ok := it.(*Button); ok {
+				btns = append(btns, b)
+			}
+		}
+		b1x1, _, _, _ := btns[0].GetPosition()
+		_, _, b2x2, _ := btns[1].GetPosition()
+		leftPad := b1x1 - (dx1 + 2)
+		rightPad := (dx1 + w - 3) - b2x2
+		return leftPad == rightPad || leftPad == rightPad-1
+	}
+
+	if !centered(60) {
+		t.Fatal("Button row not centered initially")
+	}
+	dlg.ChangeSize(80, 20)
+	if !centered(80) {
+		t.Error("Button row lost centering after growing the dialog")
+	}
+	dlg.ChangeSize(40, 20)
+	if !centered(40) {
+		t.Error("Button row lost centering after shrinking the dialog")
+	}
+}
+
+func TestNewTableDialogMinWidth(t *testing.T) {
+	dlg, _ := tableDialogFixture(t)
+	// "[ Alpha ]"=9 + spacing 2 + "[ Beta ]"=8 = 19, plus 4 for frame and padding
+	if dlg.MinW != 23 {
+		t.Errorf("MinW: got %d, want 23", dlg.MinW)
+	}
+}
+
+func TestNewTableDialogRequiresFlexibleColumn(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(100, 40)
+	FrameManager.Init(scr)
+
+	defer func() {
+		if recover() == nil {
+			t.Error("Expected panic when all columns are fixed-width")
+		}
+	}()
+	NewTableDialog(60, 20, " Test ", []TableColumn{
+		{Title: "ID", Width: 4},
+		{Title: "Name", Width: 20},
+	}, NewButton(0, 0, "&Ok"))
+}
+
+func TestNewTableDialogPassesValidator(t *testing.T) {
+	dlg, _ := tableDialogFixture(t)
+	AssertLayout(t, dlg)
+}

--- a/vmenu.go
+++ b/vmenu.go
@@ -59,6 +59,7 @@ func NewVMenu(title string) *VMenu {
 	}
 	m.canFocus = true
 	m.Wrap = true
+	m.WheelArea = WheelAreaMenu
 	m.IsSelectable = func(i int) bool {
 		return i >= 0 && i < len(m.Items) && !m.Items[i].Separator
 	}

--- a/wheel_scroll.go
+++ b/wheel_scroll.go
@@ -1,0 +1,80 @@
+package vtui
+
+// wheelNotchLines is how many text lines one wheel notch scrolls in vtui
+// widgets. It defaults to 1: terminal, X11 and Wayland backends deliver one
+// wheel event per notch and historically scrolled a single line. GUI hosts
+// that used to expand one notch into several events (gogpu, ebiten) set it
+// to the system setting on startup, preserving their previous behavior now
+// that the expansion moved from hosts to consumers.
+var wheelNotchLines = 1
+
+// WheelLinesPerNotch returns how many text lines one wheel notch scrolls.
+// Applications embedding vtui widgets should use this value for their own
+// wheel handling so the behavior stays consistent with the widgets.
+func WheelLinesPerNotch() int {
+	return wheelNotchLines
+}
+
+// setWheelNotchLines sets the per-notch scroll amount. Values below 1 are
+// ignored. Called by GUI hosts on startup.
+func setWheelNotchLines(n int) {
+	if n >= 1 {
+		wheelNotchLines = n
+	}
+}
+
+// GetWheelScrollLines returns the operating system's "lines per wheel notch"
+// setting, or 3 on platforms that have no such setting.
+func GetWheelScrollLines() int {
+	return getSystemScrollLines()
+}
+
+// WheelArea identifies a class of widgets whose wheel scroll speed can be
+// overridden independently by the embedding application.
+type WheelArea int
+
+const (
+	// WheelAreaList covers tables, list boxes and generic scroll views.
+	// It is the zero value, so an untouched ScrollView lands here.
+	WheelAreaList WheelArea = iota
+	// WheelAreaMenu covers vertical menus (VMenu, including ComboBox
+	// dropdowns).
+	WheelAreaMenu
+	wheelAreaCount
+)
+
+// wheelAreaLines holds per-area overrides: [area][0] = up, [area][1] = down.
+// A zero entry means "follow WheelLinesPerNotch".
+var wheelAreaLines [wheelAreaCount][2]int
+
+// SetWheelAreaLines overrides the wheel scroll speed (lines per notch) for a
+// widget area, separately for the up and down directions. A value of 0
+// restores the default behavior (follow WheelLinesPerNotch).
+func SetWheelAreaLines(area WheelArea, up, down int) {
+	if area < 0 || area >= wheelAreaCount {
+		return
+	}
+	if up < 0 {
+		up = 0
+	}
+	if down < 0 {
+		down = 0
+	}
+	wheelAreaLines[area][0] = up
+	wheelAreaLines[area][1] = down
+}
+
+// wheelLinesFor resolves the lines to scroll for a wheel event in the given
+// area. direction > 0 means wheel up (scroll back), < 0 means wheel down.
+func wheelLinesFor(area WheelArea, direction int) int {
+	if area >= 0 && area < wheelAreaCount {
+		v := wheelAreaLines[area][1]
+		if direction > 0 {
+			v = wheelAreaLines[area][0]
+		}
+		if v > 0 {
+			return v
+		}
+	}
+	return wheelNotchLines
+}

--- a/wheel_scroll_test.go
+++ b/wheel_scroll_test.go
@@ -1,0 +1,71 @@
+package vtui
+
+import "testing"
+
+func TestWheelLinesPerNotchDefault(t *testing.T) {
+	if got := WheelLinesPerNotch(); got != 1 {
+		t.Errorf("Expected default of 1 line per notch, got %d", got)
+	}
+}
+
+func TestSetWheelNotchLines(t *testing.T) {
+	old := WheelLinesPerNotch()
+	defer setWheelNotchLines(old)
+
+	setWheelNotchLines(5)
+	if got := WheelLinesPerNotch(); got != 5 {
+		t.Errorf("Expected 5 lines per notch, got %d", got)
+	}
+
+	// Values below 1 are ignored
+	setWheelNotchLines(0)
+	setWheelNotchLines(-3)
+	if got := WheelLinesPerNotch(); got != 5 {
+		t.Errorf("Expected values below 1 to be ignored, got %d", got)
+	}
+}
+
+func TestGetWheelScrollLines(t *testing.T) {
+	if got := GetWheelScrollLines(); got <= 0 {
+		t.Errorf("Expected positive system scroll lines, got %d", got)
+	}
+}
+
+func TestWheelAreaOverrides(t *testing.T) {
+	defer SetWheelAreaLines(WheelAreaMenu, 0, 0)
+	defer SetWheelAreaLines(WheelAreaList, 0, 0)
+
+	// Defaults: fall back to the per-notch value
+	if got := wheelLinesFor(WheelAreaMenu, 1); got != WheelLinesPerNotch() {
+		t.Errorf("Expected default up to be %d, got %d", WheelLinesPerNotch(), got)
+	}
+	if got := wheelLinesFor(WheelAreaList, -1); got != WheelLinesPerNotch() {
+		t.Errorf("Expected default down to be %d, got %d", WheelLinesPerNotch(), got)
+	}
+
+	SetWheelAreaLines(WheelAreaMenu, 2, 5)
+	if got := wheelLinesFor(WheelAreaMenu, 1); got != 2 {
+		t.Errorf("Expected menu up 2, got %d", got)
+	}
+	if got := wheelLinesFor(WheelAreaMenu, -1); got != 5 {
+		t.Errorf("Expected menu down 5, got %d", got)
+	}
+	// Other area is unaffected
+	if got := wheelLinesFor(WheelAreaList, -1); got != WheelLinesPerNotch() {
+		t.Errorf("Expected list down to stay %d, got %d", WheelLinesPerNotch(), got)
+	}
+
+	// Zero restores the default; negative clamps to zero; bad area is ignored
+	SetWheelAreaLines(WheelAreaMenu, -1, 0)
+	if got := wheelLinesFor(WheelAreaMenu, 1); got != WheelLinesPerNotch() {
+		t.Errorf("Expected menu up restored to %d, got %d", WheelLinesPerNotch(), got)
+	}
+	SetWheelAreaLines(wheelAreaCount, 9, 9) // must not panic
+}
+
+func TestVMenuUsesMenuWheelArea(t *testing.T) {
+	m := NewVMenu("Test")
+	if m.WheelArea != WheelAreaMenu {
+		t.Errorf("Expected VMenu.WheelArea to be WheelAreaMenu, got %d", m.WheelArea)
+	}
+}


### PR DESCRIPTION
### Mouse wheel scroll speed

* gogpu/ebiten hosts no longer expand one wheel notch into N events; consumers scroll WheelLinesPerNotch() lines per event (system setting in GUI hosts, 1 elsewhere — same effective behavior as before).
* `SetWheelAreaLines(area, up, down)` overrides the speed per widget area (menus, tables/lists) and per direction; `ScrollView`/`MultiLineEdit`/`HelpView` honor it; `VMenu` reports `WheelAreaMenu`.

### Table-with-toolbar dialog helper
* `NewTableDialog()` / `NewTableWithButtons()`: elastic table + centered button row in one call. Table stretches with the window; button row stays centered and bottom-anchored; window can't shrink narrower than the button row (`MinW`/`MinH` override — previously AddItem pinned the minimum to the initial size); panics when no column is flexible.
 * HBoxLayout.SetPosition re-applies its layout, so centered rows survive window resizes; the layout validator skips invisible layout containers.
 
### Fuzzy matcher
 * `FuzzyMatcher` is now exported (`NewFuzzyMatcher`/`Match`) — the same Myers bit-vector engine that powers `Table.QuickSearch`.

### Autocomplete menu generalization

 * `AutoCompleteItem`: display text separate from insert text, per-item foreground, non-selectable separators, needle highlight spans, per-item replace spans, multi-column items (flexible main column, fixed extras).
 * Menu positions next to the edit — anchored to the trigger separator for path hints, at the cursor otherwise; flip above at screen bottom; height capped by `SetAutoCompleteMaxVisible`, with optional per-category row budget (`SetAutoCompletePerCategory`).
 * `Edit.WordUnderCursor()` (word_nav space-class boundaries), `Edit.PathHintsEnabled`, global `PathHintProvider`; typing `/` or `\` in an enabled edit opens the menu. Legacy history behavior (prefix match, Tab/Enter/Shift+Del, Enter injection) unchanged — all existing tests green.