### PR TITLE
Round fractional Wayland window geometry correctly

### DIFF
--- a/wayland_host.go
+++ b/wayland_host.go
@@ -200,7 +200,11 @@ func logicalWaylandPixels(physical int, scale float64) int32 {
 	if scale <= 0 {
 		scale = 1
 	}
-	return int32(math.Ceil(float64(physical) / scale))
+	logical := int32(math.Round(float64(physical) / scale))
+	if physical > 0 && logical < 1 {
+		return 1
+	}
+	return logical
 }
 
 func (h *WaylandHost) updateScaleLocked(scale float64) bool {

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -68,11 +68,14 @@ func TestHasWaylandPixelSize(t *testing.T) {
 	}
 }
 
-func TestLogicalWaylandPixelsRoundsUp(t *testing.T) {
+func TestLogicalWaylandPixelsRoundsToNearest(t *testing.T) {
 	if got := logicalWaylandPixels(1001, 2); got != 501 {
 		t.Errorf("logicalWaylandPixels(1001, 2) = %d, want 501", got)
 	}
-	if got := logicalWaylandPixels(1400, 1.5); got != 934 {
-		t.Errorf("logicalWaylandPixels(1400, 1.5) = %d, want 934", got)
+	if got := logicalWaylandPixels(1400, 1.5); got != 933 {
+		t.Errorf("logicalWaylandPixels(1400, 1.5) = %d, want 933", got)
+	}
+	if got := logicalWaylandPixels(1, 3); got != 1 {
+		t.Errorf("logicalWaylandPixels(1, 3) = %d, want 1", got)
 	}
 }


### PR DESCRIPTION
## Problem

On KDE Wayland at 150%, F4 renders a 100x30 grid with 14x34 physical-pixel cells, so the exact backing size is 1400x1020. Converting that target with `ceil(physical / scale)` asks for 934x680 logical pixels. The fractional backend then allocates `ceil(934 * 1.5) = 1401` physical pixels, leaving a residual uncovered column.

Wayland toplevel sizes use nearest-integer rounding (halfway away from zero), not unconditional ceiling.

## Fix

- Convert physical grid dimensions to logical toplevel dimensions with nearest-integer rounding.
- Clamp positive sub-pixel results to one logical pixel.
- Update focused tests for the 150% case and the minimum-size edge case.

The larger startup blank-area issue also required processing a resize requested from inside the initial resize callback and redrawing pending client-side decorations; those backend fixes are in https://github.com/neurlang/wayland/pull/29.

## Validation

- `go test ./...`
- Built F4 against this branch and the companion Wayland branch.
- Live KDE Wayland test at 150%: startup settles from 1000x690 logical / 1500x1035 physical to 933x680 logical / 1400x1020 physical, exactly matching the 100x30 grid at 14x34 pixels.