### PR TITLE
test: close debug log handle so TempDir cleanup works on Windows

### DIFF
--- a/debug_test.go
+++ b/debug_test.go
@@ -41,7 +41,17 @@ func TestDebugLog_Rotation(t *testing.T) {
 	log2 := strings.TrimSuffix(baseLog, ".log") + ".2.log"
 
 	os.Setenv("VTUI_DEBUG", baseLog)
-	defer os.Setenv("VTUI_DEBUG", "")
+	defer func() {
+		os.Setenv("VTUI_DEBUG", "")
+		// Close the handle opened by the last DebugLog before t.TempDir
+		// cleanup unlinks the log: Windows cannot remove an open file.
+		logMu.Lock()
+		if logFile != nil {
+			logFile.Close()
+			logFile = nil
+		}
+		logMu.Unlock()
+	}()
 
 	// Helper to reset internal state for testing
 	resetRotation := func() {


### PR DESCRIPTION
## What

`TestDebugLog_Rotation` sets `VTUI_DEBUG` to a file inside `t.TempDir()`, and `DebugLog` opens it into the package-wide `logFile` handle. The test only reset the env var in its defer and never closed the handle, so on Windows `t.TempDir()` cleanup could not unlink `rotation.log`:

```
TempDir RemoveAll cleanup: unlinkat ... rotation.log: The process cannot access the file because it is being used by another process.
```

The defer now also closes `logFile`, matching the existing `TestDebugLog_CustomFile` cleanup.

## Verification

- `go test -run 'TestDebugLog_Rotation|TestDebugLog_CustomFile' -count=1` — both PASS on native Windows
- `gofmt` clean
- Test-only change; no production code touched