### PR TITLE
tasks: don't clean up the stderr log on every async task completion

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -41,7 +41,6 @@ func RunAsync(worker func(ctx *TaskContext)) *TaskContext {
 				CleanupStderrLog()
 				os.Exit(2)
 			}
-			CleanupStderrLog()
 		}()
 		worker(taskCtx)
 	}()


### PR DESCRIPTION
RunAsync deferred CleanupStderrLog() on every successful background
task, not just on process exit. On Windows RedirectStderr replaces
os.Stderr with the log file itself, so that Close() permanently
invalidates the process's standard error stream mid-run.

Colorer (wazero) calls os.Stderr.Stat() when starting a session; with
stderr closed it fails ("The handle is invalid"), the session pool stays
empty and callers retry a full ~90ms session creation on every frame.

close https://github.com/unxed/f4/issues/516
close https://github.com/unxed/f4/issues/517
