### PR TITLE
Separate Cmd and physical Ctrl onto their own Ctrl channels in the gogpu backend

### DIFF
--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -47,13 +47,12 @@ type GogpuHost struct {
 	// handled. A keypad key in navigation mode has already been delivered as
 	// a virtual key, and some platforms hand us its digit anyway.
 	suppressTextInput bool
-	lCtrl, rCtrl      bool
-	lAlt, rAlt        bool
-	lShift, rShift    bool
-	// lSuper/rSuper live apart from lCtrl/rCtrl on purpose: with Cmd folded
-	// into Ctrl, Left Cmd and Left Ctrl both arrive as VK_LCONTROL, and
-	// releasing one must not clear a side the other still holds down.
-	lSuper, rSuper bool
+	// The side flags pick which side syncMods reports for a chord. The Ctrl
+	// pair only matters where the Cmd fold is off; with it on, each Ctrl bit
+	// derives from the event's own modifier flags instead.
+	lCtrl, rCtrl   bool
+	lAlt, rAlt     bool
+	lShift, rShift bool
 	// superDown mirrors the Super (Command) modifier of the last key event.
 	// With Cmd folded into Ctrl, macOS still reports the plain character for
 	// the shortcut key ([NSEvent characters] for Cmd+C is "c"), and that text
@@ -113,31 +112,19 @@ func isSpecialOrModifiedKey(vk uint16, mods vtinput.ControlKeyState) bool {
 }
 
 func (h *GogpuHost) syncMods(key gpucontext.Key, mods gpucontext.Modifiers, isDown bool) vtinput.ControlKeyState {
-	// The Super keys are tracked by physical key, everything else by virtual
-	// key. With Cmd folded into Ctrl the Super keys map to the very Ctrl
-	// virtual keys the real Ctrl keys use, and tracking them by that shared
-	// code let a Cmd release clear a Ctrl side a physical Ctrl key was still
-	// holding down.
-	switch key {
-	case gpucontext.KeyLeftSuper:
-		h.lSuper = isDown
-	case gpucontext.KeyRightSuper:
-		h.rSuper = isDown
-	default:
-		switch gogpuKeyToVK(key, 0) {
-		case vtinput.VK_LCONTROL:
-			h.lCtrl = isDown
-		case vtinput.VK_RCONTROL:
-			h.rCtrl = isDown
-		case vtinput.VK_LMENU:
-			h.lAlt = isDown
-		case vtinput.VK_RMENU:
-			h.rAlt = isDown
-		case vtinput.VK_LSHIFT:
-			h.lShift = isDown
-		case vtinput.VK_RSHIFT:
-			h.rShift = isDown
-		}
+	switch gogpuKeyToVK(key, 0) {
+	case vtinput.VK_LCONTROL:
+		h.lCtrl = isDown
+	case vtinput.VK_RCONTROL:
+		h.rCtrl = isDown
+	case vtinput.VK_LMENU:
+		h.lAlt = isDown
+	case vtinput.VK_RMENU:
+		h.rAlt = isDown
+	case vtinput.VK_LSHIFT:
+		h.lShift = isDown
+	case vtinput.VK_RSHIFT:
+		h.rShift = isDown
 	}
 
 	h.superDown = mods.HasSuper()
@@ -146,8 +133,17 @@ func (h *GogpuHost) syncMods(key gpucontext.Key, mods gpucontext.Modifiers, isDo
 	if mods.HasShift() {
 		sysMods |= vtinput.ShiftPressed
 	}
-	if mods.HasControl() || (gogpuCmdIsCtrl && mods.HasSuper()) {
-		if h.rCtrl || (gogpuCmdIsCtrl && h.rSuper) {
+	if gogpuCmdIsCtrl {
+		// Channel split: Cmd is the left Ctrl channel, physical Ctrl the
+		// right one. Both bits may be set at once; consumers OR them.
+		if mods.HasSuper() {
+			sysMods |= vtinput.LeftCtrlPressed
+		}
+		if mods.HasControl() {
+			sysMods |= vtinput.RightCtrlPressed
+		}
+	} else if mods.HasControl() {
+		if h.rCtrl {
 			sysMods |= vtinput.RightCtrlPressed
 		} else {
 			sysMods |= vtinput.LeftCtrlPressed
@@ -427,14 +423,18 @@ func RunGogpuHost(cols, rows int, fontName string, fontSize float64, setupApp fu
 		if vk == 0 {
 			return
 		}
-		// With Cmd folded into Ctrl, two physical keys share each Ctrl virtual
-		// key. If the Ctrl bit is still set after this release, the other key
-		// of the pair is still down, and a key-up now would tell the
-		// application Ctrl was released mid-chord — the Switcher commits its
-		// selection on exactly that. Only where the fold is active: macOS
-		// reports the post-change flags on the modifier's own event, while on
-		// Wayland the modifiers event trails the key event, so a genuine final
-		// Ctrl release still carries the Ctrl bit and would be swallowed here.
+		// The FrameManager derives Ctrl-held from a Ctrl key-up's virtual key
+		// alone, ignoring ControlKeyState, so a key-up on one Ctrl channel
+		// while the other still holds Ctrl would read as a full release
+		// mid-chord — the Switcher commits its selection on exactly that.
+		// With the channel split this fires only when Cmd and a physical
+		// Ctrl are genuinely held together; gogpu's darwin layer reports a
+		// modifier release only once the aggregate flag clears, so keys
+		// sharing one channel never produce a mid-hold release. Only where
+		// the fold is active: macOS reports the post-change flags on the
+		// modifier's own event, while on Wayland the modifiers event trails
+		// the key event, so a genuine final Ctrl release still carries the
+		// Ctrl bit and would be swallowed here.
 		if gogpuCmdIsCtrl && (vk == vtinput.VK_LCONTROL || vk == vtinput.VK_RCONTROL) &&
 			currMods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0 {
 			DebugLog("GOGPU_HOST_EVENT: withheld Ctrl key-up, Ctrl still held (key=%v)", key)
@@ -924,7 +924,17 @@ func gogpuKeyToVK(k gpucontext.Key, mods vtinput.ControlKeyState) uint16 {
 	case gpucontext.KeyScrollLock:
 		return vtinput.VK_SCROLL
 
+	// Where Super acts as Ctrl (macOS Command), the modifiers arrive on two
+	// channels, the way far2l separates them: both Cmd keys as VK_LCONTROL
+	// carrying LeftCtrlPressed, both physical Ctrl keys as VK_RCONTROL
+	// carrying RightCtrlPressed. The keys never share a virtual key, so a
+	// release in one channel cannot be mistaken for a release in the other,
+	// and nothing in the framework assigns meaning to Ctrl sides (see the
+	// KeyBar doc comment).
 	case gpucontext.KeyLeftControl:
+		if gogpuCmdIsCtrl {
+			return vtinput.VK_RCONTROL
+		}
 		return vtinput.VK_LCONTROL
 	case gpucontext.KeyRightControl:
 		return vtinput.VK_RCONTROL
@@ -936,11 +946,6 @@ func gogpuKeyToVK(k gpucontext.Key, mods vtinput.ControlKeyState) uint16 {
 		return vtinput.VK_LMENU
 	case gpucontext.KeyRightAlt:
 		return vtinput.VK_RMENU
-	// Where Super acts as Ctrl (macOS Command), the key itself must arrive as
-	// a Ctrl key too: the application distinguishes a bare modifier press
-	// from a chord by it. The real Ctrl keys share these virtual keys then;
-	// syncMods keeps their sides apart, and OnKeyRelease withholds the key-up
-	// while the other key of the pair still holds Ctrl down.
 	case gpucontext.KeyLeftSuper:
 		if gogpuCmdIsCtrl {
 			return vtinput.VK_LCONTROL
@@ -948,7 +953,7 @@ func gogpuKeyToVK(k gpucontext.Key, mods vtinput.ControlKeyState) uint16 {
 		return vtinput.VK_LWIN
 	case gpucontext.KeyRightSuper:
 		if gogpuCmdIsCtrl {
-			return vtinput.VK_RCONTROL
+			return vtinput.VK_LCONTROL
 		}
 		return vtinput.VK_RWIN
 	case gpucontext.KeyA:

--- a/gogpu_host_test.go
+++ b/gogpu_host_test.go
@@ -140,8 +140,10 @@ func TestGogpuHost_LastRuneForVK_KeyRepeat(t *testing.T) {
 }
 
 // The macOS Command key must act as Ctrl: Cmd+C has to reach the application
-// as Ctrl+C, and the Command key itself as a Ctrl key. Everywhere else the
-// Super/Win key belongs to the OS and stays a Win key with no Ctrl folding.
+// as Ctrl+C, and the Command key itself as a Ctrl key. Cmd owns the left Ctrl
+// channel (VK_LCONTROL, LeftCtrlPressed) and physical Ctrl the right one, so
+// the two never share a virtual key. Everywhere else the Super/Win key
+// belongs to the OS and stays a Win key with no Ctrl folding.
 func TestGogpuHost_SuperAsCtrl(t *testing.T) {
 	oldCmdIsCtrl := gogpuCmdIsCtrl
 	defer func() { gogpuCmdIsCtrl = oldCmdIsCtrl }()
@@ -150,14 +152,23 @@ func TestGogpuHost_SuperAsCtrl(t *testing.T) {
 	if got := gogpuKeyToVK(gpucontext.KeyLeftSuper, 0); got != vtinput.VK_LCONTROL {
 		t.Errorf("Cmd-as-Ctrl: KeyLeftSuper mapped to vk %d, want VK_LCONTROL", got)
 	}
-	if got := gogpuKeyToVK(gpucontext.KeyRightSuper, 0); got != vtinput.VK_RCONTROL {
-		t.Errorf("Cmd-as-Ctrl: KeyRightSuper mapped to vk %d, want VK_RCONTROL", got)
+	if got := gogpuKeyToVK(gpucontext.KeyRightSuper, 0); got != vtinput.VK_LCONTROL {
+		t.Errorf("Cmd-as-Ctrl: KeyRightSuper mapped to vk %d, want VK_LCONTROL", got)
+	}
+	if got := gogpuKeyToVK(gpucontext.KeyLeftControl, 0); got != vtinput.VK_RCONTROL {
+		t.Errorf("Cmd-as-Ctrl: KeyLeftControl mapped to vk %d, want VK_RCONTROL", got)
+	}
+	if got := gogpuKeyToVK(gpucontext.KeyRightControl, 0); got != vtinput.VK_RCONTROL {
+		t.Errorf("Cmd-as-Ctrl: KeyRightControl mapped to vk %d, want VK_RCONTROL", got)
 	}
 
 	host := &GogpuHost{}
 	mods := host.syncMods(gpucontext.KeyC, gpucontext.ModSuper, true)
-	if mods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) == 0 {
-		t.Errorf("Cmd-as-Ctrl: Super chord produced mods %v, want a Ctrl bit", mods)
+	if mods&vtinput.LeftCtrlPressed == 0 {
+		t.Errorf("Cmd-as-Ctrl: Super chord produced mods %v, want LeftCtrlPressed", mods)
+	}
+	if mods&vtinput.RightCtrlPressed != 0 {
+		t.Errorf("Cmd-as-Ctrl: Super chord produced mods %v, RightCtrlPressed belongs to physical Ctrl", mods)
 	}
 	if !host.superDown {
 		t.Error("Cmd-as-Ctrl: superDown not set while Super is held")
@@ -177,41 +188,55 @@ func TestGogpuHost_SuperAsCtrl(t *testing.T) {
 	if got := gogpuKeyToVK(gpucontext.KeyRightSuper, 0); got != vtinput.VK_RWIN {
 		t.Errorf("plain Super: KeyRightSuper mapped to vk %d, want VK_RWIN", got)
 	}
+	if got := gogpuKeyToVK(gpucontext.KeyLeftControl, 0); got != vtinput.VK_LCONTROL {
+		t.Errorf("plain Super: KeyLeftControl mapped to vk %d, want VK_LCONTROL", got)
+	}
+	if got := gogpuKeyToVK(gpucontext.KeyRightControl, 0); got != vtinput.VK_RCONTROL {
+		t.Errorf("plain Super: KeyRightControl mapped to vk %d, want VK_RCONTROL", got)
+	}
 	if mods := (&GogpuHost{}).syncMods(gpucontext.KeyC, gpucontext.ModSuper, true); mods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0 {
 		t.Errorf("plain Super: Super chord produced Ctrl bits %v, want none", mods)
 	}
 }
 
-// With Cmd folded into Ctrl, Left Ctrl and Left Cmd collide on VK_LCONTROL.
-// Releasing one of the pair while the other is still held must keep both the
-// held side flag and the Ctrl bit; the phantom full release used to commit an
-// open Switcher mid-chord.
-func TestGogpuHost_SuperReleaseKeepsHeldCtrl(t *testing.T) {
+// Cmd and physical Ctrl each own a Ctrl channel. Holding both sets both bits,
+// and releasing one channel must not disturb the bit the other still holds —
+// a phantom full release used to commit an open Switcher mid-chord.
+func TestGogpuHost_CtrlChannelSurvivesOtherRelease(t *testing.T) {
 	oldCmdIsCtrl := gogpuCmdIsCtrl
 	defer func() { gogpuCmdIsCtrl = oldCmdIsCtrl }()
 	gogpuCmdIsCtrl = true
 
 	host := &GogpuHost{}
-	host.syncMods(gpucontext.KeyLeftControl, gpucontext.ModControl, true)
-	host.syncMods(gpucontext.KeyLeftSuper, gpucontext.ModControl|gpucontext.ModSuper, true)
-	mods := host.syncMods(gpucontext.KeyLeftSuper, gpucontext.ModControl, false)
-	if !host.lCtrl {
-		t.Error("Cmd release cleared the Ctrl side while physical Ctrl is held")
+	mods := host.syncMods(gpucontext.KeyLeftControl, gpucontext.ModControl, true)
+	if mods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != vtinput.RightCtrlPressed {
+		t.Errorf("physical Ctrl produced mods %v, want exactly RightCtrlPressed", mods)
 	}
-	if mods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) == 0 {
-		t.Errorf("mods after Cmd release = %v, want a Ctrl bit while physical Ctrl is held", mods)
+	mods = host.syncMods(gpucontext.KeyLeftSuper, gpucontext.ModControl|gpucontext.ModSuper, true)
+	if mods&vtinput.LeftCtrlPressed == 0 || mods&vtinput.RightCtrlPressed == 0 {
+		t.Errorf("Ctrl and Cmd held together produced mods %v, want both Ctrl bits", mods)
+	}
+	mods = host.syncMods(gpucontext.KeyLeftSuper, gpucontext.ModControl, false)
+	if mods&vtinput.RightCtrlPressed == 0 {
+		t.Errorf("mods after Cmd release = %v, want RightCtrlPressed while physical Ctrl is held", mods)
+	}
+	if mods&vtinput.LeftCtrlPressed != 0 {
+		t.Errorf("mods after Cmd release = %v, LeftCtrlPressed should be gone", mods)
 	}
 
 	// The mirror image: Ctrl released first, Cmd still held.
 	host = &GogpuHost{}
-	host.syncMods(gpucontext.KeyLeftSuper, gpucontext.ModSuper, true)
+	mods = host.syncMods(gpucontext.KeyLeftSuper, gpucontext.ModSuper, true)
+	if mods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != vtinput.LeftCtrlPressed {
+		t.Errorf("Cmd produced mods %v, want exactly LeftCtrlPressed", mods)
+	}
 	host.syncMods(gpucontext.KeyLeftControl, gpucontext.ModControl|gpucontext.ModSuper, true)
 	mods = host.syncMods(gpucontext.KeyLeftControl, gpucontext.ModSuper, false)
-	if host.lCtrl {
-		t.Error("physical Ctrl release left the Ctrl side flag set")
+	if mods&vtinput.LeftCtrlPressed == 0 {
+		t.Errorf("mods after Ctrl release = %v, want LeftCtrlPressed while Cmd is held", mods)
 	}
-	if mods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) == 0 {
-		t.Errorf("mods after Ctrl release = %v, want a Ctrl bit while Cmd is held", mods)
+	if mods&vtinput.RightCtrlPressed != 0 {
+		t.Errorf("mods after Ctrl release = %v, RightCtrlPressed should be gone", mods)
 	}
 }
 


### PR DESCRIPTION
## What

Simplifies the macOS Cmd-as-Ctrl fold from #28, following the design far2l uses (`WinPort/src/Backend/WX/wxWinTranslations.cpp`): instead of mapping the Cmd keys onto the very virtual keys the physical Ctrl keys use, each modifier gets a **channel** of its own:

| macOS key | VK | modifier bit |
|---|---|---|
| Cmd (both keys) | `VK_LCONTROL` | `LeftCtrlPressed` |
| physical Ctrl (both keys) | `VK_RCONTROL` | `RightCtrlPressed` |

The keys never share a virtual key, so a release in one channel cannot be mistaken for a release in the other — the `lSuper`/`rSuper` side bookkeeping that #28 needed to keep the colliding keys apart is deleted, and `syncMods` goes back to tracking sides purely by virtual key. Both Ctrl bits may now be set at once (the ebiten host already reports them that way).

## Why this is observationally safe

Nothing in the framework assigns different meaning to left vs right Ctrl: every consumer either ORs both bits or lists all three Ctrl VKs, `keybar.go` explicitly disclaims side distinction ("we do not support or require independent left/right states"), no bindings or persisted state encode a side, and `framemanager_test.go` actively asserts right Ctrl behaves like left. The only visible difference is cosmetic: debug logs render physical Ctrl as "RightCtrl" on macOS.

## What stays

- The `OnKeyRelease` withholding gate, with its rationale rewritten: the FrameManager derives Ctrl-held from a Ctrl key-up's virtual key alone, ignoring `ControlKeyState`, so a key-up on one channel while the other still holds Ctrl would read as a full release and commit an open Switcher mid-chord. With the channel split, the gate fires only when Cmd and physical Ctrl are genuinely held together (gogpu's darwin layer reports a modifier release only once the aggregate flag clears, so same-channel pairs never produce a mid-hold release).
- The `superDown` text drop in `OnTextInput` — macOS still reports the plain character for a Cmd chord.

## Tests

- `TestGogpuHost_SuperAsCtrl` now pins the full channel mapping (both Cmds → `VK_LCONTROL`, both physical Ctrls → `VK_RCONTROL` with the fold on; unchanged mappings with it off) and asserts a Cmd chord yields exactly `LeftCtrlPressed`.
- `TestGogpuHost_SuperReleaseKeepsHeldCtrl` is replaced by `TestGogpuHost_CtrlChannelSurvivesOtherRelease`: both channels held sets both bits, and releasing either one clears only its own bit, in both orders.

`gofmt` clean; full suite passes locally under the CI filter. As with #28, the state logic is unit-tested and macOS CI covers build+tests, but real Cmd/Ctrl chord behavior deserves a check on Mac hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)