### PR TITLE
vmenu: cancelling a menu restores the selection it opened with

### DIFF
--- a/vmenu.go
+++ b/vmenu.go
@@ -27,9 +27,15 @@ type VMenu struct {
 	Items      []MenuItem
 	done       bool
 	exitCode   int
-	OnAction   func(int)
-	OnKeyDown  func(*vtinput.InputEvent) bool
-	HideShadow bool
+	// selectAtOpen is SelectPos as of the last ClearDone. Browsing moves
+	// SelectPos live (arrows, mouse hover), so cancelling has to put it
+	// back: dialogs read SelectPos as the confirmed choice, and without the
+	// restore an Esc'd dropdown silently commits whatever row the user
+	// happened to stop on.
+	selectAtOpen int
+	OnAction     func(int)
+	OnKeyDown    func(*vtinput.InputEvent) bool
+	HideShadow   bool
 	BoxType    int
 
 	// Palette entries the menu paints with. They default to the Menu.* group;
@@ -219,6 +225,8 @@ func (m *VMenu) SetExitCode(code int) {
 	m.done = true
 	m.exitCode = code
 	if code == -1 {
+		// Cancelled: undo the browsing highlight (see selectAtOpen).
+		m.SetSelectPos(m.selectAtOpen)
 		FrameManager.EmitCommand(CmMenuClose, nil)
 	}
 }
@@ -238,6 +246,7 @@ func (m *VMenu) HasShadow() bool       { return !m.HideShadow }
 func (m *VMenu) ClearDone() {
 	m.done = false
 	m.exitCode = -1
+	m.selectAtOpen = m.SelectPos
 }
 
 // ProcessMouse handles mouse wheel scrolling, menu item hover, and clicks.

--- a/vmenu_cancel_test.go
+++ b/vmenu_cancel_test.go
@@ -1,0 +1,48 @@
+package vtui
+
+import (
+	"testing"
+
+	"github.com/unxed/vtinput"
+)
+
+// Dialogs read SelectPos as the confirmed choice, but browsing an open menu
+// (arrows, mouse hover) moves SelectPos live. Cancelling must therefore put
+// it back where the menu was opened, or an Esc'd dropdown silently commits
+// whatever row the user stopped on — that is how a file manager ends up in
+// Georgian (unxed/f4 language dialog, among ~30 other combo-backed settings).
+func TestVMenu_CancelRestoresSelection(t *testing.T) {
+	FrameManager.Init(NewSilentScreenBuf())
+
+	m := NewVMenu("")
+	for _, s := range []string{"en", "de", "ka", "ru"} {
+		m.AddItem(MenuItem{Text: s})
+	}
+	m.SetSelectPos(0)
+	m.ClearDone()
+
+	down := &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_DOWN}
+	m.ProcessKey(down)
+	m.ProcessKey(down)
+	if m.SelectPos != 2 {
+		t.Fatalf("browsing should move SelectPos, got %d", m.SelectPos)
+	}
+
+	esc := &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_ESCAPE}
+	m.ProcessKey(esc)
+	if !m.IsDone() {
+		t.Fatal("Esc should close the menu")
+	}
+	if m.SelectPos != 0 {
+		t.Errorf("cancel must restore SelectPos to the value at open, got %d", m.SelectPos)
+	}
+
+	// Confirming keeps the browsed row selected.
+	m.ClearDone()
+	m.ProcessKey(down)
+	enter := &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN}
+	m.ProcessKey(enter)
+	if !m.IsDone() || m.SelectPos != 1 {
+		t.Errorf("Enter must commit the browsed row: done=%v SelectPos=%d", m.IsDone(), m.SelectPos)
+	}
+}


### PR DESCRIPTION
Browsing an open VMenu moves `SelectPos` live — arrow keys and mouse hover alike — while dialog code reads `SelectPos` afterwards as the confirmed choice. Cancelling with Esc/F10/`Close()` therefore silently committed whatever row the user last stopped on.

In f4 every combo-backed setting reads `Menu.SelectPos` in its OK handler — about thirty call sites — so opening any dropdown, looking around and backing out with Esc rewrote that setting on the next OK. That is how a user's file manager ends up in Georgian: browse the language list out of curiosity, Esc, OK — and `Language = ka` lands in settings.ini while the combo still displays "English".

The fix keeps the contract "SelectPos is the confirmed selection": `ClearDone` (called on every open) snapshots the position, and a `-1` exit code — every cancel path funnels through `SetExitCode(-1)` — restores it. Confirm paths (Enter, hotkey, click) are untouched: they commit the browsed row as before.

Covered by `TestVMenu_CancelRestoresSelection` (both the cancel-restores and confirm-commits directions).

Related: unxed/f4 PR fixing the language dialog's list will reference this one — the two together close the "UI in a language nobody chose" failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
