### PR TITLE
fix: keep table cursor aligned with filtered rows

### DIFF
--- a/table.go
+++ b/table.go
@@ -498,7 +498,7 @@ func (t *Table) DisplayObject(scr *ScreenBuf) {
 	// 1. Draw Header
 	widths := t.resolvedWidths()
 	if t.ShowHeader {
-		t.drawRow(scr, t.Y1, -1, Palette[t.ColorTitleIdx], widths)
+		t.drawRow(scr, t.Y1, -1, -1, Palette[t.ColorTitleIdx], widths)
 		yOffset++
 	}
 
@@ -523,7 +523,7 @@ func (t *Table) DisplayObject(scr *ScreenBuf) {
 			//isSelected := false
 			// Calculate standard attribute as a fallback (passed into drawRow)
 			attr := Palette[t.ColorTextIdx]
-			t.drawRow(scr, currY, rowIdx, attr, widths)
+			t.drawRow(scr, currY, rowIdx, displayPos, attr, widths)
 		} else {
 			// Fill empty space with background color
 			scr.FillRect(t.X1, currY, t.X2, currY, ' ', Palette[t.ColorTextIdx])
@@ -552,7 +552,7 @@ func (t *Table) DisplayObject(scr *ScreenBuf) {
 	}
 }
 
-func (t *Table) drawRow(scr *ScreenBuf, y int, rowIdx int, attr uint64, widths []int) {
+func (t *Table) drawRow(scr *ScreenBuf, y int, rowIdx int, displayPos int, attr uint64, widths []int) {
 	endX := t.X1 + t.GetContentWidth() - 1
 
 	currX := t.X1
@@ -588,7 +588,7 @@ func (t *Table) drawRow(scr *ScreenBuf, y int, rowIdx int, attr uint64, widths [
 			}
 		}
 
-		isCursorHere := rowIdx == t.SelectPos && (!t.CellSelection || colIdx == t.SelectCol)
+		isCursorHere := displayPos == t.SelectPos && (!t.CellSelection || colIdx == t.SelectCol)
 
 		stateAttr := attr
 		if rowIdx != -1 {

--- a/table_test.go
+++ b/table_test.go
@@ -1152,6 +1152,29 @@ func TestTable_QuickSearchBottomUp(t *testing.T) {
 	checkCell(t, scr, 0, 1, ' ', base)
 }
 
+func TestTable_QuickSearchCursorFollowsFilteredPosition(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(11, 5)
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetFocus(true)
+	tbl.SetRows([]TableRow{
+		mockRow{"xab", ""}, // underlying row 0, second match
+		mockRow{"abx", ""}, // underlying row 1, best match at display position 0
+	})
+
+	typeSearch(tbl, "ab")
+	tbl.Show(scr)
+
+	// Search results are drawn bottom-up. The selected display position 0 is
+	// the underlying row 1, so the cursor must be on the bottom "abx" row.
+	checkCell(t, scr, 2, 3, 'x', Palette[ColTableSelectedText])
+	checkCell(t, scr, 0, 2, 'x', Palette[ColTableText])
+}
+
 func TestTable_QuickSearchBottomUpKeys(t *testing.T) {
 	SetDefaultPalette()
 


### PR DESCRIPTION
## Summary
- keep cursor highlighting tied to the displayed table position after sorting or QuickSearch filtering
- add a regression test covering a filtered order different from the source row order

This fixes the cursor jumping reported by unxed/f4#493 and benefits every table consumer.