### PR TITLE
Fix win32 GUI resize cursor not showing on window edges

### DIFF
--- a/win32_gui_windows.go
+++ b/win32_gui_windows.go
@@ -610,7 +610,12 @@ func (h *Win32GuiHost) handleMessage(hwnd syscall.Handle, msg uint32, wParam, lP
 		return 0
 
 	case wmSetCursor:
-		if h.hCursor != 0 {
+		// lParam's low word is the hit-test result Windows computed for the
+		// pointer. Over the non-client frame (the resizeable edges/corners)
+		// we must let DefWindowProc set the matching resize cursor, so only
+		// override the cursor when the hit is inside the client area.
+		const htClient = 1
+		if int(lParam&0xFFFF) == htClient && h.hCursor != 0 {
 			procSetCursor.Call(uintptr(h.hCursor))
 			return 1
 		}


### PR DESCRIPTION
Close part 2 https://github.com/unxed/f4/issues/549

The WM_SETCURSOR handler unconditionally forced IDC_ARROW and returned 1,
overriding Windows' own resize cursors (IDC_SIZEWE/NS/NWSE) over the
WS_THICKFRAME frame. Now the cursor is only overridden inside the client
area (HTCLIENT); the non-client frame is passed to DefWindowProc so the
correct resize cursors appear on the right/bottom/bottom-right zones.

## Summary
- Fixes missing resize cursors when hovering the window frame in the win32 GUI backend.
- The `WM_SETCURSOR` case in `win32GuiWndProc` ignored the hit-test code and always set `IDC_ARROW`, returning `1` so Windows never drew its own size cursors over the resizable edges/corners.

## Changes
- `win32_gui_windows.go`: only override the cursor when `lParam & 0xFFFF == HTCLIENT`; otherwise defer to `DefWindowProcW`, which restores `IDC_SIZEWE` / `IDC_SIZENS` / `IDC_SIZENWSE` on the right/bottom/bottom-right frame zones.

## Test plan
- Build the win32 GUI backend and run under native Windows.
- Hover the right edge, bottom edge, and bottom-right corner: cursor should change to the resize arrows.
- Hover inside the terminal: cursor stays as configured (arrow).

