### PR TITLE
gogpu: repaint on every OnDraw instead of relying on canvas dirtiness

### DIFF
--- a/gogpu_renderer.go
+++ b/gogpu_renderer.go
@@ -461,9 +461,17 @@ func (r *GogpuRenderer) DrawToScreen(ctx *gogpu.Context) {
 	}
 
 	var prof gogpuFrameStats
-	drew := false
 
-	if r.dirty {
+	// drawCanvas re-rasterizes the whole screen buffer into the canvas. OnDraw
+	// fires on content changes AND on surface-repaint events (WM_PAINT/Expose
+	// on restore from tray/minimize, alt-tab, uncover, focus change). The
+	// canvas must be repainted in both cases: ggcanvas.Render is a no-op on a
+	// clean canvas, so skipping the draw on a clean OnDraw would leave the
+	// window black after a restore until the next content change. The
+	// textured-quad path (canvas.RenderTo) is intentionally not used here —
+	// mixing it with the primary GPU-direct present path makes the screen
+	// flicker while dragging the mouse.
+	drawCanvas := func() {
 		tDraw := gogpuProfNow()
 		r.canvas.Draw(func(dc *gg.Context) {
 			dc.SetRGB(0, 0, 0)
@@ -600,15 +608,16 @@ func (r *GogpuRenderer) DrawToScreen(ctx *gogpu.Context) {
 			}
 		})
 		prof.drawTime = gogpuProfSince(tDraw)
-		r.dirty = false
-		drew = true
 	}
+
+	drawCanvas()
+	r.dirty = false
 
 	tRender := gogpuProfNow()
 	r.canvas.Render(ctx.RenderTarget())
 	prof.renderTime = gogpuProfSince(tRender)
 
-	if gogpuProfileEnabled && drew {
+	if gogpuProfileEnabled {
 		prof.report(r.cols, r.rows)
 	}
 }


### PR DESCRIPTION
ggcanvas.Render is a no-op when the canvas is clean, so after restoring
the window from the tray/minimized state (WM_PAINT -> EventExpose) the
first OnDraw presented nothing and the window stayed black until the
next content change (cursor blink, mouse, heartbeat).

Repaint the canvas on every OnDraw through the normal GPU-direct present
path. OnDraw fires only on content changes or surface-repaint events
(restore, alt-tab, uncover, focus), so idle behavior is unchanged.

The textured-quad path (canvas.RenderTo) was considered but rejected:
mixing it with the primary present path causes visible flicker while
dragging the mouse.



### Problem
After restoring the gogpu-rendered window from the tray or from minimized
state, the window stays black until the next content change (cursor blink,
mouse move, heartbeat), because ggcanvas.Render is a no-op for a clean canvas.

### Root cause
On restore Windows sends WM_PAINT -> EventExpose -> RequestRedraw -> OnDraw.
The canvas is not dirty (content unchanged), so `Canvas.Render` returned
early and nothing was presented. The surface content was lost during
minimize, hence the black window.

### Fix
Repaint the canvas on every OnDraw through the normal GPU-direct present
path instead of skipping clean canvases. OnDraw only fires on content
changes or surface-repaint events (restore, alt-tab, uncover, focus), so
the demand-driven idle behavior is preserved.

### Why not canvas.RenderTo (textured quad)
RenderTo presents via a different path (GPU render pass / swapchain quad).
Mixing it with the primary GPU-direct present path caused visible flicker
when dragging the mouse, so it was rejected.

### Tested
- Restore from tray/minimize: window shows content immediately, no black flash.
- Dragging the mouse across panels: no flicker.




### Проблема
После восстановления окна из трея или из свёрнутого состояния окно
остаётся чёрным до следующего изменения контента (мигание курсора,
движение мыши, heartbeat), потому что ggcanvas.Render — no-op для чистого
канваса.

### Причина
При restore Windows шлёт WM_PAINT -> EventExpose -> RequestRedraw -> OnDraw.
Канвас не «грязный» (контент не менялся), поэтому `Canvas.Render`
выходил раньше времени и ничего не презентовалось. Контент поверхности
терялся при сворачивании — отсюда чёрное окно.

### Исправление
Перерисовывать канвас на каждом OnDraw через обычный GPU-direct путь
презентации вместо пропуска чистых канвасов. OnDraw вызывается только при
изменении контента или событиях перерисовки поверхности (restore, alt-tab,
uncover, focus), поэтому поведение в простое (demand-driven) не меняется.

### Почему не canvas.RenderTo (текстурный quad)
RenderTo презентует другим путём (GPU render pass / swapchain quad).
Смешивание с основным GPU-direct путём вызывало заметное мельтешение при
таскании мышью, поэтому вариант отклонён.

### Проверено
- Restore из трея/свернуть: окно сразу показывает содержимое, без чёрной
  вспышки.
- Таскание мышью по панелям: мельтешения нет.
