### PR TITLE
clipboard: export the skip-OS-clipboard test knob

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -34,6 +34,15 @@ func DisableTerminalClipboard() { noTerminalBehind.Store(true) }
 // TerminalClipboardDisabled reports whether the OSC 52 fallback is suppressed.
 func TerminalClipboardDisabled() bool { return noTerminalBehind.Load() }
 
+// SkipOSClipboard routes Set/GetClipboard past the OS clipboard helpers so
+// all traffic stays in the process-local buffer. Test suites set it (together
+// with DisableTerminalClipboard to silence the OSC 52 fallback): the real
+// path shells out to pbcopy/xclip and reads back a clipboard that is global
+// to the machine — slow and racy on a shared CI runner, and clobbering the
+// developer's clipboard locally. Set it once before spawning goroutines;
+// a test that genuinely targets the OS clipboard can switch it back off.
+func SkipOSClipboard(skip bool) { testSkipOSClipboard = skip }
+
 // SetClipboard copies text to the system clipboard.
 func SetClipboard(text string) {
 	DebugLog("CLIPBOARD: SetClipboard called, len: %d", len(text))


### PR DESCRIPTION
## Why

f4's test suite currently talks to the machine's real clipboard: on macOS every `SetClipboard`/`GetClipboard` shells out to pbcopy/pbpaste against the pasteboard daemon. `TestAction_PanelCopySelectedNames` polls the clipboard every 5ms with a 2s deadline — that's up to ~400 process spawns on a loaded CI runner, and the test flakes when the pasteboard round-trip doesn't make it in time (observed on macos-latest in unxed/f4 CI). As a side effect, running f4's tests locally clobbers the developer's actual clipboard.

The fix on the f4 side is to keep test clipboard traffic in vtui's process-local buffer. vtui already has exactly the right switch — `testSkipOSClipboard`, which vtui's own tests set for the same reason — but it's unexported, and f4 can't reach it. Intercepting on the f4 side instead doesn't work: paste (e.g. Shift+Ins into the command line) is handled inside vtui's Edit widget, which reads the clipboard within the library.

## What

Exports the existing switch (9 lines, no behavior change for applications):

```go
func SkipOSClipboard(skip bool) { testSkipOSClipboard = skip }
```

Intended use is a test suite's `TestMain`, together with the already-exported `DisableTerminalClipboard()` so the OSC 52 stdout fallback stays quiet too. A test that genuinely targets the OS clipboard (f4's Win32 clipboard race reproducer) can switch it back off for its own scope.

## Next

Once this is merged and tagged, I'll follow up with the f4 PR that flips the knob in its `TestMain` (plus the rest of the deflaking work: native arm64/intel test runners and deterministic highlight-budget tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
