### PR TITLE
clipboard: serialize and thread-pin raw Win32 clipboard transactions

### DIFF
--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -3,9 +3,20 @@
 package vtui
 
 import (
+	"runtime"
+	"sync"
 	"syscall"
 	"unsafe"
 )
+
+// osClipMu serializes every raw Win32 clipboard transaction. OpenClipboard
+// ties ownership to the calling thread, so the sequence also pins its
+// goroutine to one OS thread: without both, two concurrent writers (or a
+// goroutine migrating threads mid-transaction) corrupt handle ownership --
+// SetClipboardData transfers the HGLOBAL to the system, and a racing failure
+// path then GlobalFrees memory the system already owns, killing the process
+// with no Go-visible error.
+var osClipMu sync.Mutex
 
 var (
 	user32               = syscall.NewLazyDLL("user32.dll")
@@ -28,6 +39,10 @@ const (
 )
 
 func setOSClipboard(text string) bool {
+	osClipMu.Lock()
+	defer osClipMu.Unlock()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if err := procOpenClipboard.Find(); err != nil {
 		return false
 	}
@@ -73,6 +88,10 @@ func setOSClipboard(text string) bool {
 }
 
 func getOSClipboard() (string, bool) {
+	osClipMu.Lock()
+	defer osClipMu.Unlock()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if err := procOpenClipboard.Find(); err != nil {
 		return "", false
 	}


### PR DESCRIPTION
## Problem

Raw Win32 clipboard transactions in `clipboard_windows.go` were neither serialized nor pinned to an OS thread. `OpenClipboard` ties the clipboard to the calling thread, and `SetClipboardData` transfers ownership of the `HGLOBAL` to the system. Two things could go wrong, and both did under load:

- concurrent writers (e.g. far2l extension clipboard traffic from multiple goroutines) interleave open/set/close sequences;
- the Go scheduler can migrate a goroutine to another OS thread mid-transaction, so `CloseClipboard` runs on a different thread than `OpenClipboard`.

When a racing failure path then calls `GlobalFree` on memory the system already owns, the process dies from heap corruption **with no Go-visible error** — no panic, no exit message. In f4 this killed the whole `cmd/f4` test binary with zero output; `TestTerminalView_ProcessFar2lInteract_ConcurrentRace` reproduces it reliably.

## Fix

A package-level mutex serializes `setOSClipboard`/`getOSClipboard`, and each transaction runs under `runtime.LockOSThread` so open and close happen on the same OS thread. Windows-only change; no behavior change on other platforms.

Verified: f4's full test suite (including the concurrent far2l clipboard race test) is green on windows-latest with this pinned.


## Downstream

Needed by **unxed/f4#545** (native 3-OS test CI): without this fix the concurrent clipboard race silently kills f4's whole `cmd/f4` test binary on Windows — f4 currently pins this branch via a temporary `replace`, to be swapped for a real version bump once this merges and gets a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
