### PR TITLE
fix: keep modal dialogs accessible in short windows

### DIFF
--- a/basewindow.go
+++ b/basewindow.go
@@ -182,7 +182,15 @@ func (bw *BaseWindow) Show(scr *ScreenBuf) {
 		scr.Write(bw.X1+2, bw.Y1, StringToCharInfo(numStr, Palette[bw.frame.ColorBoxIdx]))
 	}
 
-	// Delegate drawing of children to the root group
+	// A short modal dialog can retain full-size contents and scroll them
+	// through its smaller visible viewport. Normal windows keep their existing
+	// drawing behaviour.
+	if bw.Modal {
+		scr.PushClipRect(bw.X1+1, bw.Y1+1, bw.X2-1, bw.Y2-1)
+		bw.rootGroup.Show(scr)
+		scr.PopClipRect()
+		return
+	}
 	bw.rootGroup.Show(scr)
 }
 
@@ -391,6 +399,28 @@ func (bw *BaseWindow) MoveRelative(dx, dy int) {
 	bw.Y2 += dy
 	bw.frame.SetPosition(bw.X1, bw.Y1, bw.X2, bw.Y2)
 	bw.rootGroup.MoveRelative(dx, dy)
+}
+
+// setViewportSize changes only the visible window bounds. Unlike ChangeSize,
+// it deliberately does not resize or reflow child controls: a modal dialog
+// uses it to expose a scrolling viewport for controls that do not fit.
+func (bw *BaseWindow) setViewportSize(width, height int) {
+	if width < 3 {
+		width = 3
+	}
+	if height < 3 {
+		height = 3
+	}
+	bw.X2 = bw.X1 + width - 1
+	bw.Y2 = bw.Y1 + height - 1
+	bw.ScreenObject.SetPosition(bw.X1, bw.Y1, bw.X2, bw.Y2)
+	if bw.frame != nil {
+		bw.frame.SetPosition(bw.X1, bw.Y1, bw.X2, bw.Y2)
+	}
+	if bw.rootGroup != nil {
+		bw.rootGroup.SetPosition(bw.X1+1, bw.Y1+1, bw.X2-1, bw.Y2-1)
+	}
+	bw.lastW, bw.lastH = width, height
 }
 
 // HandleCommand implements Turbo Vision style command routing for Windows/Dialogs.

--- a/dialog_test.go
+++ b/dialog_test.go
@@ -5,6 +5,54 @@ import (
 	"testing"
 )
 
+func TestCenteredDialogScrollsToItsFocusedControlInAShortViewport(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(40, 8)
+	FrameManager.Init(scr)
+
+	dialog := NewCenteredDialog(30, 14, "Panel settings")
+	first := NewButton(dialog.X1+2, dialog.Y1+2, "First")
+	last := NewButton(dialog.X1+2, dialog.Y1+11, "Last")
+	last.IsDefault = true
+	dialog.AddItem(first)
+	dialog.AddItem(last)
+	dialog.Show(scr)
+
+	if dialog.Y1 != 0 || dialog.Y2 != 7 {
+		t.Fatalf("visible dialog bounds = (%d,%d), want (0,7)", dialog.Y1, dialog.Y2)
+	}
+	if dialog.scrollMax == 0 {
+		t.Fatal("short dialog viewport did not enable scrolling")
+	}
+
+	dialog.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_NEXT})
+	_, _, _, lastY := last.GetPosition()
+	if lastY > dialog.Y2-1 {
+		t.Fatalf("default button stayed below viewport at row %d (bottom %d)", lastY, dialog.Y2-1)
+	}
+}
+
+func TestCenteredDialogScrollsWithMouseWheelInAShortViewport(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(40, 8)
+	FrameManager.Init(scr)
+
+	dialog := NewCenteredDialog(30, 14, "Panel settings")
+	last := NewButton(dialog.X1+2, dialog.Y1+11, "Last")
+	dialog.AddItem(last)
+	dialog.Show(scr)
+
+	for range 8 {
+		if !dialog.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, WheelDirection: -1}) {
+			t.Fatal("mouse wheel was not handled by a short modal dialog")
+		}
+	}
+	_, _, _, lastY := last.GetPosition()
+	if lastY > dialog.Y2-1 {
+		t.Fatalf("mouse wheel did not reveal the last control: row %d, bottom %d", lastY, dialog.Y2-1)
+	}
+}
+
 func TestDialog_HotkeyCaseInsensitivity(t *testing.T) {
 	d := NewDialog(0, 0, 40, 10, "Case Test")
 	btn := NewButton(1, 1, "&File")

--- a/window.go
+++ b/window.go
@@ -1,8 +1,14 @@
 package vtui
 
+import "github.com/unxed/vtinput"
+
 // Window is a container for UI elements. It can be modal (Dialog) or non-modal.
 type Window struct {
 	BaseWindow
+	contentWidth  int
+	contentHeight int
+	scrollY       int
+	scrollMax     int
 }
 
 func NewWindow(x1, y1, x2, y2 int, title string) *Window {
@@ -11,6 +17,8 @@ func NewWindow(x1, y1, x2, y2 int, title string) *Window {
 	}
 	w.ShowClose = true
 	w.ShowZoom = true
+	w.contentWidth = x2 - x1 + 1
+	w.contentHeight = y2 - y1 + 1
 	w.rootGroup.SetOwner(w)
 	w.frame.SetOwner(w)
 	return w
@@ -34,9 +42,132 @@ func NewCenteredDialog(width, height int, title string) *Window {
 			scrH = FrameManager.scr.height
 		}
 	}
-	x1 := (scrW - width) / 2
-	y1 := (scrH - height) / 2
-	return NewDialog(x1, y1, x1+width-1, y1+height-1, title)
+	viewW, viewH := modalViewportSize(scrW, scrH, width, height)
+	x1 := (scrW - viewW) / 2
+	y1 := (scrH - viewH) / 2
+	dialog := NewDialog(x1, y1, x1+width-1, y1+height-1, title)
+	dialog.resizeModalViewport(scrW, scrH)
+	return dialog
+}
+
+// ResizeConsole keeps modal dialogs inside the usable screen viewport. A
+// dialog whose contents are taller than the viewport enables vertical
+// scrolling; shrinking fixed controls would make them overlap instead.
+func (w *Window) ResizeConsole(screenW, screenH int) {
+	if !w.Modal {
+		w.BaseWindow.ResizeConsole(screenW, screenH)
+		return
+	}
+	w.resizeModalViewport(screenW, screenH)
+}
+
+func modalViewportSize(screenW, screenH, dialogW, dialogH int) (int, int) {
+	if dialogW < screenW {
+		screenW = dialogW
+	}
+	if dialogH < screenH {
+		screenH = dialogH
+	}
+	return screenW, screenH
+}
+
+func (w *Window) resizeModalViewport(screenW, screenH int) {
+	viewW, viewH := modalViewportSize(screenW, screenH, w.contentWidth, w.contentHeight)
+	if viewW <= 0 || viewH <= 0 {
+		return
+	}
+	w.MoveRelative((screenW-viewW)/2-w.X1, (screenH-viewH)/2-w.Y1)
+	w.setViewportSize(viewW, viewH)
+	w.updateScrollBounds()
+}
+
+func (w *Window) updateScrollBounds() {
+	if !w.Modal || w.rootGroup == nil {
+		return
+	}
+	contentBottom := w.Y1 + 1
+	for _, item := range w.rootGroup.items {
+		_, _, _, y2 := item.GetPosition()
+		if bottom := y2 + w.scrollY; bottom > contentBottom {
+			contentBottom = bottom
+		}
+	}
+	w.scrollMax = contentBottom - (w.Y2 - 1)
+	if w.scrollMax < 0 {
+		w.scrollMax = 0
+	}
+	w.setScroll(w.scrollY)
+}
+
+func (w *Window) setScroll(target int) {
+	if target < 0 {
+		target = 0
+	}
+	if target > w.scrollMax {
+		target = w.scrollMax
+	}
+	delta := w.scrollY - target
+	if delta == 0 || w.rootGroup == nil {
+		return
+	}
+	for _, item := range w.rootGroup.items {
+		item.MoveRelative(0, delta)
+	}
+	w.scrollY = target
+}
+
+func (w *Window) ensureFocusedItemVisible() {
+	if w.scrollMax == 0 {
+		return
+	}
+	focused := w.GetFocusedItem()
+	if focused == nil {
+		return
+	}
+	_, y1, _, y2 := focused.GetPosition()
+	top, bottom := w.Y1+1, w.Y2-1
+	target := w.scrollY
+	if y1 < top {
+		target -= top - y1
+	}
+	if y2 > bottom {
+		target += y2 - bottom
+	}
+	w.setScroll(target)
+}
+
+func (w *Window) Show(scr *ScreenBuf) {
+	w.updateScrollBounds()
+	w.BaseWindow.Show(scr)
+}
+
+func (w *Window) ProcessKey(e *vtinput.InputEvent) bool {
+	handled := w.BaseWindow.ProcessKey(e)
+	if handled && (e.KeyDown || e.Type == vtinput.FocusEventType) {
+		w.updateScrollBounds()
+		w.ensureFocusedItemVisible()
+	}
+	return handled
+}
+
+func (w *Window) ProcessMouse(e *vtinput.InputEvent) bool {
+	// A short modal dialog owns the wheel even when the pointer happens to be
+	// above a child control. Otherwise a child can consume the event before
+	// the dialog gets a chance to reveal its hidden controls.
+	if e.WheelDirection != 0 && w.scrollMax != 0 {
+		if e.WheelDirection > 0 {
+			w.setScroll(w.scrollY - wheelLinesFor(WheelAreaList, e.WheelDirection))
+		} else {
+			w.setScroll(w.scrollY + wheelLinesFor(WheelAreaList, e.WheelDirection))
+		}
+		return true
+	}
+	if w.BaseWindow.ProcessMouse(e) {
+		w.updateScrollBounds()
+		w.ensureFocusedItemVisible()
+		return true
+	}
+	return false
 }
 
 func (w *Window) GetType() FrameType {


### PR DESCRIPTION
## Summary
- keep modal dialogs inside the active viewport when they are taller than it
- scroll hidden dialog controls into view through focus navigation or the mouse wheel
- clip dialog contents to the visible frame

Validated from f4 issue #561 on Windows 11 with the Win32 GUI: Panel Settings opens in a 30-row viewport, Page Down reaches `OK`/`Cancel`, wheel scrolling works over child controls, and repeated native resize cycles redraw without artifacts.

## Tests
- `go test . -run '^TestCenteredDialog(ScrollsToItsFocusedControl|ScrollsWithMouseWheel)InAShortViewport$' -count=1 -v`
- `go test . -count=1` *(has pre-existing environment/test failures: Python is unavailable; `TestWin32DnD_DropEffectConversion` expects `copy|move` but gets `copy`.)*