### PR TITLE
Fix Wayland mouse dragging and scrolling

### DIFF
--- a/wayland_host.go
+++ b/wayland_host.go
@@ -36,6 +36,13 @@ type WaylandHost struct {
 	mouseY   int
 	mouseBtn uint32
 
+	axisValue             [2]float64
+	axisDiscrete          [2]int32
+	axisValue120          [2]int32
+	axisStopped           [2]bool
+	axisPixelRemainder    [2]float64
+	axisValue120Remainder [2]int32
+
 	isRepeating    bool
 	repeatVK       uint16
 	repeatChar     rune
@@ -300,6 +307,7 @@ func (h *WaylandHost) Motion(w *window.Widget, input *window.Input, time uint32,
 	if h.reader != nil {
 		h.reader.EventChan <- &vtinput.InputEvent{
 			Type:            vtinput.MouseEventType,
+			KeyDown:         mouseBtn != 0,
 			MouseX:          int16(mouseX),
 			MouseY:          int16(mouseY),
 			MouseEventFlags: vtinput.MouseMoved,
@@ -325,12 +333,14 @@ func (h *WaylandHost) Button(w *window.Widget, input *window.Input, time uint32,
 	}
 
 	h.mu.Lock()
-	h.mouseBtn = bs
+	if isDown {
+		h.mouseBtn |= bs
+	} else {
+		h.mouseBtn &^= bs
+	}
+	bs = h.mouseBtn
 	mouseX, mouseY := h.mouseCellLocked()
 	h.mu.Unlock()
-	if !isDown {
-		bs = 0
-	}
 
 	if h.reader != nil {
 		h.reader.EventChan <- &vtinput.InputEvent{
@@ -352,20 +362,25 @@ func (h *WaylandHost) mouseCellLocked() (int, int) {
 }
 
 func (h *WaylandHost) AxisDiscrete(w *window.Widget, input *window.Input, axis uint32, discrete int32) {
-	dir := 0
-	// Wayland axis 0 is vertical scroll.
-	if discrete < 0 {
-		dir = 1 // Up
-	} else if discrete > 0 {
-		dir = -1 // Down
+	if axis >= uint32(len(h.axisDiscrete)) {
+		return
 	}
+	h.mu.Lock()
+	h.axisDiscrete[axis] += discrete
+	h.mu.Unlock()
+}
 
-	if dir != 0 && h.reader != nil {
-		h.reader.EventChan <- &vtinput.InputEvent{
-			Type:           vtinput.MouseEventType,
-			WheelDirection: dir,
-		}
+// AxisValue120 receives high-resolution wheel information from wl_pointer
+// version 8 and newer. It is an optional extension exposed by the Wayland
+// window package, so older window versions and non-wheel devices continue to
+// work through AxisDiscrete or Axis respectively.
+func (h *WaylandHost) AxisValue120(w *window.Widget, input *window.Input, axis uint32, value120 int32) {
+	if axis >= uint32(len(h.axisValue120)) {
+		return
 	}
+	h.mu.Lock()
+	h.axisValue120[axis] += value120
+	h.mu.Unlock()
 }
 
 func (h *WaylandHost) Key(win *window.Window, input *window.Input, timeMs uint32, key uint32, notUnicode uint32, state wl.KeyboardKeyState, handler window.WidgetHandler) {
@@ -486,7 +501,80 @@ func (h *WaylandHost) TouchMotion(w *window.Widget, i *window.Input, time uint32
 func (h *WaylandHost) TouchFrame(w *window.Widget, i *window.Input)            {}
 func (h *WaylandHost) TouchCancel(w *window.Widget, width int32, height int32) {}
 func (h *WaylandHost) Axis(w *window.Widget, i *window.Input, time uint32, axis uint32, value float32) {
+	if axis >= uint32(len(h.axisValue)) {
+		return
+	}
+	h.mu.Lock()
+	h.axisValue[axis] += float64(value)
+	h.mu.Unlock()
 }
-func (h *WaylandHost) AxisSource(w *window.Widget, i *window.Input, source uint32)          {}
-func (h *WaylandHost) AxisStop(w *window.Widget, i *window.Input, time uint32, axis uint32) {}
-func (h *WaylandHost) PointerFrame(w *window.Widget, i *window.Input)                       {}
+func (h *WaylandHost) AxisSource(w *window.Widget, i *window.Input, source uint32) {}
+func (h *WaylandHost) AxisStop(w *window.Widget, i *window.Input, time uint32, axis uint32) {
+	if axis >= uint32(len(h.axisStopped)) {
+		return
+	}
+	h.mu.Lock()
+	h.axisStopped[axis] = true
+	h.mu.Unlock()
+}
+
+func (h *WaylandHost) PointerFrame(w *window.Widget, input *window.Input) {
+	const verticalAxis = int(wl.PointerAxisVerticalScroll)
+
+	h.mu.Lock()
+	raw := h.axisValue[verticalAxis]
+	discrete := h.axisDiscrete[verticalAxis]
+	value120 := h.axisValue120[verticalAxis]
+	stopped := h.axisStopped[verticalAxis]
+	for axis := range h.axisValue {
+		h.axisValue[axis] = 0
+		h.axisDiscrete[axis] = 0
+		h.axisValue120[axis] = 0
+		h.axisStopped[axis] = false
+	}
+
+	steps := 0
+	if value120 != 0 {
+		h.axisValue120Remainder[verticalAxis] += value120
+		steps = int(h.axisValue120Remainder[verticalAxis] / 120)
+		h.axisValue120Remainder[verticalAxis] -= int32(steps * 120)
+	} else if discrete != 0 {
+		steps = int(discrete)
+	} else if raw != 0 {
+		threshold := float64(h.cellH) / h.scale
+		if threshold < 1 {
+			threshold = 1
+		}
+		h.axisPixelRemainder[verticalAxis] += raw
+		steps = int(h.axisPixelRemainder[verticalAxis] / threshold)
+		h.axisPixelRemainder[verticalAxis] -= float64(steps) * threshold
+	}
+	if stopped {
+		h.axisPixelRemainder[verticalAxis] = 0
+	}
+	mouseX, mouseY := h.mouseCellLocked()
+	mouseBtn := h.mouseBtn
+	reader := h.reader
+	h.mu.Unlock()
+
+	if steps == 0 || reader == nil {
+		return
+	}
+	direction := -1
+	if steps < 0 {
+		direction = 1
+		steps = -steps
+	}
+	mods := h.getMods(input)
+	for range steps {
+		reader.EventChan <- &vtinput.InputEvent{
+			Type:            vtinput.MouseEventType,
+			KeyDown:         mouseBtn != 0,
+			MouseX:          int16(mouseX),
+			MouseY:          int16(mouseY),
+			ButtonState:     mouseBtn,
+			WheelDirection:  direction,
+			ControlKeyState: mods,
+		}
+	}
+}

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -3,9 +3,11 @@
 package vtui
 
 import (
+	"io"
 	"testing"
 	"time"
 
+	"github.com/neurlang/wayland/wl"
 	"github.com/unxed/vtinput"
 )
 
@@ -24,6 +26,100 @@ func TestWaylandHost_KeyRepeatLogic(t *testing.T) {
 
 	// Note: full integration test of Redraw() spin loop requires mocking window.Widget
 	// which is deeply integrated with the C Wayland library in windowtrace.
+}
+
+func newWaylandPointerTestHost(t *testing.T) *WaylandHost {
+	t.Helper()
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+	return &WaylandHost{
+		reader: vtinput.NewReader(pr, true),
+		cellW:  10,
+		cellH:  20,
+		scale:  1,
+	}
+}
+
+func nextWaylandMouseEvent(t *testing.T, host *WaylandHost) *vtinput.InputEvent {
+	t.Helper()
+	select {
+	case event := <-host.reader.EventChan:
+		return event
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for Wayland mouse event")
+		return nil
+	}
+}
+
+func TestWaylandButtonReleaseClearsMotionState(t *testing.T) {
+	host := newWaylandPointerTestHost(t)
+
+	host.Button(nil, nil, 0, 272, wl.PointerButtonStatePressed, nil)
+	press := nextWaylandMouseEvent(t, host)
+	if !press.KeyDown || press.ButtonState != vtinput.FromLeft1stButtonPressed {
+		t.Fatalf("press = KeyDown:%v ButtonState:%d", press.KeyDown, press.ButtonState)
+	}
+
+	host.Button(nil, nil, 0, 272, wl.PointerButtonStateReleased, nil)
+	release := nextWaylandMouseEvent(t, host)
+	if release.KeyDown || release.ButtonState != 0 {
+		t.Fatalf("release = KeyDown:%v ButtonState:%d", release.KeyDown, release.ButtonState)
+	}
+
+	host.Motion(nil, nil, 0, 30, 40)
+	hover := nextWaylandMouseEvent(t, host)
+	if hover.KeyDown || hover.ButtonState != 0 {
+		t.Fatalf("hover after release = KeyDown:%v ButtonState:%d", hover.KeyDown, hover.ButtonState)
+	}
+}
+
+func TestWaylandMotionReportsHeldButton(t *testing.T) {
+	host := newWaylandPointerTestHost(t)
+
+	host.Button(nil, nil, 0, 272, wl.PointerButtonStatePressed, nil)
+	_ = nextWaylandMouseEvent(t, host)
+	host.Motion(nil, nil, 0, 30, 40)
+	drag := nextWaylandMouseEvent(t, host)
+
+	if !drag.KeyDown || drag.ButtonState != vtinput.FromLeft1stButtonPressed {
+		t.Fatalf("drag = KeyDown:%v ButtonState:%d", drag.KeyDown, drag.ButtonState)
+	}
+	if drag.MouseX != 3 || drag.MouseY != 2 {
+		t.Fatalf("drag cell = %d,%d, want 3,2", drag.MouseX, drag.MouseY)
+	}
+}
+
+func TestWaylandPointerFramePrefersValue120OverRawAxis(t *testing.T) {
+	host := newWaylandPointerTestHost(t)
+
+	host.Axis(nil, nil, 0, wl.PointerAxisVerticalScroll, 15)
+	host.AxisValue120(nil, nil, wl.PointerAxisVerticalScroll, 120)
+	host.PointerFrame(nil, nil)
+
+	wheel := nextWaylandMouseEvent(t, host)
+	if wheel.WheelDirection != -1 {
+		t.Fatalf("wheel direction = %d, want -1", wheel.WheelDirection)
+	}
+	select {
+	case extra := <-host.reader.EventChan:
+		t.Fatalf("raw axis duplicated value120 event: %+v", extra)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestWaylandPointerFrameSupportsSmoothAxis(t *testing.T) {
+	host := newWaylandPointerTestHost(t)
+
+	host.Axis(nil, nil, 0, wl.PointerAxisVerticalScroll, 25)
+	host.PointerFrame(nil, nil)
+
+	wheel := nextWaylandMouseEvent(t, host)
+	if wheel.WheelDirection != -1 {
+		t.Fatalf("smooth wheel direction = %d, want -1", wheel.WheelDirection)
+	}
 }
 
 func TestWaylandScaleFromDimensions(t *testing.T) {


### PR DESCRIPTION
## Problem

Three independent bugs combine into broken mouse behavior in the native Wayland host:

1. A button release emits `ButtonState=0` but leaves the host internal `mouseBtn` set. Every later hover motion therefore looks like a held-button drag and moves the panel cursor.
2. Real held-button motion carries the button state but leaves `KeyDown=false`. VTUI tables require `KeyDown=true` for row dragging, so press-and-drag does not update the cursor.
3. Raw `Axis` and `PointerFrame` callbacks are no-ops. KDE sends frame-grouped modern wheel events, so the mouse wheel is ignored.

## Fix

- Track pressed buttons as a bitmask and clear the released button in host state.
- Mark motion as down only while at least one button is actually held.
- Accumulate scroll data until `PointerFrame`, preferring `axis_value120`, then legacy discrete steps, then raw smooth-axis distance.
- Preserve partial high-resolution wheel values across frames and avoid emitting the coupled raw axis twice.
- Convert smooth vertical movement using one logical text-cell height per wheel tick.
- Include current mouse coordinates, held buttons, and modifiers in generated wheel events.

This depends on pointer-frame and value120 forwarding in https://github.com/neurlang/wayland/pull/30. It is otherwise based directly on current `upstream/main` and does not include the fractional-geometry follow-up from PR #48.

## Validation

- `go test ./...`
- `go test -race -count=1 -run TestWayland .`
- Built F4 against this branch plus neurlang/wayland#30 and the existing fractional-scale fixes.
- Live KDE Wayland run confirms pointer motion is now grouped with `PointerFrame`; the current test binary is ready for interactive hover, drag, and wheel validation.

Focused tests cover release-state clearing, held-button motion semantics, value120/raw-axis deduplication, and smooth scrolling.