### PR TITLE
Support fractional Wayland scaling and startup reflow

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -1849,6 +1849,12 @@ func (fm *frameManager) Resize(width, height int) {
 		return
 	}
 	if width == fm.scr.width && height == fm.scr.height {
+		// A pixel renderer can replace its backing buffer without changing the
+		// terminal grid (for example after a Wayland fractional-scale update).
+		// Frames still need to recalculate their geometry in that case; a plain
+		// redraw leaves the startup layout sized for the old backing buffer.
+		fm.ResizeAllScreens()
+		fm.Redraw()
 		return
 	}
 	fm.scr.AllocBuf(width, height)

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -1122,6 +1122,22 @@ func TestFrameManager_ResizeAllScreens(t *testing.T) {
 	}
 }
 
+func TestFrameManager_ResizeSameGridReflowsFrames(t *testing.T) {
+	fm := &frameManager{}
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(100, 30)
+	fm.Init(scr)
+
+	frame := &mockFrame{}
+	fm.Push(frame)
+	frame.resizedW, frame.resizedH = 0, 0
+
+	fm.Resize(100, 30)
+	if frame.resizedW != 100 || frame.resizedH != 30 {
+		t.Fatalf("same-grid Resize() did not reflow frame: got %dx%d, want 100x30", frame.resizedW, frame.resizedH)
+	}
+}
+
 func TestFrameManager_SizePolling(t *testing.T) {
 	oldGetSize := GetTerminalSize
 	defer func() { GetTerminalSize = oldGetSize }()

--- a/wayland_host.go
+++ b/wayland_host.go
@@ -130,6 +130,15 @@ func runInWaylandWindow(cols, rows int, fontName string, fontSize float64, setup
 // -- window.WidgetHandler Implementation --
 
 func (h *WaylandHost) Resize(widget *window.Widget, width int32, height int32, pwidth int32, pheight int32) {
+	// xdg_toplevel is allowed to send an initial 0x0 configure while the
+	// surface is being mapped. It is not a usable pixel size: accepting it
+	// would replace the backing image with an empty one and permanently zero
+	// the terminal grid before the first real configure arrives.
+	if !hasWaylandPixelSize(width, height, pwidth, pheight) {
+		DebugLog("WAYLAND: ignoring zero-sized configure logical=%dx%d pixels=%dx%d", width, height, pwidth, pheight)
+		return
+	}
+
 	h.mu.Lock()
 	targetCols, targetRows := h.cols, h.rows
 	scaleChanged := h.updateScaleLocked(waylandScaleFromDimensions(width, height, pwidth, pheight))
@@ -167,6 +176,10 @@ func (h *WaylandHost) Resize(widget *window.Widget, width int32, height int32, p
 			FrameManager.Redraw()
 		}
 	}
+}
+
+func hasWaylandPixelSize(width, height, pwidth, pheight int32) bool {
+	return width > 0 && height > 0 && pwidth > 0 && pheight > 0
 }
 
 func waylandScaleFromDimensions(width, height, pwidth, pheight int32) float64 {

--- a/wayland_host.go
+++ b/wayland_host.go
@@ -5,6 +5,7 @@ package vtui
 import (
 	"image"
 	"io"
+	"math"
 	"sync"
 	"time"
 
@@ -25,7 +26,7 @@ type WaylandHost struct {
 	cols, rows int
 	cellW      int
 	cellH      int
-	scale      int
+	scale      float64
 	fontName   string
 	fontSize   float64
 	screen     *ScreenBuf
@@ -56,7 +57,8 @@ func runInWaylandWindow(cols, rows int, fontName string, fontSize float64, setup
 		fontSize = 18.0
 	}
 	// The host starts at 1x and updates itself from the physical dimensions
-	// supplied by the Wayland surface after it enters an output.
+	// supplied by the Wayland surface. Fractional-scale compositors report a
+	// 1.5x backing buffer for a 150% output, for example.
 	dpi := 72.0
 	face, cellW, cellH := loadBestFont(fontName, fontSize, dpi)
 
@@ -143,13 +145,13 @@ func (h *WaylandHost) Resize(widget *window.Widget, width int32, height int32, p
 		cols, rows = h.cols, h.rows
 		h.mu.Unlock()
 
-		if !scaleChanged && h.reader != nil {
+		if h.reader != nil {
 			h.reader.EventChan <- &vtinput.InputEvent{Type: vtinput.ResizeEventType}
 		}
 	} else {
 		h.mu.Unlock()
 	}
-	DebugLog("WAYLAND: resize logical=%dx%d pixels=%dx%d scale=%d cell=%dx%d grid=%dx%d", width, height, pwidth, pheight, scale, cellW, cellH, cols, rows)
+	DebugLog("WAYLAND: resize logical=%dx%d pixels=%dx%d scale=%.2f cell=%dx%d grid=%dx%d", width, height, pwidth, pheight, scale, cellW, cellH, cols, rows)
 	widget.SetAllocation(0, 0, width, height)
 	if scaleChanged && targetCols > 0 && targetRows > 0 {
 		widget.ScheduleResize(logicalWaylandPixels(targetCols*cellW, scale), logicalWaylandPixels(targetRows*cellH, scale))
@@ -167,26 +169,29 @@ func (h *WaylandHost) Resize(widget *window.Widget, width int32, height int32, p
 	}
 }
 
-func waylandScaleFromDimensions(width, height, pwidth, pheight int32) int {
-	scale := int32(1)
-	if width > 0 && pwidth >= width {
-		scale = max(scale, pwidth/width)
+func waylandScaleFromDimensions(width, height, pwidth, pheight int32) float64 {
+	scale := 0.0
+	if width > 0 && pwidth > 0 {
+		scale = math.Max(scale, float64(pwidth)/float64(width))
 	}
-	if height > 0 && pheight >= height {
-		scale = max(scale, pheight/height)
+	if height > 0 && pheight > 0 {
+		scale = math.Max(scale, float64(pheight)/float64(height))
 	}
-	return int(scale)
+	if scale <= 0 {
+		return 1
+	}
+	return scale
 }
 
-func logicalWaylandPixels(physical, scale int) int32 {
-	if scale < 1 {
+func logicalWaylandPixels(physical int, scale float64) int32 {
+	if scale <= 0 {
 		scale = 1
 	}
-	return int32((physical + scale - 1) / scale)
+	return int32(math.Ceil(float64(physical) / scale))
 }
 
-func (h *WaylandHost) updateScaleLocked(scale int) bool {
-	if scale < 1 || h.scale == scale {
+func (h *WaylandHost) updateScaleLocked(scale float64) bool {
+	if scale <= 0 || math.Abs(h.scale-scale) < 0.001 {
 		return false
 	}
 	face, cellW, cellH := loadBestFont(h.fontName, h.fontSize, 72.0*float64(scale))
@@ -330,7 +335,7 @@ func (h *WaylandHost) mouseCellLocked() (int, int) {
 	if h.cellW <= 0 || h.cellH <= 0 {
 		return 0, 0
 	}
-	return h.mouseX * h.scale / h.cellW, h.mouseY * h.scale / h.cellH
+	return int(float64(h.mouseX) * h.scale / float64(h.cellW)), int(float64(h.mouseY) * h.scale / float64(h.cellH))
 }
 
 func (h *WaylandHost) AxisDiscrete(w *window.Widget, input *window.Input, axis uint32, discrete int32) {

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -30,18 +30,19 @@ func TestWaylandScaleFromDimensions(t *testing.T) {
 	tests := []struct {
 		name                           string
 		width, height, pwidth, pheight int32
-		want                           int
+		want                           float64
 	}{
 		{name: "one times", width: 800, height: 600, pwidth: 800, pheight: 600, want: 1},
 		{name: "two times", width: 800, height: 600, pwidth: 1600, pheight: 1200, want: 2},
+		{name: "fractional", width: 800, height: 600, pwidth: 1200, pheight: 900, want: 1.5},
 		{name: "uses available dimension", width: 0, height: 600, pwidth: 0, pheight: 1200, want: 2},
-		{name: "invalid physical size", width: 800, height: 600, pwidth: 400, pheight: 300, want: 1},
+		{name: "sub-unit scale", width: 800, height: 600, pwidth: 400, pheight: 300, want: 0.5},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := waylandScaleFromDimensions(tt.width, tt.height, tt.pwidth, tt.pheight); got != tt.want {
-				t.Errorf("waylandScaleFromDimensions() = %d, want %d", got, tt.want)
+				t.Errorf("waylandScaleFromDimensions() = %.2f, want %.2f", got, tt.want)
 			}
 		})
 	}
@@ -50,5 +51,8 @@ func TestWaylandScaleFromDimensions(t *testing.T) {
 func TestLogicalWaylandPixelsRoundsUp(t *testing.T) {
 	if got := logicalWaylandPixels(1001, 2); got != 501 {
 		t.Errorf("logicalWaylandPixels(1001, 2) = %d, want 501", got)
+	}
+	if got := logicalWaylandPixels(1400, 1.5); got != 934 {
+		t.Errorf("logicalWaylandPixels(1400, 1.5) = %d, want 934", got)
 	}
 }

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -48,6 +48,26 @@ func TestWaylandScaleFromDimensions(t *testing.T) {
 	}
 }
 
+func TestHasWaylandPixelSize(t *testing.T) {
+	tests := []struct {
+		name                           string
+		width, height, pwidth, pheight int32
+		want                           bool
+	}{
+		{name: "valid", width: 1000, height: 690, pwidth: 1500, pheight: 1035, want: true},
+		{name: "zero logical width", width: 0, height: 690, pwidth: 0, pheight: 1035, want: false},
+		{name: "zero physical height", width: 1000, height: 690, pwidth: 1500, pheight: 0, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasWaylandPixelSize(tt.width, tt.height, tt.pwidth, tt.pheight); got != tt.want {
+				t.Errorf("hasWaylandPixelSize(%d, %d, %d, %d) = %v, want %v", tt.width, tt.height, tt.pwidth, tt.pheight, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLogicalWaylandPixelsRoundsUp(t *testing.T) {
 	if got := logicalWaylandPixels(1001, 2); got != 501 {
 		t.Errorf("logicalWaylandPixels(1001, 2) = %d, want 501", got)

--- a/wayland_renderer.go
+++ b/wayland_renderer.go
@@ -5,6 +5,7 @@ package vtui
 import (
 	"image"
 	"image/color"
+	"math"
 	"time"
 
 	"golang.org/x/image/font"
@@ -326,7 +327,7 @@ func (r *WaylandRenderer) drawCachedGlyph(img *image.RGBA, cellVal uint64, px, p
 }
 
 func (r *WaylandRenderer) drawCustomChar(img *image.RGBA, char rune, px, py, cw, ch int, fg uint32) bool {
-	return drawBoxGlyph(img, char, px, py, cw, ch, r.host.scale, fg)
+	return drawBoxGlyph(img, char, px, py, cw, ch, int(math.Ceil(r.host.scale)), fg)
 }
 
 func (r *WaylandRenderer) Flush() {


### PR DESCRIPTION
## Follow-up to #46

PR #46 was merged before the remaining KDE-specific failures were found. This follow-up contains only the additional work required for the actual 150% fractional-scale session and for correct first-frame geometry.

## Problem

KDE reports a 0x0 xdg configure before the first usable configure. Accepting it reset the Wayland host grid to 0x0. The next valid 150% configure then started from invalid state, leaving blank space until the user manually resized the window.

The actual scale is 1.50; the compositor also reports wl_output.scale = 2 only as its integer buffer fallback.

## Fix

- Preserve fractional scale as a float and re-rasterize at the exact scale.
- Ignore zero-sized startup configures.
- Reflow frames when the backing buffer changes while the text grid stays the same.
- Send a resize after every backing-buffer replacement.

This depends on the companion Wayland protocol support in https://github.com/neurlang/wayland/pull/29.

## Validation

- go test ./...
- focused go test -race for the new Wayland scale and startup-configure tests
- GOARCH=amd64 go test -vet=off -c .
- live F4 test on KDE: 1000x690 logical, 1500x1035 backing pixels, scale 1.50, grid 100x30 before manual resize.