### PR TITLE
gui: expose native window position

### DIFF
--- a/ebiten_renderer.go
+++ b/ebiten_renderer.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hajimehoshi/ebiten/v2"
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )
@@ -406,6 +407,19 @@ func (r *EbitenRenderer) ResizeWindow(cols, rows int) {
 	if host != nil && cw > 0 && ch > 0 {
 		host.requestSize(cols*cw, rows*ch)
 	}
+}
+
+// WindowPosition returns the current desktop position of the Ebitengine
+// window. Ebitengine owns the native window, so the query is delegated to
+// its platform-aware API.
+func (r *EbitenRenderer) WindowPosition() (x, y int, ok bool) {
+	x, y = ebiten.WindowPosition()
+	return x, y, true
+}
+
+// SetWindowPosition moves the Ebitengine window without changing its size.
+func (r *EbitenRenderer) SetWindowPosition(x, y int) {
+	ebiten.SetWindowPosition(x, y)
 }
 
 // takeFrame hands the current framebuffer to the game loop and reports

--- a/framemanager.go
+++ b/framemanager.go
@@ -1839,6 +1839,49 @@ func SetWindowTitle(title string) {
 	}
 }
 
+// GetWindowPosition returns the native GUI window's top-left screen position.
+// It reports ok=false for terminal renderers and GUI backends that do not
+// expose a desktop position.
+func (fm *frameManager) GetWindowPosition() (x, y int, ok bool) {
+	if fm.scr == nil || fm.scr.Renderer == nil {
+		return 0, 0, false
+	}
+	if r, ok := fm.scr.Renderer.(interface {
+		WindowPosition() (int, int, bool)
+	}); ok {
+		return r.WindowPosition()
+	}
+	return 0, 0, false
+}
+
+// SetWindowPosition moves the native GUI window when the active backend
+// supports desktop positioning. Terminal renderers simply ignore the call.
+func (fm *frameManager) SetWindowPosition(x, y int) {
+	if fm.scr == nil || fm.scr.Renderer == nil {
+		return
+	}
+	if r, ok := fm.scr.Renderer.(interface {
+		SetWindowPosition(int, int)
+	}); ok {
+		r.SetWindowPosition(x, y)
+	}
+}
+
+// GetWindowPosition returns the active GUI window's top-left screen position.
+func GetWindowPosition() (x, y int, ok bool) {
+	if FrameManager == nil {
+		return 0, 0, false
+	}
+	return FrameManager.GetWindowPosition()
+}
+
+// SetWindowPosition moves the active GUI window when its backend supports it.
+func SetWindowPosition(x, y int) {
+	if FrameManager != nil {
+		FrameManager.SetWindowPosition(x, y)
+	}
+}
+
 // SetEventSink registers a unified callback receiving all semantic UI events.
 func (fm *frameManager) SetEventSink(fn func(UIEvent)) {
 	fm.eventSinkMu.Lock()

--- a/win32_gui_common.go
+++ b/win32_gui_common.go
@@ -74,6 +74,14 @@ const (
 	wmPerformDragDrop = 0x0400 + 101
 )
 
+// SetWindowPos flags used when moving the GUI window without changing its
+// size, z-order, or activation state.
+const (
+	swpNoSize     = 0x0001
+	swpNoZOrder   = 0x0004
+	swpNoActivate = 0x0010
+)
+
 // Win32 DIB and GDI Constants
 const (
 	biRGB        = 0

--- a/win32_gui_windows.go
+++ b/win32_gui_windows.go
@@ -33,6 +33,8 @@ var (
 	procEndPaint           = user32.NewProc("EndPaint")
 	procInvalidateRect     = user32.NewProc("InvalidateRect")
 	procGetClientRect      = user32.NewProc("GetClientRect")
+	procGetWindowRect      = user32.NewProc("GetWindowRect")
+	procSetWindowPos       = user32.NewProc("SetWindowPos")
 	procAdjustWindowRectEx = user32.NewProc("AdjustWindowRectEx")
 	procLoadCursorW        = user32.NewProc("LoadCursorW")
 	procSetCursor          = user32.NewProc("SetCursor")
@@ -221,6 +223,56 @@ func (h *Win32GuiHost) ResizeGrid(cols, rows int) {
 	defer h.mu.Unlock()
 	h.cols = cols
 	h.rows = rows
+}
+
+// WindowPosition returns the top-left screen position of the native window.
+// The bool is false while the host has not created a window or when Windows
+// cannot provide its rectangle.
+func (h *Win32GuiHost) WindowPosition() (x, y int, ok bool) {
+	h.mu.Lock()
+	hwnd := h.hwnd
+	h.mu.Unlock()
+	if hwnd == 0 {
+		return 0, 0, false
+	}
+
+	var rect win32Rect
+	ret, _, _ := procGetWindowRect.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&rect)))
+	if ret == 0 {
+		return 0, 0, false
+	}
+	return int(rect.left), int(rect.top), true
+}
+
+// SetWindowPosition moves the native window without resizing or activating
+// it. The call is also safe before the window is shown, which lets callers
+// restore a saved position during GUI startup.
+func (h *Win32GuiHost) SetWindowPosition(x, y int) {
+	h.mu.Lock()
+	hwnd := h.hwnd
+	h.mu.Unlock()
+	if hwnd == 0 {
+		return
+	}
+	procSetWindowPos.Call(
+		uintptr(hwnd), 0,
+		uintptr(uint32(int32(x))), uintptr(uint32(int32(y))),
+		0, 0,
+		uintptr(swpNoSize|swpNoZOrder|swpNoActivate),
+	)
+}
+
+func (r *Win32GuiRenderer) WindowPosition() (x, y int, ok bool) {
+	if r == nil || r.host == nil {
+		return 0, 0, false
+	}
+	return r.host.WindowPosition()
+}
+
+func (r *Win32GuiRenderer) SetWindowPosition(x, y int) {
+	if r != nil && r.host != nil {
+		r.host.SetWindowPosition(x, y)
+	}
 }
 
 func (h *Win32GuiHost) Invalidate() {


### PR DESCRIPTION
Expose native GUI window coordinates through vtui's public API. Win32 uses GetWindowRect/SetWindowPos, and the Ebiten backend delegates to its desktop window API. Terminal renderers and unsupported backends remain no-ops. This lets f4 persist Shift+F9 window placement without finding windows by title.