### PR TITLE
Preserve full edit selection on Ctrl+Shift+Left

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -585,6 +585,10 @@ func (e *Edit) ProcessKey(event *vtinput.InputEvent) bool {
 		return e.FireAction(e.OnAction, nil)
 
 	case vtinput.VK_LEFT:
+		// zoin-bot: A full edit selection starts at the right edge. When
+		// Ctrl+Shift+Left reaches the beginning of an undivided value, keep
+		// that full selection so the next character replaces the value.
+		fullSelectionAtEnd := e.selStart == 0 && e.selEnd == len(e.text) && e.curPos == len(e.text)
 		isAtStart := false
 		var cmap CaretMap
 		if DefaultBidiMode == BidiFull {
@@ -637,6 +641,11 @@ func (e *Edit) ProcessKey(event *vtinput.InputEvent) bool {
 		}
 		if shift {
 			e.endSelection()
+			if ctrl && fullSelectionAtEnd && e.curPos == 0 {
+				e.selStart = 0
+				e.selEnd = len(e.text)
+				e.selAnchor = 0
+			}
 		}
 		e.clearFlag = false
 		return true

--- a/edit_test.go
+++ b/edit_test.go
@@ -642,6 +642,42 @@ func TestEdit_WordSelection_FarSpec(t *testing.T) {
 		t.Errorf("Selection fail: expected [0:12], got [%d:%d]", e.selStart, e.selEnd)
 	}
 }
+
+func TestEdit_WordSelection_FromFullValuePreservesWholeWord(t *testing.T) {
+	SetDefaultPalette()
+
+	e := NewEdit(0, 0, 20, "syslog")
+	e.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_LEFT,
+		ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed,
+	})
+
+	if e.selStart != 0 || e.selEnd != len(e.text) {
+		t.Fatalf("Ctrl+Shift+Left cleared the initial full selection: [%d:%d]", e.selStart, e.selEnd)
+	}
+
+	e.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, Char: '1'})
+	if got := e.GetText(); got != "1" {
+		t.Fatalf("typing after Ctrl+Shift+Left produced %q, want %q", got, "1")
+	}
+}
+
+func TestEdit_WordSelection_FromFullValueKeepsDividerBoundary(t *testing.T) {
+	SetDefaultPalette()
+
+	e := NewEdit(0, 0, 20, "syslog.2.gz")
+	e.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_LEFT,
+		ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed,
+	})
+
+	if e.selStart != 0 || e.selEnd != len([]rune("syslog.2.")) {
+		t.Fatalf("Ctrl+Shift+Left changed the divider boundary: [%d:%d]", e.selStart, e.selEnd)
+	}
+}
+
 func TestEdit_WordJumps_DifferentDividers(t *testing.T) {
 	// A change of divider kind is not a word boundary in far2l, so plain
 	// Ctrl+Right crosses the whole run at once (issue #280).


### PR DESCRIPTION
I, zoin-bot, fixed the edit selection regression behind unxed/f4#559.

When an edit control started with a fully selected value without divider characters (for example, `syslog`), Ctrl+Shift+Left moved the caret to position 0 and collapsed the selection. The next character was then inserted before the value (`1syslog`) instead of replacing it.

This change preserves the initial full selection at that boundary while retaining the existing divider behavior (`syslog.2.gz` selects `syslog.2.`). It adds regression tests for both cases.

Validation:
- `go test ./...` passes in vtui.
- f4 targeted dialog tests pass against the patched vtui.
- f4 builds successfully for Linux ARM64 and the rename flow was verified in a real ANSI TTY.