### PR TITLE
fix: reveal workspace tabs after Ctrl+Tab

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -244,6 +244,7 @@ type frameManager struct {
 
 	// Switcher State
 	ctrlPressed              bool
+	workspaceTabPreview      bool
 	switcherMenu             *VMenu
 	WorkspaceTabMode         WorkspaceTabMode
 	WorkspaceCtrlTabMode     WorkspaceCtrlTabMode
@@ -394,7 +395,7 @@ func (fm *frameManager) tickAnimations() {
 func (fm *frameManager) WorkspaceTopInset() int {
 	if fm.WorkspaceTabMode == WorkspaceTabsAlways ||
 		(fm.WorkspaceTabMode == WorkspaceTabsMultiple && len(fm.Screens) > 1) ||
-		(fm.WorkspaceTabMode == WorkspaceTabsOnCtrl && fm.ctrlPressed) {
+		(fm.WorkspaceTabMode == WorkspaceTabsOnCtrl && fm.ctrlPressed && fm.workspaceTabPreview) {
 		return 1
 	}
 	return 0
@@ -1418,7 +1419,7 @@ func (fm *frameManager) workspaceTabsVisible() bool {
 	case WorkspaceTabsMultiple:
 		return len(fm.Screens) > 1
 	case WorkspaceTabsOnCtrl:
-		return fm.ctrlPressed
+		return fm.ctrlPressed && fm.workspaceTabPreview
 	default:
 		return false
 	}
@@ -2639,9 +2640,13 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 		}
 		fm.ctrlPressed = ctrl
 		if wasCtrlPressed != fm.ctrlPressed && fm.WorkspaceTabMode == WorkspaceTabsOnCtrl {
+			if !fm.ctrlPressed {
+				fm.workspaceTabPreview = false
+			}
 			// The overlay tab strip takes and releases the top row as Ctrl is
-			// held, so frames must relayout; a plain redraw would leave the
-			// image where it was and let it paint over the tabs.
+			// held after the first Ctrl+Tab, so frames must relayout; a plain
+			// redraw would leave the image where it was and let it paint over
+			// the tabs.
 			fm.ResizeAllScreens()
 			fm.Redraw()
 		}
@@ -2876,6 +2881,11 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 
 		// Workspace cycling (Ctrl+Tab / Ctrl+Shift+Tab).
 		if ev.VirtualKeyCode == vtinput.VK_TAB && (fm.ctrlPressed || fm.switcherMenu != nil) {
+			if fm.WorkspaceTabMode == WorkspaceTabsOnCtrl && !fm.workspaceTabPreview {
+				fm.workspaceTabPreview = true
+				fm.ResizeAllScreens()
+				fm.Redraw()
+			}
 			shift := (ev.ControlKeyState & vtinput.ShiftPressed) != 0
 			cycled := false
 			if fm.WorkspaceCtrlTabMode == WorkspaceCtrlTabMenu || fm.WorkspaceTabMode == WorkspaceTabsNever {

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -1795,14 +1795,58 @@ func TestFrameManager_OnCtrlInsetTracksCtrlState(t *testing.T) {
 	fm.ConfigureWorkspaceTabs(WorkspaceTabsOnCtrl, WorkspaceCtrlTabDirect)
 
 	// The overlay strip is drawn while Ctrl is held, so that row must be
-	// reserved then; otherwise a full-screen image paints over the tabs.
+	// reserved after the first Ctrl+Tab; otherwise a full-screen image paints
+	// over the tabs.
 	fm.ctrlPressed = true
+	if got := fm.WorkspaceTopInset(); got != 0 {
+		t.Fatalf("on-ctrl mode before Ctrl+Tab inset = %d, want 0", got)
+	}
+	fm.workspaceTabPreview = true
 	if got := fm.WorkspaceTopInset(); got != 1 {
-		t.Fatalf("on-ctrl mode while ctrl is held inset = %d, want 1", got)
+		t.Fatalf("on-ctrl mode after Ctrl+Tab inset = %d, want 1", got)
 	}
 	fm.ctrlPressed = false
 	if got := fm.WorkspaceTopInset(); got != 0 {
 		t.Fatalf("on-ctrl mode without ctrl inset = %d, want 0", got)
+	}
+}
+
+func TestFrameManager_OnCtrlTabsArmAfterFirstCtrlTab(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	fm := &frameManager{}
+	fm.Init(scr)
+	fm.Push(newMockFrame(0, 0, 80, 25, false))
+	fm.AddScreenBackground(newMockFrame(0, 0, 80, 25, false))
+	fm.ConfigureWorkspaceTabs(WorkspaceTabsOnCtrl, WorkspaceCtrlTabDirect)
+
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_CONTROL,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	}, false)
+	if fm.workspaceTabsVisible() || fm.WorkspaceTopInset() != 0 {
+		t.Fatal("pressing Ctrl alone should not reveal workspace tabs")
+	}
+
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_TAB,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	}, false)
+	if !fm.workspaceTabsVisible() || fm.WorkspaceTopInset() != 1 {
+		t.Fatal("the first Ctrl+Tab should reveal workspace tabs")
+	}
+
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        false,
+		VirtualKeyCode: vtinput.VK_CONTROL,
+	}, false)
+	if fm.workspaceTabsVisible() || fm.WorkspaceTopInset() != 0 {
+		t.Fatal("releasing Ctrl should hide workspace tabs again")
 	}
 }
 


### PR DESCRIPTION
Fixes the WorkspaceTabsOnCtrl flicker reported by f4#496. The workspace tab strip now stays hidden when Ctrl is pressed alone, arms on the first Ctrl+Tab or Ctrl+Shift+Tab, remains visible while Ctrl is held, and hides again on release.

Validation: go test ./... -count=1; core package and command builds; git diff --check. go vet ./... still reports the repository's existing warnings in bindings/c/cabi, test_main_test.go, and x11_shm_unix.go.

— zoin-bot