### PR TITLE
Optionally prefer exact QuickSearch matches

### DIFF
--- a/table.go
+++ b/table.go
@@ -104,6 +104,9 @@ type Table struct {
 	QuickSearch bool
 	// SearchCaseSensitive makes QuickSearch case-sensitive (default false).
 	SearchCaseSensitive bool
+	// SearchExactOnHit keeps only exact matches when at least one exact match
+	// exists. Fuzzy matches remain available while no exact result is present.
+	SearchExactOnHit bool
 	// OnSearchChange is called whenever the search string changes.
 	OnSearchChange func(text string)
 
@@ -410,6 +413,25 @@ func (t *Table) applySearchFilter() {
 		if bestScore >= 0 {
 			t.matchBuf = append(t.matchBuf, searchMatch{i, bestScore, bestStart})
 			t.matchSpans[i] = cellHighlight{bestCol, bestStart, bestEnd}
+		}
+	}
+	if t.SearchExactOnHit {
+		hasExact := false
+		for _, m := range t.matchBuf {
+			if m.score == 0 {
+				hasExact = true
+				break
+			}
+		}
+		if hasExact {
+			write := 0
+			for _, m := range t.matchBuf {
+				if m.score == 0 {
+					t.matchBuf[write] = m
+					write++
+				}
+			}
+			t.matchBuf = t.matchBuf[:write]
 		}
 	}
 	sort.Slice(t.matchBuf, func(a, b int) bool {

--- a/table_test.go
+++ b/table_test.go
@@ -888,6 +888,33 @@ func TestTable_QuickSearchFuzzyRanking(t *testing.T) {
 	}
 }
 
+func TestTable_QuickSearchExactOnHit(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "Key", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SearchExactOnHit = true
+	tbl.SetRows([]TableRow{
+		mockRow{"CtrlUp", ""},
+		mockRow{"CtrlA", ""},
+		mockRow{"CtrlPgUp", ""},
+	})
+
+	typeSearch(tbl, "ctrla")
+	if tbl.ItemCount != 1 {
+		t.Fatalf("expected only the exact key match, got %d rows", tbl.ItemCount)
+	}
+	if got := tbl.Rows[tbl.RowAt(0)].(mockRow).col1; got != "CtrlA" {
+		t.Fatalf("exact match = %q, want CtrlA", got)
+	}
+
+	tbl.SetSearchText("ctrlx")
+	if tbl.ItemCount == 0 {
+		t.Fatal("fuzzy matches should remain available when no exact result exists")
+	}
+}
+
 func TestTable_QuickSearchCaseInsensitive(t *testing.T) {
 	SetDefaultPalette()
 


### PR DESCRIPTION
## Summary

- add `Table.SearchExactOnHit` for command-like tables that should stop showing fuzzy near-matches once an exact result exists
- preserve the existing fuzzy ranking behavior by default
- keep fuzzy matches available when no exact result is present
- add regression coverage for the `ctrla` / `CtrlA` case

## Validation

- targeted table QuickSearch tests pass
- the new exact-on-hit test confirms that `CtrlUp` and `CtrlPgUp` are excluded when an exact `CtrlA` result exists

The local full suite still has the existing Windows-only Python binding and drag-and-drop expectation failures unrelated to this change.