### PR TITLE
Win32 GUI: apply logical resize to native window

### DIFF
--- a/win32_gui_common.go
+++ b/win32_gui_common.go
@@ -72,6 +72,13 @@ const (
 	wmMouseMove       = 0x0200
 	wmMouseWheel      = 0x020A
 	wmPerformDragDrop = 0x0400 + 101
+	wmPerformResize   = wmPerformDragDrop + 1
+)
+
+const (
+	swpNoMove     = 0x0002
+	swpNoZOrder   = 0x0004
+	swpNoActivate = 0x0010
 )
 
 // Win32 DIB and GDI Constants

--- a/win32_gui_resize_windows_test.go
+++ b/win32_gui_resize_windows_test.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package vtui
+
+import "testing"
+
+func TestWin32GuiHost_ResizeGridWithoutWindow(t *testing.T) {
+	host := &Win32GuiHost{cols: 80, rows: 25, cellW: 8, cellH: 16}
+	host.ResizeGrid(120, 40)
+	if host.cols != 120 || host.rows != 40 {
+		t.Fatalf("logical grid = %dx%d, want 120x40", host.cols, host.rows)
+	}
+
+	host.ResizeGrid(0, 40)
+	host.ResizeGrid(120, 0)
+	if host.cols != 120 || host.rows != 40 {
+		t.Fatalf("invalid resize changed logical grid to %dx%d", host.cols, host.rows)
+	}
+}

--- a/win32_gui_test.go
+++ b/win32_gui_test.go
@@ -72,6 +72,20 @@ func TestWin32GuiRenderer_CursorDirty(t *testing.T) {
 	}
 }
 
+func TestWin32GuiHost_ResizeGridWithoutWindow(t *testing.T) {
+	host := &Win32GuiHost{cols: 80, rows: 25, cellW: 8, cellH: 16}
+	host.ResizeGrid(120, 40)
+	if host.cols != 120 || host.rows != 40 {
+		t.Fatalf("logical grid = %dx%d, want 120x40", host.cols, host.rows)
+	}
+
+	host.ResizeGrid(0, 40)
+	host.ResizeGrid(120, 0)
+	if host.cols != 120 || host.rows != 40 {
+		t.Fatalf("invalid resize changed logical grid to %dx%d", host.cols, host.rows)
+	}
+}
+
 func TestWin32GuiRenderer_ImplementsInterfaces(t *testing.T) {
 	var _ SurfaceRenderer = (*Win32GuiRenderer)(nil)
 	var _ GraphicsRenderer = (*Win32GuiRenderer)(nil)

--- a/win32_gui_test.go
+++ b/win32_gui_test.go
@@ -72,20 +72,6 @@ func TestWin32GuiRenderer_CursorDirty(t *testing.T) {
 	}
 }
 
-func TestWin32GuiHost_ResizeGridWithoutWindow(t *testing.T) {
-	host := &Win32GuiHost{cols: 80, rows: 25, cellW: 8, cellH: 16}
-	host.ResizeGrid(120, 40)
-	if host.cols != 120 || host.rows != 40 {
-		t.Fatalf("logical grid = %dx%d, want 120x40", host.cols, host.rows)
-	}
-
-	host.ResizeGrid(0, 40)
-	host.ResizeGrid(120, 0)
-	if host.cols != 120 || host.rows != 40 {
-		t.Fatalf("invalid resize changed logical grid to %dx%d", host.cols, host.rows)
-	}
-}
-
 func TestWin32GuiRenderer_ImplementsInterfaces(t *testing.T) {
 	var _ SurfaceRenderer = (*Win32GuiRenderer)(nil)
 	var _ GraphicsRenderer = (*Win32GuiRenderer)(nil)

--- a/win32_gui_windows.go
+++ b/win32_gui_windows.go
@@ -34,6 +34,7 @@ var (
 	procInvalidateRect     = user32.NewProc("InvalidateRect")
 	procGetClientRect      = user32.NewProc("GetClientRect")
 	procAdjustWindowRectEx = user32.NewProc("AdjustWindowRectEx")
+	procSetWindowPos       = user32.NewProc("SetWindowPos")
 	procLoadCursorW        = user32.NewProc("LoadCursorW")
 	procSetCursor          = user32.NewProc("SetCursor")
 	procSetCapture         = user32.NewProc("SetCapture")
@@ -128,20 +129,21 @@ type win32Point struct {
 }
 
 type Win32GuiHost struct {
-	mu           sync.Mutex
-	hwnd         syscall.Handle
-	hCursor      syscall.Handle
-	renderer     *Win32GuiRenderer
-	reader       *vtinput.Reader
-	scr          *ScreenBuf
-	cols, rows   int
-	cellW, cellH int
-	scale        int
-	winW, winH   int
-	mouseBtn     uint32
-	closeChan    chan struct{}
-	closed       bool
-	pendingDrag  *win32DragRequest
+	mu                                   sync.Mutex
+	hwnd                                 syscall.Handle
+	hCursor                              syscall.Handle
+	renderer                             *Win32GuiRenderer
+	reader                               *vtinput.Reader
+	scr                                  *ScreenBuf
+	cols, rows                           int
+	cellW, cellH                         int
+	scale                                int
+	winW, winH                           int
+	mouseBtn                             uint32
+	closeChan                            chan struct{}
+	closed                               bool
+	pendingDrag                          *win32DragRequest
+	pendingResizeCols, pendingResizeRows int
 
 	// dropTarget is the IDropTarget registered for this window, held as the
 	// bare interface pointer so this struct stays free of a type that only
@@ -217,10 +219,27 @@ func (h *Win32GuiHost) SetTitle(title string) {
 }
 
 func (h *Win32GuiHost) ResizeGrid(cols, rows int) {
+	if h == nil || cols <= 0 || rows <= 0 {
+		return
+	}
 	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.cols = cols
-	h.rows = rows
+	hwnd := h.hwnd
+	if hwnd == 0 {
+		// This path keeps the renderer testable before a native window exists.
+		h.cols = cols
+		h.rows = rows
+		h.mu.Unlock()
+		return
+	}
+	h.pendingResizeCols = cols
+	h.pendingResizeRows = rows
+	h.mu.Unlock()
+
+	// The Win32 window and its message pump live on the locked GUI thread,
+	// while FrameManager dispatches actions from its own goroutine. Post the
+	// resize just like DoDragDrop is posted, so SetWindowPos and the resulting
+	// WM_SIZE are handled by the window's owning thread.
+	procPostMessageW.Call(uintptr(hwnd), wmPerformResize, 0, 0)
 }
 
 func (h *Win32GuiHost) Invalidate() {
@@ -348,6 +367,44 @@ func (h *Win32GuiHost) handleMessage(hwnd syscall.Handle, msg uint32, wParam, lP
 			action, err := win32DoDragDrop(req.paths, req.allowed)
 			req.done <- win32DragResult{action: action, err: err}
 		}
+		return 0
+
+	case wmPerformResize:
+		h.mu.Lock()
+		cols, rows := h.pendingResizeCols, h.pendingResizeRows
+		h.pendingResizeCols, h.pendingResizeRows = 0, 0
+		cellW, cellH := h.cellW, h.cellH
+		h.mu.Unlock()
+		if cols <= 0 || rows <= 0 || cellW <= 0 || cellH <= 0 {
+			return 0
+		}
+
+		// ResizeGrid takes logical cells, but SetWindowPos takes the outer
+		// window size. Use the exact same style/ex-style pair as creation so
+		// the requested client area remains cols*cellW by rows*cellH.
+		var rc win32Rect
+		rc.right = int32(cols * cellW)
+		rc.bottom = int32(rows * cellH)
+		procAdjustWindowRectEx.Call(
+			uintptr(unsafe.Pointer(&rc)),
+			uintptr(wsOverlappedWindow),
+			0,
+			uintptr(wsExAcceptFiles|wsExAppWindow),
+		)
+		outerW := rc.right - rc.left
+		outerH := rc.bottom - rc.top
+		if outerW <= 0 || outerH <= 0 {
+			return 0
+		}
+		procSetWindowPos.Call(
+			uintptr(hwnd),
+			0,
+			0,
+			0,
+			uintptr(outerW),
+			uintptr(outerH),
+			swpNoMove|swpNoZOrder|swpNoActivate,
+		)
 		return 0
 
 	case wmEraseBkgnd:


### PR DESCRIPTION
## Summary
- make Win32 `ResizeGrid` apply the requested logical cell size to the native window
- marshal `SetWindowPos` onto the GUI thread and preserve the client-area dimensions
- add coverage for logical resize validation before a native window exists

This fixes the native-window side of `unxed/f4#549` (Alt+F9). The cursor behavior in that report is already fixed by the current vtui mainline cursor handling.

## Verification by zoin-bot
- `go test . -run 'TestWin32GuiHost_ResizeGridWithoutWindow|TestWin32GuiRenderer|TestWin32Gui_DIBInfo|TestWin32Gui_RGBAToBGRA' -count=1`
- Windows 10 x64 real-device check: old binary stayed at `901x528`; patched binary toggled `901x528` -> `1257x775` -> `901x528` with Alt+F9.
- Windows 10 x64 real-device cursor check: patched binary reported `SIZEWE` on side edges and `SIZENS` on the top edge.