### PR TITLE
Coalesce Wayland drag motion by cell

### DIFF
--- a/wayland_host.go
+++ b/wayland_host.go
@@ -32,9 +32,12 @@ type WaylandHost struct {
 	screen     *ScreenBuf
 	renderer   *WaylandRenderer
 
-	mouseX   int
-	mouseY   int
-	mouseBtn uint32
+	mouseX         int
+	mouseY         int
+	mouseBtn       uint32
+	lastMouseCellX int
+	lastMouseCellY int
+	mouseCellKnown bool
 
 	axisValue             [2]float64
 	axisDiscrete          [2]int32
@@ -307,11 +310,20 @@ func (h *WaylandHost) Motion(w *window.Widget, input *window.Input, time uint32,
 	h.mouseX, h.mouseY = int(x), int(y)
 	mouseX, mouseY := h.mouseCellLocked()
 	mouseBtn := h.mouseBtn
+	moved := !h.mouseCellKnown || mouseX != h.lastMouseCellX || mouseY != h.lastMouseCellY
+	if mouseBtn != 0 && moved {
+		h.lastMouseCellX, h.lastMouseCellY = mouseX, mouseY
+		h.mouseCellKnown = true
+	}
 	h.mu.Unlock()
-	if h.reader != nil {
+
+	// VTUI consumes mouse coordinates in cells. Sending every pixel-level
+	// Wayland motion can fill the input queue faster than a drag can be drawn,
+	// so only report a held-button move after the pointer enters another cell.
+	if h.reader != nil && mouseBtn != 0 && moved {
 		h.reader.EventChan <- &vtinput.InputEvent{
 			Type:            vtinput.MouseEventType,
-			KeyDown:         mouseBtn != 0,
+			KeyDown:         true,
 			MouseX:          int16(mouseX),
 			MouseY:          int16(mouseY),
 			MouseEventFlags: vtinput.MouseMoved,
@@ -344,6 +356,8 @@ func (h *WaylandHost) Button(w *window.Widget, input *window.Input, time uint32,
 	}
 	bs = h.mouseBtn
 	mouseX, mouseY := h.mouseCellLocked()
+	h.lastMouseCellX, h.lastMouseCellY = mouseX, mouseY
+	h.mouseCellKnown = true
 	h.mu.Unlock()
 
 	if h.reader != nil {

--- a/wayland_host.go
+++ b/wayland_host.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	window "github.com/neurlang/wayland/windowtrace"
+	"github.com/neurlang/wayland/window"
 	"github.com/neurlang/wayland/wl"
 	"github.com/unxed/vtinput"
 )

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -54,6 +54,15 @@ func nextWaylandMouseEvent(t *testing.T, host *WaylandHost) *vtinput.InputEvent 
 	}
 }
 
+func assertNoWaylandMouseEvent(t *testing.T, host *WaylandHost) {
+	t.Helper()
+	select {
+	case event := <-host.reader.EventChan:
+		t.Fatalf("unexpected Wayland mouse event: %+v", event)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
 func TestWaylandButtonReleaseClearsMotionState(t *testing.T) {
 	host := newWaylandPointerTestHost(t)
 
@@ -70,10 +79,7 @@ func TestWaylandButtonReleaseClearsMotionState(t *testing.T) {
 	}
 
 	host.Motion(nil, nil, 0, 30, 40)
-	hover := nextWaylandMouseEvent(t, host)
-	if hover.KeyDown || hover.ButtonState != 0 {
-		t.Fatalf("hover after release = KeyDown:%v ButtonState:%d", hover.KeyDown, hover.ButtonState)
-	}
+	assertNoWaylandMouseEvent(t, host)
 }
 
 func TestWaylandMotionReportsHeldButton(t *testing.T) {
@@ -89,6 +95,31 @@ func TestWaylandMotionReportsHeldButton(t *testing.T) {
 	}
 	if drag.MouseX != 3 || drag.MouseY != 2 {
 		t.Fatalf("drag cell = %d,%d, want 3,2", drag.MouseX, drag.MouseY)
+	}
+}
+
+func TestWaylandMotionReportsOnlyCellChanges(t *testing.T) {
+	host := newWaylandPointerTestHost(t)
+
+	host.Button(nil, nil, 0, 272, wl.PointerButtonStatePressed, nil)
+	_ = nextWaylandMouseEvent(t, host)
+
+	host.Motion(nil, nil, 0, 9, 19)
+	assertNoWaylandMouseEvent(t, host)
+
+	host.Motion(nil, nil, 0, 10, 19)
+	firstCell := nextWaylandMouseEvent(t, host)
+	if firstCell.MouseX != 1 || firstCell.MouseY != 0 {
+		t.Fatalf("first drag cell = %d,%d, want 1,0", firstCell.MouseX, firstCell.MouseY)
+	}
+
+	host.Motion(nil, nil, 0, 19, 19)
+	assertNoWaylandMouseEvent(t, host)
+
+	host.Motion(nil, nil, 0, 19, 20)
+	secondCell := nextWaylandMouseEvent(t, host)
+	if secondCell.MouseX != 1 || secondCell.MouseY != 1 {
+		t.Fatalf("second drag cell = %d,%d, want 1,1", secondCell.MouseX, secondCell.MouseY)
 	}
 }
 

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -24,8 +24,8 @@ func TestWaylandHost_KeyRepeatLogic(t *testing.T) {
 		t.Error("Expected isRepeating to be true")
 	}
 
-	// Note: full integration test of Redraw() spin loop requires mocking window.Widget
-	// which is deeply integrated with the C Wayland library in windowtrace.
+	// Note: full integration test of Redraw() spin loop requires mocking window.Widget,
+	// which is deeply integrated with the Wayland protocol implementation.
 }
 
 func newWaylandPointerTestHost(t *testing.T) *WaylandHost {


### PR DESCRIPTION
## Problem

On KDE Wayland, a press-and-drag gesture lagged far behind the pointer. VTUI converted every pointer position to terminal-cell coordinates, but still sent an input event for every pixel-level `wl_pointer.motion`. In the reproduced session the trace recorded 2,724 Motion callbacks for only 10 button events, so redundant same-cell events could fill the synchronous input path faster than F4 rendered them.

The backend also imported `windowtrace` in production. That wrapper unconditionally printed every Motion, PointerFrame, ScheduleRedraw, and other Wayland call to stderr, adding more work and producing very large logs regardless of F4's `--debug` setting.

## Fix

- Track the last terminal cell at the Wayland host boundary.
- While a button is held, emit MouseMoved only when the pointer enters a different cell.
- Do not enqueue unpressed hover motion, matching the other GUI backends.
- Seed the last cell on button transitions so sub-cell movement immediately after a click is not reported as drag.
- Use the normal `window` package instead of the diagnostic `windowtrace` wrapper.

Button press/release and wheel events are unchanged. This PR is based directly on main after #49 and does not contain F4, Wayland library, DPI, or window-geometry changes.

## Verification

- `GOWORK=off go test ./...`
- `GOWORK=off go test -race -count=1 -run TestWayland .`
- Live ARM64 KDE Wayland build at 150% fractional scaling; the production trace spam is gone and a rebuilt F4 instance is ready for interactive fast-drag validation.

The focused tests verify that held-button motion carries the button state, hover after release is not enqueued, same-cell pixel motion is coalesced, and crossing either a column or row boundary emits exactly one event.