### PR TITLE
framemanager: let frames veto workspace closing (CloseVetoer)

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -79,6 +79,13 @@ type Frame interface {
 	GetProgress() int // Returns 0-100, or -1 if no progress
 }
 
+// CloseVetoer lets a frame veto workspace closing. ConfirmClose is consulted
+// before frames are closed; returning false aborts the close, and the frame may
+// have pushed its own confirmation dialog.
+type CloseVetoer interface {
+	ConfirmClose() bool
+}
+
 // AppScreen represents an isolated workspace with its own frame stack.
 type AppScreen struct {
 	Number        int // Stable workspace number; never changes during its lifetime.
@@ -625,17 +632,22 @@ func (fm *frameManager) CloseScreen(idx int) {
 	if idx < 0 || idx >= len(fm.Screens) {
 		return
 	}
+	fm.SyncCurrentScreen()
+	screenToClose := fm.Screens[idx]
+	for _, frame := range screenToClose.Frames {
+		if vetoer, ok := frame.(CloseVetoer); ok && !vetoer.ConfirmClose() {
+			return
+		}
+	}
 	if len(fm.Screens) <= 1 {
 		fm.EmitCommand(CmQuit, nil)
 		return
 	}
 
 	oldInset := fm.WorkspaceTopInset()
-	fm.SyncCurrentScreen()
 	closedIdx := idx
 	activeScreen := fm.Screens[fm.ActiveIdx]
 	closingActive := closedIdx == fm.ActiveIdx
-	screenToClose := fm.Screens[closedIdx]
 	for i := len(screenToClose.Frames) - 1; i >= 0; i-- {
 		screenToClose.Frames[i].Close()
 	}

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -20,6 +20,22 @@ type mockFrame struct {
 	resizedW, resizedH int
 }
 
+type closeVetoFrame struct {
+	mockFrame
+	allowClose        bool
+	confirmCloseCalls int
+	closeCalls        int
+}
+
+func (f *closeVetoFrame) ConfirmClose() bool {
+	f.confirmCloseCalls++
+	return f.allowClose
+}
+
+func (f *closeVetoFrame) Close() {
+	f.closeCalls++
+}
+
 func (m *mockFrame) ResizeConsole(w, h int) {
 	m.resizedW, m.resizedH = w, h
 }
@@ -2653,6 +2669,150 @@ func TestFrameManager_CloseActiveScreen_Shifting(t *testing.T) {
 		t.Errorf("Expected W2 to be active, got %q", fm.Screens[fm.ActiveIdx].GetTitle())
 	}
 }
+
+func TestFrameManager_CloseScreenVeto(t *testing.T) {
+	fm := &frameManager{}
+	fm.Init(NewSilentScreenBuf())
+	fm.Push(newMockFrame(0, 0, 10, 10, false))
+	vetoer := &closeVetoFrame{}
+	fm.AddScreen(vetoer)
+
+	target := fm.Screens[fm.ActiveIdx]
+	fm.CloseScreen(fm.ActiveIdx)
+
+	if len(fm.Screens) != 2 {
+		t.Fatalf("CloseScreen left %d workspaces, want 2 after veto", len(fm.Screens))
+	}
+	if fm.Screens[fm.ActiveIdx] != target {
+		t.Fatal("CloseScreen changed the active workspace after veto")
+	}
+	if vetoer.confirmCloseCalls != 1 {
+		t.Fatalf("ConfirmClose called %d times, want 1", vetoer.confirmCloseCalls)
+	}
+	if vetoer.closeCalls != 0 {
+		t.Fatalf("Close called %d times before veto, want 0", vetoer.closeCalls)
+	}
+}
+
+func TestFrameManager_CloseScreenAllowedByVetoer(t *testing.T) {
+	fm := &frameManager{}
+	fm.Init(NewSilentScreenBuf())
+	fm.Push(newMockFrame(0, 0, 10, 10, false))
+	vetoer := &closeVetoFrame{allowClose: true}
+	fm.AddScreen(vetoer)
+
+	fm.CloseScreen(fm.ActiveIdx)
+
+	if len(fm.Screens) != 1 {
+		t.Fatalf("CloseScreen left %d workspaces, want 1", len(fm.Screens))
+	}
+	if vetoer.confirmCloseCalls != 1 {
+		t.Fatalf("ConfirmClose called %d times, want 1", vetoer.confirmCloseCalls)
+	}
+	if vetoer.closeCalls != 1 {
+		t.Fatalf("Close called %d times, want 1", vetoer.closeCalls)
+	}
+}
+
+func TestFrameManager_CloseScreenFindsVetoerUnderDialog(t *testing.T) {
+	fm := &frameManager{}
+	fm.Init(NewSilentScreenBuf())
+	fm.Push(newMockFrame(0, 0, 10, 10, false))
+	vetoer := &closeVetoFrame{}
+	fm.AddScreen(vetoer)
+	dialog := newMockFrame(0, 0, 5, 5, true)
+	fm.Push(dialog)
+
+	fm.CloseScreen(fm.ActiveIdx)
+
+	if len(fm.Screens) != 2 {
+		t.Fatalf("CloseScreen left %d workspaces, want 2 after underlying frame veto", len(fm.Screens))
+	}
+	if vetoer.confirmCloseCalls != 1 {
+		t.Fatalf("underlying frame ConfirmClose called %d times, want 1", vetoer.confirmCloseCalls)
+	}
+	if vetoer.closeCalls != 0 {
+		t.Fatalf("underlying frame Close called %d times before veto, want 0", vetoer.closeCalls)
+	}
+	if dialog.IsDone() {
+		t.Fatal("dialog was closed before underlying frame veto")
+	}
+}
+
+func TestFrameManager_WorkspaceCloseRoutesRespectVeto(t *testing.T) {
+	newManager := func() (*frameManager, *closeVetoFrame) {
+		SetDefaultPalette()
+		scr := NewSilentScreenBuf()
+		scr.AllocBuf(80, 10)
+		fm := &frameManager{}
+		fm.Init(scr)
+		fm.Push(newMockFrame(0, 0, 20, 5, false))
+		vetoer := &closeVetoFrame{}
+		fm.AddScreen(vetoer)
+		fm.SwitchScreen(0)
+		return fm, vetoer
+	}
+
+	t.Run("Ctrl+W fallback", func(t *testing.T) {
+		fm, vetoer := newManager()
+		fm.SwitchScreen(1)
+
+		fm.dispatchEvent(&vtinput.InputEvent{
+			Type:            vtinput.KeyEventType,
+			KeyDown:         true,
+			VirtualKeyCode:  vtinput.VK_W,
+			ControlKeyState: vtinput.LeftCtrlPressed,
+		}, false)
+
+		if len(fm.Screens) != 2 || fm.ActiveIdx != 1 {
+			t.Fatal("Ctrl+W fallback closed a vetoed workspace or changed the active workspace")
+		}
+		if vetoer.confirmCloseCalls != 1 || vetoer.closeCalls != 0 {
+			t.Fatalf("Ctrl+W ConfirmClose calls = %d, Close calls = %d; want 1, 0", vetoer.confirmCloseCalls, vetoer.closeCalls)
+		}
+	})
+
+	t.Run("middle click", func(t *testing.T) {
+		fm, vetoer := newManager()
+		active := fm.Screens[fm.ActiveIdx]
+		fm.drawWorkspaceTabs()
+		target := fm.workspaceTabHits[1]
+
+		fm.dispatchEvent(&vtinput.InputEvent{
+			Type:        vtinput.MouseEventType,
+			KeyDown:     true,
+			MouseX:      int16(target.x1 + 1),
+			MouseY:      0,
+			ButtonState: vtinput.FromLeft2ndButtonPressed,
+		}, false)
+
+		if len(fm.Screens) != 2 || fm.Screens[fm.ActiveIdx] != active {
+			t.Fatal("middle-click closed a vetoed workspace or changed the active workspace")
+		}
+		if vetoer.confirmCloseCalls != 1 || vetoer.closeCalls != 0 {
+			t.Fatalf("middle-click ConfirmClose calls = %d, Close calls = %d; want 1, 0", vetoer.confirmCloseCalls, vetoer.closeCalls)
+		}
+	})
+
+	t.Run("semantic action", func(t *testing.T) {
+		fm, vetoer := newManager()
+		handled := fm.HandleSemanticAction(map[string]any{
+			"action": "workspace.close",
+			"index":  1,
+		})
+
+		if !handled {
+			t.Fatal("semantic workspace.close was not handled")
+		}
+		if len(fm.Screens) != 2 {
+			t.Fatalf("semantic workspace.close left %d workspaces, want 2 after veto", len(fm.Screens))
+		}
+		if vetoer.confirmCloseCalls != 1 || vetoer.closeCalls != 0 {
+			t.Fatalf("semantic close ConfirmClose calls = %d, Close calls = %d; want 1, 0", vetoer.confirmCloseCalls, vetoer.closeCalls)
+		}
+	})
+}
+
 func TestFrameManager_CloseActiveScreen_CancelsTasks(t *testing.T) {
 	fm := &frameManager{}
 	fm.Init(NewSilentScreenBuf())


### PR DESCRIPTION
## Why this belongs in vtui

f4's editor asks "save / don't save / cancel" before it closes — unless the *workspace* closes, in which case the buffer dies silently. That is f4 issue [#527](https://github.com/unxed/f4/issues/527), and f4 cannot fix it on its own side, because every route that closes a workspace ends in `FrameManager.CloseScreen`, which tears down each frame with no way for a frame to object: the Ctrl+W key fallback, middle click on a workspace tab, the `workspace.close` semantic action, and application-driven closes.

We first tried the application-side workaround — the editor swallowing Ctrl+W. Review proved it insufficient: it fixed exactly one route, left the menu/palette/macro, tab-click and semantic-action routes still destroying the buffer, and pressing Ctrl+W a second time (with the confirmation already up) still closed the workspace, because the dialog on top does not consume the key either. A frame that owns unsaved user data needs to be asked, wherever the close came from — and only the framework knows about all those routes.

The same hook lets f4 retire an existing hack: `QueueFrame` currently protects running file operations with a bespoke Ctrl+W swallow plus a pre-check in its close action, which still leaves the tab-click route unguarded.

## What this adds

```go
// CloseVetoer lets a frame veto workspace closing.
type CloseVetoer interface { ConfirmClose() bool }
```

`CloseScreen` consults every frame in the target workspace **before** closing anything; if one returns false the close is aborted and nothing is torn down. The frame is free to push its own confirmation dialog from `ConfirmClose` — the loop returns on the first veto, and `range` over the captured slice header keeps that safe.

The check sits before the last-screen quit branch on purpose, so closing the final workspace asks too. Frames that do not implement the interface are unaffected: opt-in, no behavior change for anything that exists today.

Tests cover: veto aborts (frame not closed, screen count unchanged, `ConfirmClose` called once), non-veto closes as before, a vetoer *under* a stacked dialog still vetoes, and all three input routes (Ctrl+W fallback, middle click, semantic action) reach the veto through the real dispatch path.

The f4 side is ready and will follow as a PR there once this lands: `EditorView.ConfirmClose` returns true when clean, and otherwise shows its usual confirmation and vetoes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
