### PR TITLE
fix: draw toast after workspace tabs so it overlays the top row

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -1964,6 +1964,14 @@ func (fm *frameManager) renderPhase() {
 			fm.StatusLine.Show(fm.scr)
 		}
 
+		if fm.OnRender != nil {
+			fm.OnRender(fm.scr)
+		}
+		fm.drawWorkspaceTabs()
+		fm.drawWorkspaceCounter()
+
+		// Draw the toast after the workspace tab bar so it overlays the top row
+		// instead of being erased by drawWorkspaceTabs' FillRect.
 		if fm.currentToast != nil {
 			if time.Now().After(fm.currentToast.Expires) {
 				fm.currentToast = nil
@@ -1977,11 +1985,6 @@ func (fm *frameManager) renderPhase() {
 				fm.scr.Write(x, 0, StringToCharInfo(msg, attr))
 			}
 		}
-		if fm.OnRender != nil {
-			fm.OnRender(fm.scr)
-		}
-		fm.drawWorkspaceTabs()
-		fm.drawWorkspaceCounter()
 
 		fm.scr.Graphics().EndFrame()
 		if semanticRenderer, ok := fm.scr.Renderer.(SemanticSceneRenderer); ok {


### PR DESCRIPTION
The toast was rendered in the top row before drawWorkspaceTabs, whose
FillRect then erased it. Move the toast drawing after the tab bar and
counter so it stays visible on top.

## Problem

When the workspace tab bar is visible (default `WorkspaceTabsAlways`),
`ShowToast` messages (e.g. "Settings saved" on Shift-F9) are never seen:
the toast is drawn in the top row first, and `drawWorkspaceTabs()`
immediately overwrites it with `FillRect(0,0,...)`.

## Fix

Move the toast rendering in the render phase after
`drawWorkspaceTabs()` / `drawWorkspaceCounter()`, so the toast overlays
the tab bar instead of being erased.

## Verification

- `TestFrameManager_Toast` passes
- `TestFrameManager_WorkspaceTabsAndCounterRendering` passes
- `TestFrameManager_WorkspaceTabsSemanticModelAndActions` passes
- f4 `TestPanelsFrame_ShiftF9_SaveSettings` passes
