### PR TITLE
ansi: batch palette OSC 4 and stop post-Suspend flushes, fixing iTerm2 freezes

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -1168,7 +1168,13 @@ func (fm *frameManager) Shutdown() {
 	fm.capturedFrame = nil
 	if fm.scr != nil {
 		fm.scr.SetCursorVisible(true)
-		fm.scr.Flush()
+		// If a Suspend already restored the terminal (quit path), this flush
+		// would paint a full frame -- including the theme palette OSC 4 dump
+		// -- onto the user's shell screen, and the Suspend() below is a
+		// no-op that never resets it back.
+		if _, ansi := fm.scr.Renderer.(*AnsiRenderer); !ansi || IsPrepared() {
+			fm.scr.Flush()
+		}
 	}
 	Suspend()
 	CleanupStderrLog()
@@ -2076,7 +2082,13 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 		fm.running = false
 		if fm.scr != nil {
 			fm.scr.SetCursorVisible(true)
-			fm.scr.Flush()
+			// Skip the flush if Suspend already restored the terminal: this
+			// defer runs after the quit path's Suspend(), and a frame written
+			// now lands on the user's shell screen and re-applies the theme
+			// palette OSC 4 that Suspend's OSC 104 just reset.
+			if _, ansi := fm.scr.Renderer.(*AnsiRenderer); !ansi || IsPrepared() {
+				fm.scr.Flush()
+			}
 		}
 		CleanupStderrLog()
 	}()

--- a/palette_batch_test.go
+++ b/palette_batch_test.go
@@ -1,0 +1,39 @@
+package vtui
+
+import (
+	"strings"
+	"testing"
+)
+
+// SetPalette must pack every changed color into a single OSC 4 message
+// (xterm accepts multiple ;index;spec pairs). Terminals that repaint per
+// OSC message — iTerm2 among them — take multiple seconds to process 256
+// individual messages, which froze startup and exit visibly.
+func TestSetPaletteSingleOSC4Message(t *testing.T) {
+	s := NewScreenBuf()
+	r := s.Renderer.(*AnsiRenderer)
+
+	var pal [256]uint32
+	for i := range pal {
+		pal[i] = uint32(i) * 0x010101
+	}
+	r.SetPalette(&pal)
+
+	out := string(r.frameOut)
+	if got := strings.Count(out, "\x1b]4"); got != 1 {
+		t.Fatalf("want all changed colors in 1 OSC 4 message, got %d messages", got)
+	}
+	if pairs := strings.Count(out, ";rgb:"); pairs != 256 {
+		t.Fatalf("want 256 color pairs, got %d", pairs)
+	}
+	if !strings.HasSuffix(out, "\x07") {
+		t.Fatalf("OSC 4 message not BEL-terminated: %q", out[len(out)-16:])
+	}
+
+	// A second call with the same palette must emit nothing.
+	r.frameOut.Reset()
+	r.SetPalette(&pal)
+	if r.frameOut.Len() != 0 {
+		t.Fatalf("unchanged palette re-emitted %d bytes", r.frameOut.Len())
+	}
+}

--- a/screenbuf.go
+++ b/screenbuf.go
@@ -805,17 +805,26 @@ func (r *AnsiRenderer) SetPalette(pal *[256]uint32) {
 	if pal == nil {
 		return
 	}
+	// All changed entries go into a single OSC 4 message (xterm accepts
+	// multiple ;index;spec pairs). One message per frame instead of up to
+	// 256: terminals that repaint per OSC message (iTerm2) take seconds to
+	// chew through individual messages, which showed up as a multi-second
+	// visible freeze on startup and exit.
 	changed := false
 	for i := 0; i < 256; i++ {
 		if !r.parent.HostPaletteValid[i] || r.parent.HostPalette[i] != pal[i] {
-			changed = true
+			if !changed {
+				changed = true
+				r.frameOut.WriteString("\x1b]4")
+			}
 			pr, pg, pb := rgb(pal[i])
-			r.frameOut.WriteString(fmt.Sprintf("\x1b]4;%d;rgb:%02x/%02x/%02x\x07", i, pr, pg, pb))
+			r.frameOut.WriteString(fmt.Sprintf(";%d;rgb:%02x/%02x/%02x", i, pr, pg, pb))
 			r.parent.HostPalette[i] = pal[i]
 			r.parent.HostPaletteValid[i] = true
 		}
 	}
 	if changed {
+		r.frameOut.WriteString("\x07")
 		r.parent.quantCache = make(map[uint32]uint8)
 	}
 }

--- a/terminal_env.go
+++ b/terminal_env.go
@@ -61,6 +61,17 @@ func PrepareTerminal() (func(), error) {
 
 // Suspend fully restores the terminal state (exits raw mode, alternate screen, etc.).
 // Useful when temporarily returning control to the shell or an external program.
+// IsPrepared reports whether the terminal is currently in the raw/alt-screen
+// state (between Resume and Suspend). Frame flushes must not reach the host
+// terminal outside that window: Suspend has already reset the palette and
+// attributes, and a late frame would repaint the theme palette (OSC 4) right
+// over the user's restored shell.
+func IsPrepared() bool {
+	termMu.Lock()
+	defer termMu.Unlock()
+	return isPrepared
+}
+
 func Suspend() {
 	termMu.Lock()
 	defer termMu.Unlock()


### PR DESCRIPTION
## Problem

On iTerm2, f4 `--tty` startup freezes for ~5 seconds before panels appear, and after quitting the terminal either freezes again (with sync output) or is left with wrong colors. Terminal.app is unaffected. Reproduced and bisected against live byte-stream captures of `f4 --tty`.

## Causes

**1. Palette flood.** `SetPalette` emits up to 256 individual `OSC 4` messages per palette load. iTerm2 repaints per OSC message and takes seconds to process the burst (easily reproduced: `for i in {0..255}; do printf "\\033]4;%d;rgb:80/80/80\\007" $i; done` visibly hangs iTerm2, while the same 256 pairs in a single OSC 4 are instant). Terminal.app ignores OSC 4 entirely, which is why it never showed the problem.

**2. Post-Suspend frame flush.** The quit path runs `Suspend()` (OSC 104 palette reset, `isPrepared` drops) before `frameManager.Shutdown()` and `Run()`'s deferred cleanup — yet both still flush a final frame. `InvalidateHostPalette()` has marked every entry stale, so that frame re-applies the full theme palette onto the user's restored shell screen, and Shutdown's own trailing `Suspend()` is a no-op by then, so nothing ever resets it. The user's terminal keeps f4's theme colors after exit.

## Fix

- `SetPalette` packs all changed entries into a single `OSC 4` message with multiple `;index;spec` pairs (standard xterm syntax).
- Both post-Suspend flushes are skipped when the terminal is no longer prepared, via a new `IsPrepared()` accessor. GUI renderers keep the old behavior.

Adds `TestSetPaletteSingleOSC4Message`: one OSC 4 message, 256 pairs, BEL-terminated, and no re-emission for an unchanged palette — red before the fix, green after. Verified end-to-end: startup is instant on iTerm2 and the exit stream ends with the normal teardown (OSC 104 last) instead of a palette dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)