### PR TITLE
Load GUI fallback fonts lazily, on first use

### DIFF
--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -310,7 +310,7 @@ func RunGogpuHost(cols, rows int, fontName string, fontSize float64, setupApp fu
 			os.Setenv("GOGPU_DX12_DXIL", "1")
 		}
 	}
-	face, fallbackFaces, cellW, cellH := loadGogpuFont(fontName, fontSize)
+	face, fallbackChain, cellW, cellH := loadGogpuFont(fontName, fontSize)
 
 	fmt.Fprintf(os.Stdout, "GOGPU_HOST: Starting RunGogpuHost %dx%d (Cell: %dx%d)\n", cols, rows, cellW, cellH)
 	DebugLog("GOGPU_HOST: Starting RunGogpuHost %dx%d (Cell: %dx%d)", cols, rows, cellW, cellH)
@@ -338,7 +338,7 @@ func RunGogpuHost(cols, rows int, fontName string, fontSize float64, setupApp fu
 	host.scr = scr
 	scr.AllocBuf(cols, rows)
 	renderer := NewGogpuRenderer(host, face, cellW, cellH)
-	renderer.SetFallbackFaces(fallbackFaces)
+	renderer.SetFallbackFontChain(fallbackChain)
 	scr.Renderer = renderer
 	scr.Graphics().SetProtocol(GraphicsNative)
 	scr.Graphics().SetCellSize(cellW, cellH)
@@ -714,14 +714,14 @@ func isGogpuFaceSafe(f text.Face) (ok bool) {
 	return
 }
 
-// loadGogpuFont returns the primary face plus the fallback faces that cover
-// the runes the primary lacks. The fallbacks are returned as separate faces
-// rather than folded into a gg text.MultiFace on purpose: a MultiFace has no
-// single FontSource, and the GPU glyph-mask engine refuses such a face and
-// sends every DrawString down the CPU path. Selecting the face per rune keeps
-// each face a plain single-source one, so both the primary and the fallbacks
-// stay on the GPU path.
-func loadGogpuFont(fontName string, size float64) (text.Face, []text.Face, int, int) {
+// loadGogpuFont returns the primary face plus a lazily loaded chain of the
+// fallback fonts that cover the runes the primary lacks. The fallbacks are
+// kept as separate faces rather than folded into a gg text.MultiFace on
+// purpose: a MultiFace has no single FontSource, and the GPU glyph-mask
+// engine refuses such a face and sends every DrawString down the CPU path.
+// Selecting the face per rune keeps each face a plain single-source one, so
+// both the primary and the fallbacks stay on the GPU path.
+func loadGogpuFont(fontName string, size float64) (text.Face, *fallbackFontChain, int, int) {
 	if size <= 0 {
 		size = 18.0
 	}
@@ -762,30 +762,31 @@ func loadGogpuFont(fontName string, size float64) (text.Face, []text.Face, int, 
 	// something worse than a .notdef box, the old behaviour is one variable
 	// away.
 	noFallback := os.Getenv("VTUI_GOGPU_NO_FALLBACK") != ""
-	var fallbacks []text.Face
 
 	// The fallbacks cannot be attached to the face yet — see the note below on
 	// MultiFace — but which of them exist on this machine is worth recording.
 	// "No CJK font installed" and "CJK font installed and never consulted" are
 	// different bugs with identical symptoms, and the log is the only place
-	// they can be told apart. Parsing is part of the probe on purpose: a .ttc
-	// collection that gg refuses to open explains a missing glyph just as well
-	// as a missing file does.
+	// they can be told apart.
+	//
+	// Existence is all the startup probe checks now. The old probe also parsed
+	// every file, which cost ~800 MB of heap on a stock macOS (the fallback
+	// list is ~400 MB of font files and gg holds each twice) in sessions that
+	// never drew a single glyph from them. Whether gg can actually open a file
+	// is still logged — by the chain, the first time that file is consulted.
+	var chain *fallbackFontChain
 	for _, p := range fallbackFontPaths {
 		if _, err := os.Stat(p); err != nil {
 			continue
 		}
-		src, err := text.NewFontSourceFromFile(p)
-		if err != nil {
-			DebugLog("GOGPU_DIAG_FONT: fallback present but gg cannot open it: %s: %v", p, err)
+		DebugLog("GOGPU_DIAG_FONT: fallback present, deferred until first use: %s", p)
+		if noFallback {
 			continue
 		}
-		probe := src.Face(size)
-		DebugLog("GOGPU_DIAG_FONT: fallback ok: %s (has 字=%v, has emoji=%v)",
-			p, probe.HasGlyph('字'), probe.HasGlyph('😀'))
-		if !noFallback {
-			fallbacks = append(fallbacks, probe)
+		if chain == nil {
+			chain = &fallbackFontChain{size: size}
 		}
+		chain.entries = append(chain.entries, fallbackFontEntry{path: p})
 	}
 
 	// text.MultiFace stays out of this backend deliberately. It reports no
@@ -797,7 +798,7 @@ func loadGogpuFont(fontName string, size float64) (text.Face, []text.Face, int, 
 	//
 	// This can be revisited when gg lands per-font-run GPU support (ADR-065),
 	// and only if it measures better than the chain below.
-	return primaryFace, fallbacks, cellW, cellH
+	return primaryFace, chain, cellW, cellH
 }
 
 func isNumLockEffectiveGogpu(mods vtinput.ControlKeyState) bool {

--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -721,7 +721,7 @@ func isGogpuFaceSafe(f text.Face) (ok bool) {
 // engine refuses such a face and sends every DrawString down the CPU path.
 // Selecting the face per rune keeps each face a plain single-source one, so
 // both the primary and the fallbacks stay on the GPU path.
-func loadGogpuFont(fontName string, size float64) (text.Face, *fallbackFontChain, int, int) {
+func loadGogpuFont(fontName string, size float64) (text.Face, *fontFallbackChain, int, int) {
 	if size <= 0 {
 		size = 18.0
 	}
@@ -773,20 +773,24 @@ func loadGogpuFont(fontName string, size float64) (text.Face, *fallbackFontChain
 	// every file, which cost ~800 MB of heap on a stock macOS (the fallback
 	// list is ~400 MB of font files and gg holds each twice) in sessions that
 	// never drew a single glyph from them. Whether gg can actually open a file
-	// is still logged — by the chain, the first time that file is consulted.
-	var chain *fallbackFontChain
-	for _, p := range fallbackFontPaths {
-		if _, err := os.Stat(p); err != nil {
-			continue
+	// is still logged — by the chain's warm() sweep, shortly after startup.
+	var chain *fontFallbackChain
+	if noFallback {
+		DebugLog("GOGPU_DIAG_FONT: fallback chain disabled by VTUI_GOGPU_NO_FALLBACK")
+	} else {
+		for _, p := range fallbackFontPaths {
+			if _, err := os.Stat(p); err != nil {
+				continue
+			}
+			DebugLog("GOGPU_DIAG_FONT: fallback present, deferred until first use: %s", p)
+			if chain == nil {
+				chain = newGogpuFallbackChain(size)
+			}
+			chain.entries = append(chain.entries, fontFallbackEntry{path: p})
 		}
-		DebugLog("GOGPU_DIAG_FONT: fallback present, deferred until first use: %s", p)
-		if noFallback {
-			continue
+		if chain != nil {
+			chain.warm()
 		}
-		if chain == nil {
-			chain = &fallbackFontChain{size: size}
-		}
-		chain.entries = append(chain.entries, fallbackFontEntry{path: p})
 	}
 
 	// text.MultiFace stays out of this backend deliberately. It reports no

--- a/gogpu_renderer.go
+++ b/gogpu_renderer.go
@@ -15,11 +15,121 @@ import (
 	"github.com/gogpu/gogpu"
 )
 
+// fallbackFontChain hands out fallback faces for runes the primary font
+// lacks, keeping in memory only the fonts that have actually supplied a
+// glyph. The eager version of this cost real memory for text that was never
+// drawn: the macOS fallback list alone is ~400 MB of font files, held twice
+// over by gg (the parsed original and its internal copy) — ~800 MB of heap
+// in every GUI session, almost all of which never rendered a single CJK
+// glyph or emoji.
+//
+// Each entry is parsed at most twice over its lifetime. The first time it is
+// consulted at all, the font is parsed, its rune coverage is condensed into
+// a 16 KB bitmap, and the parse is thrown away unless the font owns the very
+// rune that was asked for. From then on the bitmap answers "does this font
+// cover ch" without the font in memory, so a rune nobody covers — the reason
+// a naive lazy chain still ended up loading everything — costs nothing to
+// ask about again, and a covered rune parses (and this time retains) exactly
+// the one font that will draw it.
+//
+// The chain is consulted in list order, so the priority of fallbackFontPaths
+// is preserved exactly; the only difference from the eager version is *when*
+// a file is read. A file that fails to parse is logged and skipped for good,
+// same as it was at startup before.
+type fallbackFontChain struct {
+	size    float64
+	entries []fallbackFontEntry
+}
+
+type fallbackFontEntry struct {
+	path   string
+	failed bool          // gg could not open it; never try again
+	cov    *runeCoverage // built on first parse, nil until then
+	face   text.Face     // retained only once the font has supplied a glyph
+}
+
+// runeCoverage is a bitmap of the runes a font has glyphs for, over planes 0
+// and 1 — everything a terminal plausibly draws, emoji included. Runes above
+// plane 1 are so rare that "maybe" (and a re-parse to find out) is the right
+// answer for them.
+type runeCoverage struct {
+	bits [0x20000 / 64]uint64
+}
+
+func (c *runeCoverage) maybeHas(r rune) bool {
+	if r < 0 {
+		return false
+	}
+	if r >= 0x20000 {
+		return true
+	}
+	return c.bits[r>>6]&(1<<(uint(r)&63)) != 0
+}
+
+func buildRuneCoverage(f text.Face) *runeCoverage {
+	cov := &runeCoverage{}
+	for r := rune(0); r < 0x20000; r++ {
+		if r >= 0xD800 && r <= 0xDFFF {
+			continue // surrogates are not runes a cmap can hold
+		}
+		if f.HasGlyph(r) {
+			cov.bits[r>>6] |= 1 << (uint(r) & 63)
+		}
+	}
+	return cov
+}
+
+// faceFor returns the first fallback face that owns a glyph for ch, walking
+// the fonts in priority order, or nil when none of them covers it. The
+// caller must serialize calls (GogpuRenderer holds r.mu) and is expected to
+// memoise the answer per rune, so each rune walks this at most once.
+func (c *fallbackFontChain) faceFor(ch rune) text.Face {
+	for i := range c.entries {
+		e := &c.entries[i]
+		if e.failed {
+			continue
+		}
+		if e.face != nil {
+			if e.face.HasGlyph(ch) {
+				return e.face
+			}
+			continue
+		}
+		if e.cov != nil && !e.cov.maybeHas(ch) {
+			continue
+		}
+
+		t0 := time.Now()
+		src, err := text.NewFontSourceFromFile(e.path)
+		if err != nil {
+			e.failed = true
+			DebugLog("GOGPU_DIAG_FONT: fallback present but gg cannot open it: %s: %v", e.path, err)
+			continue
+		}
+		f := src.Face(c.size)
+		if e.cov == nil {
+			e.cov = buildRuneCoverage(f)
+		}
+		if f.HasGlyph(ch) {
+			e.face = f
+			DebugLog("GOGPU_DIAG_FONT: fallback loaded for U+%04X: %s in %v (has 字=%v, has emoji=%v)",
+				ch, e.path, time.Since(t0), f.HasGlyph('字'), f.HasGlyph('😀'))
+			return f
+		}
+		// Parsed, mapped, not needed: the source is dropped here and the
+		// bitmap answers for this font from now on.
+		DebugLog("GOGPU_DIAG_FONT: fallback probed for U+%04X and dropped: %s in %v",
+			ch, e.path, time.Since(t0))
+	}
+	return nil
+}
+
 type GogpuRenderer struct {
 	mu           sync.Mutex
 	host         *GogpuHost
 	face         text.Face
 	fallbacks    []text.Face
+	chain        *fallbackFontChain
 	faceCache    map[rune]text.Face
 	cellW, cellH int // logical cell sizes from font measurement
 	cols, rows   int // dimensions of the current renderBuf
@@ -64,6 +174,15 @@ func (r *GogpuRenderer) SetFallbackFaces(faces []text.Face) {
 	r.faceCache = nil
 }
 
+// SetFallbackFontChain installs a lazily loaded fallback chain, consulted
+// after any faces installed by SetFallbackFaces. Passing nil removes it.
+func (r *GogpuRenderer) SetFallbackFontChain(chain *fallbackFontChain) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.chain = chain
+	r.faceCache = nil
+}
+
 // faceFor resolves the face that actually owns a glyph for ch, memoising the
 // answer. The probe itself is a cmap lookup, but it happens once per distinct
 // rune on screen rather than once per cell per frame, which is what keeps this
@@ -73,7 +192,7 @@ func (r *GogpuRenderer) SetFallbackFaces(faces []text.Face) {
 // The caller must hold r.mu. DrawToScreen, the only caller, holds it for the
 // whole frame.
 func (r *GogpuRenderer) faceFor(ch rune) text.Face {
-	if r.face == nil || len(r.fallbacks) == 0 {
+	if r.face == nil || (len(r.fallbacks) == 0 && r.chain == nil) {
 		return r.face
 	}
 	if f, ok := r.faceCache[ch]; ok {
@@ -82,10 +201,21 @@ func (r *GogpuRenderer) faceFor(ch rune) text.Face {
 
 	f := r.face
 	if !r.face.HasGlyph(ch) {
+		found := false
 		for _, fb := range r.fallbacks {
 			if fb != nil && fb.HasGlyph(ch) {
 				f = fb
+				found = true
 				break
+			}
+		}
+		if !found && r.chain != nil {
+			// The chain opens further font files as needed, so this misses
+			// at most once per rune: the answer — including "nobody has it"
+			// — goes into faceCache below, and a negative answer is final
+			// because the chain has been walked to its end by then.
+			if fb := r.chain.faceFor(ch); fb != nil {
+				f = fb
 			}
 		}
 	}

--- a/gogpu_renderer.go
+++ b/gogpu_renderer.go
@@ -48,24 +48,8 @@ type fallbackFontEntry struct {
 	face   text.Face     // retained only once the font has supplied a glyph
 }
 
-// runeCoverage is a bitmap of the runes a font has glyphs for, over planes 0
-// and 1 — everything a terminal plausibly draws, emoji included. Runes above
-// plane 1 are so rare that "maybe" (and a re-parse to find out) is the right
-// answer for them.
-type runeCoverage struct {
-	bits [0x20000 / 64]uint64
-}
-
-func (c *runeCoverage) maybeHas(r rune) bool {
-	if r < 0 {
-		return false
-	}
-	if r >= 0x20000 {
-		return true
-	}
-	return c.bits[r>>6]&(1<<(uint(r)&63)) != 0
-}
-
+// buildRuneCoverage condenses a gg face's cmap into a runeCoverage bitmap
+// (the type lives in gui_font.go, which compiles on every GUI platform).
 func buildRuneCoverage(f text.Face) *runeCoverage {
 	cov := &runeCoverage{}
 	for r := rune(0); r < 0x20000; r++ {

--- a/gogpu_renderer.go
+++ b/gogpu_renderer.go
@@ -15,105 +15,31 @@ import (
 	"github.com/gogpu/gogpu"
 )
 
-// fallbackFontChain hands out fallback faces for runes the primary font
-// lacks, keeping in memory only the fonts that have actually supplied a
-// glyph. The eager version of this cost real memory for text that was never
-// drawn: the macOS fallback list alone is ~400 MB of font files, held twice
-// over by gg (the parsed original and its internal copy) — ~800 MB of heap
-// in every GUI session, almost all of which never rendered a single CJK
-// glyph or emoji.
-//
-// Each entry is parsed at most twice over its lifetime. The first time it is
-// consulted at all, the font is parsed, its rune coverage is condensed into
-// a 16 KB bitmap, and the parse is thrown away unless the font owns the very
-// rune that was asked for. From then on the bitmap answers "does this font
-// cover ch" without the font in memory, so a rune nobody covers — the reason
-// a naive lazy chain still ended up loading everything — costs nothing to
-// ask about again, and a covered rune parses (and this time retains) exactly
-// the one font that will draw it.
-//
-// The chain is consulted in list order, so the priority of fallbackFontPaths
-// is preserved exactly; the only difference from the eager version is *when*
-// a file is read. A file that fails to parse is logged and skipped for good,
-// same as it was at startup before.
-type fallbackFontChain struct {
-	size    float64
-	entries []fallbackFontEntry
-}
-
-type fallbackFontEntry struct {
-	path   string
-	failed bool          // gg could not open it; never try again
-	cov    *runeCoverage // built on first parse, nil until then
-	face   text.Face     // retained only once the font has supplied a glyph
-}
-
-// buildRuneCoverage condenses a gg face's cmap into a runeCoverage bitmap
-// (the type lives in gui_font.go, which compiles on every GUI platform).
-func buildRuneCoverage(f text.Face) *runeCoverage {
-	cov := &runeCoverage{}
-	for r := rune(0); r < 0x20000; r++ {
-		if r >= 0xD800 && r <= 0xDFFF {
-			continue // surrogates are not runes a cmap can hold
-		}
-		if f.HasGlyph(r) {
-			cov.bits[r>>6] |= 1 << (uint(r) & 63)
-		}
-	}
-	return cov
-}
-
-// faceFor returns the first fallback face that owns a glyph for ch, walking
-// the fonts in priority order, or nil when none of them covers it. The
-// caller must serialize calls (GogpuRenderer holds r.mu) and is expected to
-// memoise the answer per rune, so each rune walks this at most once.
-func (c *fallbackFontChain) faceFor(ch rune) text.Face {
-	for i := range c.entries {
-		e := &c.entries[i]
-		if e.failed {
-			continue
-		}
-		if e.face != nil {
-			if e.face.HasGlyph(ch) {
-				return e.face
+// newGogpuFallbackChain binds the shared fallback chain (gui_font.go) to gg
+// faces. gg's HasGlyph reflects what DrawString can actually draw, so covers
+// and renders coincide here, unlike on the x/image side.
+func newGogpuFallbackChain(size float64) *fontFallbackChain {
+	hasGlyph := func(face any, r rune) bool { return face.(text.Face).HasGlyph(r) }
+	return &fontFallbackChain{
+		logTag: "GOGPU_DIAG_FONT",
+		open: func(path string) (any, error) {
+			src, err := text.NewFontSourceFromFile(path)
+			if err != nil {
+				return nil, err
 			}
-			continue
-		}
-		if e.cov != nil && !e.cov.maybeHas(ch) {
-			continue
-		}
-
-		t0 := time.Now()
-		src, err := text.NewFontSourceFromFile(e.path)
-		if err != nil {
-			e.failed = true
-			DebugLog("GOGPU_DIAG_FONT: fallback present but gg cannot open it: %s: %v", e.path, err)
-			continue
-		}
-		f := src.Face(c.size)
-		if e.cov == nil {
-			e.cov = buildRuneCoverage(f)
-		}
-		if f.HasGlyph(ch) {
-			e.face = f
-			DebugLog("GOGPU_DIAG_FONT: fallback loaded for U+%04X: %s in %v (has 字=%v, has emoji=%v)",
-				ch, e.path, time.Since(t0), f.HasGlyph('字'), f.HasGlyph('😀'))
-			return f
-		}
-		// Parsed, mapped, not needed: the source is dropped here and the
-		// bitmap answers for this font from now on.
-		DebugLog("GOGPU_DIAG_FONT: fallback probed for U+%04X and dropped: %s in %v",
-			ch, e.path, time.Since(t0))
+			return src.Face(size), nil
+		},
+		covers:  hasGlyph,
+		renders: hasGlyph,
+		drop:    func(any) {},
 	}
-	return nil
 }
 
 type GogpuRenderer struct {
 	mu           sync.Mutex
 	host         *GogpuHost
 	face         text.Face
-	fallbacks    []text.Face
-	chain        *fallbackFontChain
+	chain        *fontFallbackChain
 	faceCache    map[rune]text.Face
 	cellW, cellH int // logical cell sizes from font measurement
 	cols, rows   int // dimensions of the current renderBuf
@@ -149,18 +75,10 @@ func NewGogpuRenderer(host *GogpuHost, face text.Face, cw, ch int) *GogpuRendere
 	}
 }
 
-// SetFallbackFaces installs the faces consulted for runes the primary font
-// has no glyph for. Passing nil restores primary-only rendering.
-func (r *GogpuRenderer) SetFallbackFaces(faces []text.Face) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.fallbacks = faces
-	r.faceCache = nil
-}
-
 // SetFallbackFontChain installs a lazily loaded fallback chain, consulted
-// after any faces installed by SetFallbackFaces. Passing nil removes it.
-func (r *GogpuRenderer) SetFallbackFontChain(chain *fallbackFontChain) {
+// for runes the primary font has no glyph for. Passing nil restores
+// primary-only rendering.
+func (r *GogpuRenderer) SetFallbackFontChain(chain *fontFallbackChain) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.chain = chain
@@ -176,7 +94,7 @@ func (r *GogpuRenderer) SetFallbackFontChain(chain *fallbackFontChain) {
 // The caller must hold r.mu. DrawToScreen, the only caller, holds it for the
 // whole frame.
 func (r *GogpuRenderer) faceFor(ch rune) text.Face {
-	if r.face == nil || (len(r.fallbacks) == 0 && r.chain == nil) {
+	if r.face == nil || r.chain == nil {
 		return r.face
 	}
 	if f, ok := r.faceCache[ch]; ok {
@@ -185,22 +103,13 @@ func (r *GogpuRenderer) faceFor(ch rune) text.Face {
 
 	f := r.face
 	if !r.face.HasGlyph(ch) {
-		found := false
-		for _, fb := range r.fallbacks {
-			if fb != nil && fb.HasGlyph(ch) {
-				f = fb
-				found = true
-				break
-			}
-		}
-		if !found && r.chain != nil {
-			// The chain opens further font files as needed, so this misses
-			// at most once per rune: the answer — including "nobody has it"
-			// — goes into faceCache below, and a negative answer is final
-			// because the chain has been walked to its end by then.
-			if fb := r.chain.faceFor(ch); fb != nil {
-				f = fb
-			}
+		// The chain opens further font files as needed and memoises its own
+		// answer per rune, so this misses at most once per rune: the answer —
+		// including "nobody has it" — goes into faceCache below, and a
+		// negative answer is final because the chain has been walked to its
+		// end by then.
+		if fb, ok := r.chain.faceFor(ch).(text.Face); ok {
+			f = fb
 		}
 	}
 

--- a/gui_font.go
+++ b/gui_font.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/basicfont"
@@ -77,21 +78,21 @@ var fallbackFontPaths = []string{
 	"/Library/Fonts/Arial Unicode.ttf",
 }
 
-// runeCoverage is a bitmap of the runes a font has glyphs for, over planes 0
-// and 1 — everything a terminal plausibly draws, emoji included. Runes above
-// plane 1 are so rare that "maybe" (and a re-parse to find out) is the right
-// answer for them. It is shared by the gogpu backend's fallbackFontChain and
-// the guiFallbackChain below.
+// runeCoverage is a bitmap of the runes a font has glyphs for, over all of
+// Unicode, so it answers definitively for every rune. An earlier version
+// covered only planes 0 and 1 and answered "maybe" above that, which forced a
+// re-parse of the font file for every consultation of a plane-2 CJK
+// ideograph. At 136 KB per probed font the full bitmap is still noise next to
+// the multi-megabyte parse it replaces.
+const runeCoverageMax = 0x110000
+
 type runeCoverage struct {
-	bits [0x20000 / 64]uint64
+	bits [runeCoverageMax / 64]uint64
 }
 
-func (c *runeCoverage) maybeHas(r rune) bool {
-	if r < 0 {
+func (c *runeCoverage) has(r rune) bool {
+	if r < 0 || r >= runeCoverageMax {
 		return false
-	}
-	if r >= 0x20000 {
-		return true
 	}
 	return c.bits[r>>6]&(1<<(uint(r)&63)) != 0
 }
@@ -111,100 +112,190 @@ func parseFontBytes(data []byte) (*opentype.Font, error) {
 	return nil, err
 }
 
-// guiFallbackChain is the x/image twin of the gogpu backend's
-// fallbackFontChain: it opens a fallback font file the first time a rune
-// actually needs it, and keeps in memory only the fonts that have supplied a
-// glyph. The eager version parsed every fallback font on the machine at
-// startup — on a Linux install with Noto CJK that is hundreds of megabytes
-// held for glyphs that almost never render (the same bug measured at ~800 MB
-// on macOS in the gogpu backend).
+// fontFallbackChain opens a fallback font file the first time a rune actually
+// needs it, and keeps in memory only the fonts that have rendered a glyph.
+// The eager approach parsed every fallback font on the machine at startup —
+// on a stock macOS that is ~400 MB of font files, held twice over by gg in
+// the gogpu backend (~800 MB of heap), almost all of it for glyphs that never
+// render.
 //
-// A parsed font that lacks the requested rune is condensed into a 16 KB
-// runeCoverage bitmap and dropped, so a rune nobody covers cannot make the
-// chain retain everything, and each file is parsed at most twice over the
-// process lifetime: once to learn its coverage, once more only if a covered
-// rune ever shows up.
-type guiFallbackChain struct {
-	mu      sync.Mutex
-	size    float64
-	dpi     float64
-	entries []guiFallbackEntry
+// Both GUI backends share this engine; the face type and the parse mechanics
+// arrive as closures. The chain itself carries the policy the backends must
+// agree on:
+//
+//   - Fonts are consulted in list order, so the priority of fallbackFontPaths
+//     is preserved exactly.
+//   - A font is retained, and returned, only if it renders a glyph for the
+//     rune. covers alone is not enough: a color-bitmap emoji font maps runes
+//     in its cmap that x/image cannot rasterize, and selecting on the cmap
+//     would blank those runes instead of falling through to the next font.
+//   - A font that was parsed and not retained is condensed into a
+//     runeCoverage bitmap and dropped, so from then on it answers "does this
+//     font cover r" without being in memory.
+//   - Every answer — including "nobody renders it" — is memoised per rune, so
+//     a rune no font covers pays for the full walk exactly once.
+type fontFallbackChain struct {
+	mu sync.Mutex
+
+	open    func(path string) (any, error) // parse a file into a face
+	covers  func(face any, r rune) bool    // cmap probe, cheap; feeds runeCoverage
+	renders func(face any, r rune) bool    // can the face produce an actual glyph image
+	drop    func(face any)                 // release a face that was not retained
+	logTag  string                         // backend prefix for DebugLog lines
+
+	entries  []fontFallbackEntry
+	resolved map[rune]any // memoised faceFor answers; nil = nobody renders it
 }
 
-type guiFallbackEntry struct {
+type fontFallbackEntry struct {
 	path   string
 	failed bool          // unreadable or unparseable; never try again
-	cov    *runeCoverage // built on first parse, nil until then
-	face   font.Face     // retained only once the font has supplied a glyph
+	cov    *runeCoverage // built when the font is probed and dropped, nil until then
+	face   any           // retained only once the font has rendered a glyph
 }
 
-// faceFor returns the first fallback face that owns a glyph for r, walking
-// the fonts in priority order, or nil when none of them covers it.
-func (c *guiFallbackChain) faceFor(r rune) font.Face {
+// faceFor returns the first fallback face that renders a glyph for r, walking
+// the fonts in priority order, or nil when none of them does. A repeat call
+// for the same rune is a map lookup.
+func (c *fontFallbackChain) faceFor(r rune) any {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if f, ok := c.resolved[r]; ok {
+		return f
+	}
+	f := c.resolveLocked(r)
+	if c.resolved == nil {
+		c.resolved = make(map[rune]any, 256)
+	}
+	c.resolved[r] = f
+	return f
+}
+
+func (c *fontFallbackChain) resolveLocked(r rune) any {
 	for i := range c.entries {
 		e := &c.entries[i]
 		if e.failed {
 			continue
 		}
 		if e.face != nil {
-			if _, ok := e.face.GlyphAdvance(r); ok {
+			if c.renders(e.face, r) {
 				return e.face
 			}
 			continue
 		}
-		if e.cov != nil && !e.cov.maybeHas(r) {
+		if e.cov != nil && !e.cov.has(r) {
 			continue
 		}
 
-		face, err := openFallbackFace(e.path, c.size, c.dpi)
+		t0 := time.Now()
+		face, err := c.open(e.path)
 		if err != nil {
 			e.failed = true
-			DebugLog("GUI_FONT: fallback present but unusable: %s: %v", e.path, err)
+			DebugLog("%s: fallback present but unusable: %s: %v", c.logTag, e.path, err)
 			continue
 		}
-		if e.cov == nil {
-			cov := &runeCoverage{}
-			for probe := rune(0); probe < 0x20000; probe++ {
-				if probe >= 0xD800 && probe <= 0xDFFF {
-					continue // surrogates are not runes a cmap can hold
-				}
-				if _, ok := face.GlyphAdvance(probe); ok {
-					cov.bits[probe>>6] |= 1 << (uint(probe) & 63)
-				}
-			}
-			e.cov = cov
-		}
-		if _, ok := face.GlyphAdvance(r); ok {
+		if c.renders(face, r) {
 			e.face = face
-			DebugLog("GUI_FONT: fallback loaded for U+%04X: %s", r, e.path)
+			DebugLog("%s: fallback loaded for U+%04X: %s in %v", c.logTag, r, e.path, time.Since(t0))
 			return face
 		}
-		// Parsed, mapped into the bitmap, not needed: dropped here, and the
+		// Parsed and not needed. Condense into the bitmap — unless a warm()
+		// sweep already has; a retained font never needs one — and drop; the
 		// bitmap answers for this font from now on.
-		_ = face.Close()
-		DebugLog("GUI_FONT: fallback probed for U+%04X and dropped: %s", r, e.path)
+		if e.cov == nil {
+			e.cov = c.coverageOf(face)
+		}
+		c.drop(face)
+		DebugLog("%s: fallback probed for U+%04X and dropped: %s in %v", c.logTag, r, e.path, time.Since(t0))
 	}
 	return nil
 }
 
-func (c *guiFallbackChain) close() error {
+func (c *fontFallbackChain) coverageOf(face any) *runeCoverage {
+	cov := &runeCoverage{}
+	for r := rune(0); r < runeCoverageMax; r++ {
+		if r >= 0xD800 && r <= 0xDFFF {
+			continue // surrogates are not runes a cmap can hold
+		}
+		if c.covers(face, r) {
+			cov.bits[r>>6] |= 1 << (uint(r) & 63)
+		}
+	}
+	return cov
+}
+
+// warm parses each not-yet-consulted entry once, in the background, building
+// its coverage bitmap and dropping the parse. Without it the first rune the
+// primary font lacks pays for parsing every fallback font ahead of the
+// covering one — synchronously, mid-frame, at whatever moment the first emoji
+// or CJK character happens to appear. The lock is taken per entry, so a
+// concurrent faceFor interleaves between files instead of waiting out the
+// whole sweep.
+func (c *fontFallbackChain) warm() {
+	go func() {
+		for i := 0; ; i++ {
+			c.mu.Lock()
+			if i >= len(c.entries) {
+				c.mu.Unlock()
+				return
+			}
+			e := &c.entries[i]
+			if !e.failed && e.face == nil && e.cov == nil {
+				t0 := time.Now()
+				if face, err := c.open(e.path); err != nil {
+					e.failed = true
+					DebugLog("%s: fallback present but unusable: %s: %v", c.logTag, e.path, err)
+				} else {
+					e.cov = c.coverageOf(face)
+					c.drop(face)
+					DebugLog("%s: fallback coverage warmed: %s in %v", c.logTag, e.path, time.Since(t0))
+				}
+			}
+			c.mu.Unlock()
+		}
+	}()
+}
+
+// close releases every retained face and forgets the memoised answers.
+// Coverage bitmaps and failure marks survive: they stay correct for the files
+// on disk.
+func (c *fontFallbackChain) close() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var err error
 	for i := range c.entries {
 		if f := c.entries[i].face; f != nil {
-			if e := f.Close(); e != nil {
-				err = e
-			}
+			c.drop(f)
 			c.entries[i].face = nil
 		}
 	}
-	return err
+	c.resolved = nil
 }
 
-func openFallbackFace(path string, size, dpi float64) (font.Face, error) {
+// newGUIFallbackChain binds the shared chain to x/image faces. covers is the
+// plain cmap probe; renders actually rasterizes, because a color-bitmap emoji
+// font (e.g. NotoColorEmoji) passes the cmap probe and then fails Glyph with
+// ErrColoredGlyph — such a font must be passed over, not selected.
+func newGUIFallbackChain(size, dpi float64) *fontFallbackChain {
+	return &fontFallbackChain{
+		logTag: "GUI_FONT",
+		open: func(path string) (any, error) {
+			return openFace(path, size, dpi)
+		},
+		covers: func(face any, r rune) bool {
+			_, ok := face.(font.Face).GlyphAdvance(r)
+			return ok
+		},
+		renders: func(face any, r rune) bool {
+			_, _, _, _, ok := face.(font.Face).Glyph(fixed.Point26_6{}, r)
+			return ok
+		},
+		drop: func(face any) { _ = face.(font.Face).Close() },
+	}
+}
+
+// openFace builds a face the way both the primary loop and the fallback chain
+// need one: same options, so primary and fallback glyphs share metrics.
+func openFace(path string, size, dpi float64) (font.Face, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -222,7 +313,7 @@ func openFallbackFace(path string, size, dpi float64) (font.Face, error) {
 
 type fallbackFace struct {
 	faces []font.Face
-	chain *guiFallbackChain
+	chain *fontFallbackChain
 }
 
 func (f *fallbackFace) Close() error {
@@ -233,9 +324,7 @@ func (f *fallbackFace) Close() error {
 		}
 	}
 	if f.chain != nil {
-		if e := f.chain.close(); e != nil {
-			err = e
-		}
+		f.chain.close()
 	}
 	return err
 }
@@ -256,12 +345,15 @@ func (f *fallbackFace) Kern(r0, r1 rune) fixed.Int26_6 {
 
 // chainFace resolves r through the lazy chain, or nil when the chain is
 // absent or exhausted. Each glyph method consults it only after every
-// already-open face has answered "no glyph".
+// already-open face has answered "no glyph". A non-nil result is a face that
+// renders r — the chain selects by rasterization, not the cmap — so the glyph
+// methods can return its answer without a further ok-check.
 func (f *fallbackFace) chainFace(r rune) font.Face {
 	if f.chain == nil {
 		return nil
 	}
-	return f.chain.faceFor(r)
+	face, _ := f.chain.faceFor(r).(font.Face)
+	return face
 }
 
 func (f *fallbackFace) GlyphBounds(r rune) (bounds fixed.Rectangle26_6, advance fixed.Int26_6, ok bool) {
@@ -373,24 +465,11 @@ func loadBestFont(fontName string, size float64, dpi float64) (font.Face, int, i
 	var cellW, cellH int
 
 	for _, path := range getFontCandidates(fontName) {
-		data, err := os.ReadFile(path)
+		face, err := openFace(path, size, dpi)
 		if err != nil {
-			continue
-		}
-
-		f, err := parseFontBytes(data)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "GUI_FONT: Error parsing %s: %v\n", path, err)
-			continue
-		}
-
-		face, err := opentype.NewFace(f, &opentype.FaceOptions{
-			Size:    size,
-			DPI:     dpi,
-			Hinting: font.HintingFull,
-		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "GUI_FONT: Error creating face for %s: %v\n", path, err)
+			if !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "GUI_FONT: Error loading %s: %v\n", path, err)
+			}
 			continue
 		}
 
@@ -416,16 +495,19 @@ func loadBestFont(fontName string, size float64, dpi float64) (font.Face, int, i
 	// opened by the chain on first use. The old loop read and parsed every
 	// fallback font here, which held hundreds of megabytes for glyphs most
 	// sessions never draw.
-	var chain *guiFallbackChain
+	var chain *fontFallbackChain
 	for _, path := range fallbackFontPaths {
 		if _, err := os.Stat(path); err != nil {
 			continue
 		}
 		DebugLog("GUI_FONT: fallback present, deferred until first use: %s", path)
 		if chain == nil {
-			chain = &guiFallbackChain{size: size, dpi: dpi}
+			chain = newGUIFallbackChain(size, dpi)
 		}
-		chain.entries = append(chain.entries, guiFallbackEntry{path: path})
+		chain.entries = append(chain.entries, fontFallbackEntry{path: path})
+	}
+	if chain != nil {
+		chain.warm()
 	}
 
 	return &fallbackFace{faces: []font.Face{primaryFace}, chain: chain}, cellW, cellH

--- a/gui_font.go
+++ b/gui_font.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/basicfont"
@@ -76,6 +77,25 @@ var fallbackFontPaths = []string{
 	"/Library/Fonts/Arial Unicode.ttf",
 }
 
+// runeCoverage is a bitmap of the runes a font has glyphs for, over planes 0
+// and 1 — everything a terminal plausibly draws, emoji included. Runes above
+// plane 1 are so rare that "maybe" (and a re-parse to find out) is the right
+// answer for them. It is shared by the gogpu backend's fallbackFontChain and
+// the guiFallbackChain below.
+type runeCoverage struct {
+	bits [0x20000 / 64]uint64
+}
+
+func (c *runeCoverage) maybeHas(r rune) bool {
+	if r < 0 {
+		return false
+	}
+	if r >= 0x20000 {
+		return true
+	}
+	return c.bits[r>>6]&(1<<(uint(r)&63)) != 0
+}
+
 func parseFontBytes(data []byte) (*opentype.Font, error) {
 	f, err := opentype.Parse(data)
 	if err == nil {
@@ -91,14 +111,129 @@ func parseFontBytes(data []byte) (*opentype.Font, error) {
 	return nil, err
 }
 
+// guiFallbackChain is the x/image twin of the gogpu backend's
+// fallbackFontChain: it opens a fallback font file the first time a rune
+// actually needs it, and keeps in memory only the fonts that have supplied a
+// glyph. The eager version parsed every fallback font on the machine at
+// startup — on a Linux install with Noto CJK that is hundreds of megabytes
+// held for glyphs that almost never render (the same bug measured at ~800 MB
+// on macOS in the gogpu backend).
+//
+// A parsed font that lacks the requested rune is condensed into a 16 KB
+// runeCoverage bitmap and dropped, so a rune nobody covers cannot make the
+// chain retain everything, and each file is parsed at most twice over the
+// process lifetime: once to learn its coverage, once more only if a covered
+// rune ever shows up.
+type guiFallbackChain struct {
+	mu      sync.Mutex
+	size    float64
+	dpi     float64
+	entries []guiFallbackEntry
+}
+
+type guiFallbackEntry struct {
+	path   string
+	failed bool          // unreadable or unparseable; never try again
+	cov    *runeCoverage // built on first parse, nil until then
+	face   font.Face     // retained only once the font has supplied a glyph
+}
+
+// faceFor returns the first fallback face that owns a glyph for r, walking
+// the fonts in priority order, or nil when none of them covers it.
+func (c *guiFallbackChain) faceFor(r rune) font.Face {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := range c.entries {
+		e := &c.entries[i]
+		if e.failed {
+			continue
+		}
+		if e.face != nil {
+			if _, ok := e.face.GlyphAdvance(r); ok {
+				return e.face
+			}
+			continue
+		}
+		if e.cov != nil && !e.cov.maybeHas(r) {
+			continue
+		}
+
+		face, err := openFallbackFace(e.path, c.size, c.dpi)
+		if err != nil {
+			e.failed = true
+			DebugLog("GUI_FONT: fallback present but unusable: %s: %v", e.path, err)
+			continue
+		}
+		if e.cov == nil {
+			cov := &runeCoverage{}
+			for probe := rune(0); probe < 0x20000; probe++ {
+				if probe >= 0xD800 && probe <= 0xDFFF {
+					continue // surrogates are not runes a cmap can hold
+				}
+				if _, ok := face.GlyphAdvance(probe); ok {
+					cov.bits[probe>>6] |= 1 << (uint(probe) & 63)
+				}
+			}
+			e.cov = cov
+		}
+		if _, ok := face.GlyphAdvance(r); ok {
+			e.face = face
+			DebugLog("GUI_FONT: fallback loaded for U+%04X: %s", r, e.path)
+			return face
+		}
+		// Parsed, mapped into the bitmap, not needed: dropped here, and the
+		// bitmap answers for this font from now on.
+		_ = face.Close()
+		DebugLog("GUI_FONT: fallback probed for U+%04X and dropped: %s", r, e.path)
+	}
+	return nil
+}
+
+func (c *guiFallbackChain) close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var err error
+	for i := range c.entries {
+		if f := c.entries[i].face; f != nil {
+			if e := f.Close(); e != nil {
+				err = e
+			}
+			c.entries[i].face = nil
+		}
+	}
+	return err
+}
+
+func openFallbackFace(path string, size, dpi float64) (font.Face, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	f, err := parseFontBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	return opentype.NewFace(f, &opentype.FaceOptions{
+		Size:    size,
+		DPI:     dpi,
+		Hinting: font.HintingFull,
+	})
+}
+
 type fallbackFace struct {
 	faces []font.Face
+	chain *guiFallbackChain
 }
 
 func (f *fallbackFace) Close() error {
 	var err error
 	for _, face := range f.faces {
 		if e := face.Close(); e != nil {
+			err = e
+		}
+	}
+	if f.chain != nil {
+		if e := f.chain.close(); e != nil {
 			err = e
 		}
 	}
@@ -119,12 +254,25 @@ func (f *fallbackFace) Kern(r0, r1 rune) fixed.Int26_6 {
 	return 0
 }
 
+// chainFace resolves r through the lazy chain, or nil when the chain is
+// absent or exhausted. Each glyph method consults it only after every
+// already-open face has answered "no glyph".
+func (f *fallbackFace) chainFace(r rune) font.Face {
+	if f.chain == nil {
+		return nil
+	}
+	return f.chain.faceFor(r)
+}
+
 func (f *fallbackFace) GlyphBounds(r rune) (bounds fixed.Rectangle26_6, advance fixed.Int26_6, ok bool) {
 	for _, face := range f.faces {
 		bounds, advance, ok = face.GlyphBounds(r)
 		if ok {
 			return bounds, advance, ok
 		}
+	}
+	if face := f.chainFace(r); face != nil {
+		return face.GlyphBounds(r)
 	}
 	if len(f.faces) > 0 {
 		return f.faces[0].GlyphBounds(r)
@@ -139,6 +287,9 @@ func (f *fallbackFace) GlyphAdvance(r rune) (advance fixed.Int26_6, ok bool) {
 			return advance, ok
 		}
 	}
+	if face := f.chainFace(r); face != nil {
+		return face.GlyphAdvance(r)
+	}
 	if len(f.faces) > 0 {
 		return f.faces[0].GlyphAdvance(r)
 	}
@@ -151,6 +302,9 @@ func (f *fallbackFace) Glyph(dot fixed.Point26_6, r rune) (dr image.Rectangle, m
 		if ok {
 			return dr, mask, maskp, advance, ok
 		}
+	}
+	if face := f.chainFace(r); face != nil {
+		return face.Glyph(dot, r)
 	}
 	if len(f.faces) > 0 {
 		return f.faces[0].Glyph(dot, r)
@@ -258,27 +412,21 @@ func loadBestFont(fontName string, size float64, dpi float64) (font.Face, int, i
 		return basicfont.Face7x13, 7, 13
 	}
 
-	faces := []font.Face{primaryFace}
-
+	// Existence is all the startup probe checks; the files themselves are
+	// opened by the chain on first use. The old loop read and parsed every
+	// fallback font here, which held hundreds of megabytes for glyphs most
+	// sessions never draw.
+	var chain *guiFallbackChain
 	for _, path := range fallbackFontPaths {
-		data, err := os.ReadFile(path)
-		if err != nil {
+		if _, err := os.Stat(path); err != nil {
 			continue
 		}
-		f, err := parseFontBytes(data)
-		if err != nil {
-			continue
+		DebugLog("GUI_FONT: fallback present, deferred until first use: %s", path)
+		if chain == nil {
+			chain = &guiFallbackChain{size: size, dpi: dpi}
 		}
-		face, err := opentype.NewFace(f, &opentype.FaceOptions{
-			Size:    size,
-			DPI:     dpi,
-			Hinting: font.HintingFull,
-		})
-		if err != nil {
-			continue
-		}
-		faces = append(faces, face)
+		chain.entries = append(chain.entries, guiFallbackEntry{path: path})
 	}
 
-	return &fallbackFace{faces: faces}, cellW, cellH
+	return &fallbackFace{faces: []font.Face{primaryFace}, chain: chain}, cellW, cellH
 }


### PR DESCRIPTION
## Summary

Both GUI backends used to read and parse every fallback font on the machine at startup — on a stock macOS that is ~400 MB of font files, held twice over by gg in the gogpu backend (~800 MB of heap), almost all of it for glyphs that never render. This PR loads fallback fonts on first use instead, on both the gogpu and x/image paths, and then unifies the two implementations into one shared chain with the defects found in review fixed.

- **gogpu + x/image backends**: a fallback font file is opened the first time a rune actually needs it; only fonts that have supplied a glyph stay in memory. A font that is probed and not needed is condensed into a coverage bitmap and dropped.
- **Shared `fontFallbackChain`**: the two per-backend twins are merged into one engine parameterized by `open`/`covers`/`renders`/`drop` closures, so both backends follow the same policy and future fixes land once.
- **Correctness**: a font is selected only if it *renders* the rune, not merely maps it — a color-bitmap emoji font (e.g. NotoColorEmoji, which x/image cannot rasterize) is passed over instead of blanking emoji cells. Coverage bitmaps span all of Unicode and every resolution is memoised per rune (negative answers included), so plane-2 CJK ideographs can no longer trigger unbounded re-parsing of fallback files.
- **Latency**: coverage bitmaps are warmed in a background goroutine right after startup, so the first emoji/CJK rune drawn consults bitmaps and parses exactly the one font that will draw it, instead of parsing every fallback ahead of it mid-frame.
- Also included on the branch: macOS chord handling fixes in the gogpu host (per-keystroke text claims, Alt-only Char fill).

## Test plan

- `go build ./...`, `gofmt`, `go vet` clean (one pre-existing vet warning in `test_main_test.go`, present on main).
- Full test suite passes apart from the pre-existing `TestFrameManager_*` hangs, which reproduce identically on unchanged main.
- f4 built and launched against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)