### PR TITLE
Add compact workspace type markers

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -92,6 +92,12 @@ type WorkspaceTabTitleProvider interface {
 	GetWorkspaceTabTitle() string
 }
 
+// WorkspaceTabMarkerProvider exposes a short workspace-type marker that is
+// rendered separately from the title so it can use a subdued foreground.
+type WorkspaceTabMarkerProvider interface {
+	GetWorkspaceTabMarker() string
+}
+
 // WorkspaceMenuInfo describes the richer, full-width representation of a
 // workspace used by the Screens popup. Secondary is shown as an aligned second
 // column when present (for example, the right panel path).
@@ -115,7 +121,22 @@ func (s *AppScreen) GetTitle() string {
 	return strings.TrimSpace(s.Frames[len(s.Frames)-1].GetTitle())
 }
 
-func (s *AppScreen) GetTabTitle() string {
+// GetWorkspaceTitle returns the title of the active non-modal frame. Menus and
+// dialogs are transient overlays and must not replace the host terminal's tab
+// title while they are open.
+func (s *AppScreen) GetWorkspaceTitle() string {
+	for i := len(s.Frames) - 1; i >= 0; i-- {
+		if s.Frames[i].IsModal() {
+			continue
+		}
+		if title := strings.TrimSpace(s.Frames[i].GetTitle()); title != "" {
+			return title
+		}
+	}
+	return s.GetTitle()
+}
+
+func (s *AppScreen) getTabContentTitle() string {
 	for i := len(s.Frames) - 1; i >= 0; i-- {
 		if provider, ok := s.Frames[i].(WorkspaceTabTitleProvider); ok {
 			if title := strings.TrimSpace(provider.GetWorkspaceTabTitle()); title != "" {
@@ -124,6 +145,25 @@ func (s *AppScreen) GetTabTitle() string {
 		}
 	}
 	return s.GetTitle()
+}
+
+func (s *AppScreen) GetTabMarker() string {
+	for i := len(s.Frames) - 1; i >= 0; i-- {
+		if provider, ok := s.Frames[i].(WorkspaceTabMarkerProvider); ok {
+			if marker := strings.TrimSpace(provider.GetWorkspaceTabMarker()); marker != "" {
+				return marker
+			}
+		}
+	}
+	return ""
+}
+
+func (s *AppScreen) GetTabTitle() string {
+	title := s.getTabContentTitle()
+	if marker := s.GetTabMarker(); marker != "" {
+		return marker + " " + title
+	}
+	return title
 }
 
 func (s *AppScreen) GetMenuInfo() WorkspaceMenuInfo {
@@ -1132,11 +1172,16 @@ func (fm *frameManager) drawWorkspaceTabs() {
 
 		number := strconv.Itoa(screen.Number)
 		numberWidth := runewidth.StringWidth(number)
+		marker := screen.GetTabMarker()
+		markerWidth := runewidth.StringWidth(marker)
 		titleWidth := maxTabWidth - numberWidth - 3
+		if markerWidth > 0 {
+			titleWidth -= markerWidth
+		}
 		if titleWidth < 0 {
 			titleWidth = 0
 		}
-		title := TruncateMiddle(screen.GetTabTitle(), titleWidth)
+		title := TruncateMiddle(screen.getTabContentTitle(), titleWidth)
 
 		attr := baseAttr
 		if i == fm.ActiveIdx {
@@ -1153,6 +1198,10 @@ func (fm *frameManager) drawWorkspaceTabs() {
 		x++
 		fm.scr.Write(x, 0, StringToCharInfo(number, numberAttr))
 		x += numberWidth
+		if marker != "" && x < tabsLimit {
+			fm.scr.Write(x, 0, StringToCharInfo(marker, workspaceTitleSeparatorAttr(attr)))
+			x += markerWidth
+		}
 		if title != "" && x < tabsLimit {
 			parts := strings.Split(" "+title, "─")
 			for partIndex, part := range parts {

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -17,6 +17,7 @@ type mockFrame struct {
 	onProcessKey       func(e *vtinput.InputEvent) bool
 	onHandleCommand    func(cmd int, args any) bool
 	tabTitle           string
+	tabMarker          string
 	resizedW, resizedH int
 }
 
@@ -55,6 +56,22 @@ func (m *mockFrame) HandleCommand(cmd int, args any) bool {
 func (m *mockFrame) GetType() FrameType           { return TypeUser }
 func (m *mockFrame) GetTitle() string             { return "MockFrame" }
 func (m *mockFrame) GetWorkspaceTabTitle() string { return m.tabTitle }
+func (m *mockFrame) GetWorkspaceTabMarker() string {
+	return m.tabMarker
+}
+
+func TestAppScreen_GetWorkspaceTitleIgnoresModalFrames(t *testing.T) {
+	workspace := newMockFrame(0, 0, 40, 20, false)
+	menu := NewVMenu("Commands")
+	screen := &AppScreen{Frames: []Frame{workspace, menu}}
+
+	if got := screen.GetTitle(); got != "Commands" {
+		t.Fatalf("top-frame title = %q, want transient menu title", got)
+	}
+	if got := screen.GetWorkspaceTitle(); got != "MockFrame" {
+		t.Fatalf("workspace title = %q, want underlying frame title", got)
+	}
+}
 
 func TestFrameManager_DuplicateMouseMoveDoesNotHoverNewMenu(t *testing.T) {
 	oldFM := FrameManager
@@ -1712,7 +1729,10 @@ func TestFrameManager_WorkspaceTabsAndCounterRendering(t *testing.T) {
 	scr.AllocBuf(60, 10)
 	fm := &frameManager{}
 	fm.Init(scr)
-	fm.Push(NewWindow(0, 0, 20, 5, "Panels ─ Files"))
+	panels := newMockFrame(0, 0, 20, 5, false)
+	panels.tabTitle = "Panels ─ Files"
+	panels.tabMarker = "P"
+	fm.Push(panels)
 	fm.AddScreen(NewWindow(0, 0, 20, 5, "Editor"))
 	fm.ConfigureWorkspaceTabs(WorkspaceTabsMultiple, WorkspaceCtrlTabDirect)
 	fm.ConfigureWorkspaceTabColors(
@@ -1729,7 +1749,7 @@ func TestFrameManager_WorkspaceTabsAndCounterRendering(t *testing.T) {
 		row.WriteRune(rune(scr.GetCell(x, 0).Char))
 	}
 	text := row.String()
-	if !strings.Contains(text, "1 Panels") || !strings.Contains(text, "2 Editor") {
+	if !strings.Contains(text, "1P Panels") || !strings.Contains(text, "2 Editor") {
 		t.Fatalf("tab row does not contain both workspaces: %q", text)
 	}
 	if !strings.Contains(text, "Files │ 2 Editor") {
@@ -1760,6 +1780,13 @@ func TestFrameManager_WorkspaceTabsAndCounterRendering(t *testing.T) {
 	}
 	if got := GetRGBFore(scr.GetCell(titleSeparatorX, 0).Attributes); got != 0x5D5D5D {
 		t.Fatalf("workspace title separator foreground = %#x, want half-brightness %#x", got, uint32(0x5D5D5D))
+	}
+	typeMarkerX := strings.Index(text, "P Panels")
+	if typeMarkerX < 0 {
+		t.Fatalf("workspace type marker is missing: %q", text)
+	}
+	if got := GetRGBFore(scr.GetCell(typeMarkerX, 0).Attributes); got != 0x5D5D5D {
+		t.Fatalf("workspace type marker foreground = %#x, want half-brightness %#x", got, uint32(0x5D5D5D))
 	}
 	counterCurrentX := scr.width - runewidth.StringWidth("[2/2]") + 1
 	if tabFG, counterFG := GetRGBFore(scr.GetCell(fm.workspaceTabHits[0].x1+1, 0).Attributes), GetRGBFore(scr.GetCell(counterCurrentX, 0).Attributes); tabFG != counterFG {


### PR DESCRIPTION
## Summary
- add a dedicated workspace tab marker provider for compact type labels
- render type markers separately with the existing dimmed separator styling
- place the marker directly after the tab number (for example, 1P)
- expose a stable workspace title that ignores transient modal menus and dialogs

## Tests
- go test . -run TestWorkspace (focused workspace tests pass)

The full Windows suite still hits the pre-existing TestDebugLog_Rotation locked-file cleanup failure.