### PR TITLE
fix(wayland): clear keyboard state on focus loss

### DIFF
--- a/wayland_host.go
+++ b/wayland_host.go
@@ -452,7 +452,7 @@ func (h *WaylandHost) Key(win *window.Window, input *window.Input, timeMs uint32
 	mods := h.getMods(input)
 
 	h.mu.Lock()
-	if isDown {
+	if isDown && waylandKeyCanRepeat(vk) {
 		h.isRepeating = true
 		h.repeatVK = vk
 		h.repeatChar = char
@@ -460,8 +460,8 @@ func (h *WaylandHost) Key(win *window.Window, input *window.Input, timeMs uint32
 		h.repeatNext = time.Now().Add(400 * time.Millisecond)
 		// Force an immediate redraw to start the spin loop
 		h.widget.ScheduleRedraw()
-	} else {
-		h.isRepeating = false
+	} else if !isDown && h.repeatVK == vk {
+		h.stopKeyRepeatLocked()
 	}
 	h.mu.Unlock()
 
@@ -474,6 +474,27 @@ func (h *WaylandHost) Key(win *window.Window, input *window.Input, timeMs uint32
 			ControlKeyState: mods,
 		}
 	}
+}
+
+func waylandKeyCanRepeat(vk uint16) bool {
+	switch vk {
+	case vtinput.VK_LCONTROL, vtinput.VK_RCONTROL,
+		vtinput.VK_LMENU, vtinput.VK_RMENU,
+		vtinput.VK_LSHIFT, vtinput.VK_RSHIFT,
+		vtinput.VK_LWIN, vtinput.VK_RWIN,
+		vtinput.VK_CAPITAL, vtinput.VK_NUMLOCK, vtinput.VK_SCROLL:
+		return false
+	default:
+		return true
+	}
+}
+
+func (h *WaylandHost) stopKeyRepeatLocked() {
+	h.isRepeating = false
+	h.repeatVK = 0
+	h.repeatChar = 0
+	h.repeatMods = 0
+	h.repeatNext = time.Time{}
 }
 
 func (h *WaylandHost) getMods(input *window.Input) vtinput.ControlKeyState {
@@ -508,8 +529,24 @@ func (h *WaylandHost) getMods(input *window.Input) vtinput.ControlKeyState {
 	return mods
 }
 
+func (h *WaylandHost) Focus(w *window.Window, device *window.Input) {
+	if device != nil {
+		return
+	}
+
+	// Wayland does not send key releases to a surface after keyboard focus has
+	// left it. Drop all locally tracked state so a held modifier or repeat key
+	// cannot remain active indefinitely when the window later regains focus.
+	h.mu.Lock()
+	h.stopKeyRepeatLocked()
+	h.currentMods = 0
+	h.lCtrl, h.rCtrl = false, false
+	h.lAlt, h.rAlt = false, false
+	h.lShift, h.rShift = false, false
+	h.mu.Unlock()
+}
+
 // Unused Handlers to satisfy interface
-func (h *WaylandHost) Focus(w *window.Window, device *window.Input) {}
 func (h *WaylandHost) TouchUp(w *window.Widget, i *window.Input, serial uint32, time uint32, id int32) {
 }
 func (h *WaylandHost) TouchDown(w *window.Widget, i *window.Input, serial uint32, time uint32, id int32, x float32, y float32) {

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/neurlang/wayland/window"
 	"github.com/neurlang/wayland/wl"
 	"github.com/unxed/vtinput"
 )
@@ -26,6 +27,61 @@ func TestWaylandHost_KeyRepeatLogic(t *testing.T) {
 
 	// Note: full integration test of Redraw() spin loop requires mocking window.Widget,
 	// which is deeply integrated with the Wayland protocol implementation.
+}
+
+func TestWaylandFocusLossClearsKeyboardState(t *testing.T) {
+	host := &WaylandHost{
+		isRepeating: true,
+		repeatVK:    vtinput.VK_LMENU,
+		repeatChar:  'x',
+		repeatMods:  vtinput.LeftAltPressed,
+		repeatNext:  time.Now().Add(time.Second),
+		currentMods: vtinput.LeftAltPressed,
+		lCtrl:       true,
+		rCtrl:       true,
+		lAlt:        true,
+		rAlt:        true,
+		lShift:      true,
+		rShift:      true,
+	}
+
+	// Gaining focus must not discard state established by a subsequent key
+	// event; only the nil-device notification denotes focus loss.
+	host.Focus(nil, &window.Input{})
+	if !host.isRepeating || !host.lAlt {
+		t.Fatal("focus gain unexpectedly cleared keyboard state")
+	}
+
+	host.Focus(nil, nil)
+
+	host.mu.Lock()
+	defer host.mu.Unlock()
+	if host.isRepeating || host.repeatVK != 0 || host.repeatChar != 0 || host.repeatMods != 0 || !host.repeatNext.IsZero() {
+		t.Fatalf("repeat state not cleared: active=%v vk=%d char=%q mods=%d next=%v",
+			host.isRepeating, host.repeatVK, host.repeatChar, host.repeatMods, host.repeatNext)
+	}
+	if host.currentMods != 0 || host.lCtrl || host.rCtrl || host.lAlt || host.rAlt || host.lShift || host.rShift {
+		t.Fatalf("modifier state not cleared: mods=%d ctrl=%v/%v alt=%v/%v shift=%v/%v",
+			host.currentMods, host.lCtrl, host.rCtrl, host.lAlt, host.rAlt, host.lShift, host.rShift)
+	}
+}
+
+func TestWaylandModifierKeysDoNotRepeat(t *testing.T) {
+	modifiers := []uint16{
+		vtinput.VK_LCONTROL, vtinput.VK_RCONTROL,
+		vtinput.VK_LMENU, vtinput.VK_RMENU,
+		vtinput.VK_LSHIFT, vtinput.VK_RSHIFT,
+		vtinput.VK_LWIN, vtinput.VK_RWIN,
+		vtinput.VK_CAPITAL, vtinput.VK_NUMLOCK, vtinput.VK_SCROLL,
+	}
+	for _, vk := range modifiers {
+		if waylandKeyCanRepeat(vk) {
+			t.Errorf("modifier/toggle key %#x unexpectedly repeats", vk)
+		}
+	}
+	if !waylandKeyCanRepeat(vtinput.VK_A) {
+		t.Error("ordinary key unexpectedly does not repeat")
+	}
 }
 
 func newWaylandPointerTestHost(t *testing.T) *WaylandHost {


### PR DESCRIPTION
## Problem

During investigation of a live F4 Wayland session that had stopped updating, VTUI still had `isRepeating = true`, `repeatVK = VK_LMENU`, and `lAlt = true` long after the compositor reported no active modifiers. This continuously scheduled redraws and left Alt logically stuck.

Wayland removes keyboard focus with `Focus(window, nil)`. Key releases are not delivered to the old surface after focus has left it, but VTUI implemented `Focus` as a no-op, so locally tracked repeat and modifier state could survive indefinitely. VTUI also started its manual repeat loop for modifier/toggle keys even though XKB defines those keys as non-repeatable.

## Fix

- On keyboard focus loss, stop repeat and clear the repeat payload, deadline, and all locally tracked modifier state.
- Do not start manual repeat for Ctrl, Alt, Shift, Super, or lock keys.
- Stop repeat on release only when the released key is the active repeat key, so an unrelated key release cannot cancel it.

Focus gain remains a no-op. The change is Wayland-only and independent of the pointer and scaling fixes.

## Verification

- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go test -race -count=20 -run "^TestWayland" .`
- Added regression tests for focus-gain preservation, focus-loss cleanup, repeat payload cleanup, and non-repeatable modifier/toggle keys.

The repository-wide race suite still reports existing races in unrelated frame-manager/protocol tests; the scoped Wayland-host race suite is clean.