### PR TITLE
input: preserve EnhancedKey for X11 and Wayland navigation

### DIFF
--- a/ebiten_renderer.go
+++ b/ebiten_renderer.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hajimehoshi/ebiten/v2"
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )
@@ -406,6 +407,19 @@ func (r *EbitenRenderer) ResizeWindow(cols, rows int) {
 	if host != nil && cw > 0 && ch > 0 {
 		host.requestSize(cols*cw, rows*ch)
 	}
+}
+
+// WindowPosition returns the current desktop position of the Ebitengine
+// window. Ebitengine owns the native window, so the query is delegated to
+// its platform-aware API.
+func (r *EbitenRenderer) WindowPosition() (x, y int, ok bool) {
+	x, y = ebiten.WindowPosition()
+	return x, y, true
+}
+
+// SetWindowPosition moves the Ebitengine window without changing its size.
+func (r *EbitenRenderer) SetWindowPosition(x, y int) {
+	ebiten.SetWindowPosition(x, y)
 }
 
 // takeFrame hands the current framebuffer to the game loop and reports

--- a/framemanager.go
+++ b/framemanager.go
@@ -1839,6 +1839,49 @@ func SetWindowTitle(title string) {
 	}
 }
 
+// GetWindowPosition returns the native GUI window's top-left screen position.
+// It reports ok=false for terminal renderers and GUI backends that do not
+// expose a desktop position.
+func (fm *frameManager) GetWindowPosition() (x, y int, ok bool) {
+	if fm.scr == nil || fm.scr.Renderer == nil {
+		return 0, 0, false
+	}
+	if r, ok := fm.scr.Renderer.(interface {
+		WindowPosition() (int, int, bool)
+	}); ok {
+		return r.WindowPosition()
+	}
+	return 0, 0, false
+}
+
+// SetWindowPosition moves the native GUI window when the active backend
+// supports desktop positioning. Terminal renderers simply ignore the call.
+func (fm *frameManager) SetWindowPosition(x, y int) {
+	if fm.scr == nil || fm.scr.Renderer == nil {
+		return
+	}
+	if r, ok := fm.scr.Renderer.(interface {
+		SetWindowPosition(int, int)
+	}); ok {
+		r.SetWindowPosition(x, y)
+	}
+}
+
+// GetWindowPosition returns the active GUI window's top-left screen position.
+func GetWindowPosition() (x, y int, ok bool) {
+	if FrameManager == nil {
+		return 0, 0, false
+	}
+	return FrameManager.GetWindowPosition()
+}
+
+// SetWindowPosition moves the active GUI window when its backend supports it.
+func SetWindowPosition(x, y int) {
+	if FrameManager != nil {
+		FrameManager.SetWindowPosition(x, y)
+	}
+}
+
 // SetEventSink registers a unified callback receiving all semantic UI events.
 func (fm *frameManager) SetEventSink(fn func(UIEvent)) {
 	fm.eventSinkMu.Lock()

--- a/go.mod
+++ b/go.mod
@@ -48,3 +48,7 @@ require (
 replace github.com/ebitengine/purego => github.com/unxed/pureffi v0.1.14
 
 replace github.com/ebitengine/hideconsole => ./internal/hideconsole
+
+// Use the immutable keytrans revision that preserves EnhancedKey for the
+// physical X11/Wayland navigation cluster while unxed/keytrans#4 is reviewed.
+replace github.com/unxed/keytrans => github.com/Zoinen/keytrans v0.0.0-20260822041013-227b3d517c1a

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Zoinen/keytrans v0.0.0-20260822041013-227b3d517c1a h1:MCk8nNHTWm8MrwNmdTZZ3R3MXwGdCjmF9PgkKIESjDk=
+github.com/Zoinen/keytrans v0.0.0-20260822041013-227b3d517c1a/go.mod h1:rBB4IN6grB7BjyRuNmy8Kxlsu1P6Nf4pchLHvPmFpGg=
 github.com/ebitengine/gomobile v0.0.0-20260211053922-3d992dae95d1 h1:U8WldvN7/4cgo65U2fr2urv43/yhqYOK5FegFPPfI4M=
 github.com/ebitengine/gomobile v0.0.0-20260211053922-3d992dae95d1/go.mod h1:J7sDBRQG9pJGMa9Z+h8l3flwk0yEKDzWeR57vA1LI5U=
 github.com/emmansun/base64 v0.9.0 h1:92dLrE7iro6g/yWuPsd7M9TzJpe9fEeqKH0H7MApDtE=
@@ -39,8 +41,6 @@ github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y
 github.com/soniakeys/quant v1.0.0/go.mod h1:HI1k023QuVbD4H8i9YdfZP2munIHU4QpjsImz6Y6zds=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/unxed/keytrans v0.1.31 h1:Vk26zByEJkZAx3ZhgHGipO/wyiPj3LMn0wjy0BMBvO0=
-github.com/unxed/keytrans v0.1.31/go.mod h1:rBB4IN6grB7BjyRuNmy8Kxlsu1P6Nf4pchLHvPmFpGg=
 github.com/unxed/kiwi-go v0.1.0 h1:JTZb5mZSrzevswnL3OxCgN8oODkbPLHX7LXxJnpJ9YU=
 github.com/unxed/kiwi-go v0.1.0/go.mod h1:9nseXE0X7yf8SPvY4N2KOD2FiPwa+uNBDztt1kqf0aY=
 github.com/unxed/pureffi v0.1.14 h1:KLtaNZyGH+P5Yz7gZvViJO9q6P841jRozEP6koeFBDo=

--- a/wayland_host.go
+++ b/wayland_host.go
@@ -450,6 +450,7 @@ func (h *WaylandHost) Key(win *window.Window, input *window.Input, timeMs uint32
 	h.mu.Unlock()
 
 	mods := h.getMods(input)
+	mods |= enhancedKeyForX11Keysym(notUnicode)
 
 	h.mu.Lock()
 	if isDown && waylandKeyCanRepeat(vk) {

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -29,6 +29,15 @@ func TestWaylandHost_KeyRepeatLogic(t *testing.T) {
 	// which is deeply integrated with the Wayland protocol implementation.
 }
 
+func TestWaylandEnhancedKeyMapping(t *testing.T) {
+	if got := enhancedKeyForX11Keysym(0xffff); got != vtinput.EnhancedKey {
+		t.Fatalf("XK_Delete flag = %v, want EnhancedKey", got)
+	}
+	if got := enhancedKeyForX11Keysym(0xff9f); got != 0 {
+		t.Fatalf("XK_KP_Delete flag = %v, want no EnhancedKey", got)
+	}
+}
+
 func TestWaylandFocusLossClearsKeyboardState(t *testing.T) {
 	host := &WaylandHost{
 		isRepeating: true,

--- a/win32_gui_common.go
+++ b/win32_gui_common.go
@@ -77,13 +77,6 @@ const (
 
 const (
 	swpNoMove     = 0x0002
-	swpNoZOrder   = 0x0004
-	swpNoActivate = 0x0010
-)
-
-// SetWindowPos flags used when moving the GUI window without changing its
-// size, z-order, or activation state.
-const (
 	swpNoSize     = 0x0001
 	swpNoZOrder   = 0x0004
 	swpNoActivate = 0x0010

--- a/win32_gui_common.go
+++ b/win32_gui_common.go
@@ -81,6 +81,14 @@ const (
 	swpNoActivate = 0x0010
 )
 
+// SetWindowPos flags used when moving the GUI window without changing its
+// size, z-order, or activation state.
+const (
+	swpNoSize     = 0x0001
+	swpNoZOrder   = 0x0004
+	swpNoActivate = 0x0010
+)
+
 // Win32 DIB and GDI Constants
 const (
 	biRGB        = 0

--- a/win32_gui_windows.go
+++ b/win32_gui_windows.go
@@ -36,7 +36,6 @@ var (
 	procGetWindowRect      = user32.NewProc("GetWindowRect")
 	procSetWindowPos       = user32.NewProc("SetWindowPos")
 	procAdjustWindowRectEx = user32.NewProc("AdjustWindowRectEx")
-	procSetWindowPos       = user32.NewProc("SetWindowPos")
 	procLoadCursorW        = user32.NewProc("LoadCursorW")
 	procSetCursor          = user32.NewProc("SetCursor")
 	procSetCapture         = user32.NewProc("SetCapture")

--- a/win32_gui_windows.go
+++ b/win32_gui_windows.go
@@ -33,6 +33,8 @@ var (
 	procEndPaint           = user32.NewProc("EndPaint")
 	procInvalidateRect     = user32.NewProc("InvalidateRect")
 	procGetClientRect      = user32.NewProc("GetClientRect")
+	procGetWindowRect      = user32.NewProc("GetWindowRect")
+	procSetWindowPos       = user32.NewProc("SetWindowPos")
 	procAdjustWindowRectEx = user32.NewProc("AdjustWindowRectEx")
 	procSetWindowPos       = user32.NewProc("SetWindowPos")
 	procLoadCursorW        = user32.NewProc("LoadCursorW")
@@ -240,6 +242,56 @@ func (h *Win32GuiHost) ResizeGrid(cols, rows int) {
 	// resize just like DoDragDrop is posted, so SetWindowPos and the resulting
 	// WM_SIZE are handled by the window's owning thread.
 	procPostMessageW.Call(uintptr(hwnd), wmPerformResize, 0, 0)
+}
+
+// WindowPosition returns the top-left screen position of the native window.
+// The bool is false while the host has not created a window or when Windows
+// cannot provide its rectangle.
+func (h *Win32GuiHost) WindowPosition() (x, y int, ok bool) {
+	h.mu.Lock()
+	hwnd := h.hwnd
+	h.mu.Unlock()
+	if hwnd == 0 {
+		return 0, 0, false
+	}
+
+	var rect win32Rect
+	ret, _, _ := procGetWindowRect.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&rect)))
+	if ret == 0 {
+		return 0, 0, false
+	}
+	return int(rect.left), int(rect.top), true
+}
+
+// SetWindowPosition moves the native window without resizing or activating
+// it. The call is also safe before the window is shown, which lets callers
+// restore a saved position during GUI startup.
+func (h *Win32GuiHost) SetWindowPosition(x, y int) {
+	h.mu.Lock()
+	hwnd := h.hwnd
+	h.mu.Unlock()
+	if hwnd == 0 {
+		return
+	}
+	procSetWindowPos.Call(
+		uintptr(hwnd), 0,
+		uintptr(uint32(int32(x))), uintptr(uint32(int32(y))),
+		0, 0,
+		uintptr(swpNoSize|swpNoZOrder|swpNoActivate),
+	)
+}
+
+func (r *Win32GuiRenderer) WindowPosition() (x, y int, ok bool) {
+	if r == nil || r.host == nil {
+		return 0, 0, false
+	}
+	return r.host.WindowPosition()
+}
+
+func (r *Win32GuiRenderer) SetWindowPosition(x, y int) {
+	if r != nil && r.host != nil {
+		r.host.SetWindowPosition(x, y)
+	}
 }
 
 func (h *Win32GuiHost) Invalidate() {

--- a/x11_keys_shared.go
+++ b/x11_keys_shared.go
@@ -23,6 +23,28 @@ func keysymToVK(keysym uint32) uint16 {
 	return 0
 }
 
+// enhancedKeyForX11Keysym preserves the physical navigation-cluster bit that
+// XKB exposes separately from keypad keysyms. Wayland delivers the keysym
+// directly to its host, while the X11 host receives the same bit from
+// github.com/unxed/keytrans.
+func enhancedKeyForX11Keysym(keysym uint32) vtinput.ControlKeyState {
+	switch keysym {
+	case 0xff50, // XK_Home
+		0xff51, // XK_Left
+		0xff52, // XK_Up
+		0xff53, // XK_Right
+		0xff54, // XK_Down
+		0xff55, // XK_Prior
+		0xff56, // XK_Next
+		0xff57, // XK_End
+		0xff63, // XK_Insert
+		0xffff: // XK_Delete
+		return vtinput.EnhancedKey
+	default:
+		return 0
+	}
+}
+
 var x11KeysymToVK = map[uint32]uint16{
 	0xff08: vtinput.VK_BACK,
 	0xff09: vtinput.VK_TAB,

--- a/x11_keys_test.go
+++ b/x11_keys_test.go
@@ -25,3 +25,25 @@ func TestX11_KeysymMapping(t *testing.T) {
 		}
 	}
 }
+
+func TestX11_EnhancedKeyMapping(t *testing.T) {
+	tests := []struct {
+		name   string
+		keysym uint32
+		want   vtinput.ControlKeyState
+	}{
+		{"navigation delete", 0xffff, vtinput.EnhancedKey},
+		{"navigation insert", 0xff63, vtinput.EnhancedKey},
+		{"navigation home", 0xff50, vtinput.EnhancedKey},
+		{"keypad delete", 0xff9f, 0},
+		{"keypad insert", 0xff9e, 0},
+		{"keypad home", 0xff95, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := enhancedKeyForX11Keysym(tt.keysym); got != tt.want {
+				t.Errorf("enhancedKeyForX11Keysym(0x%x) = %v, want %v", tt.keysym, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- preserve `EnhancedKey` for physical navigation-cluster keysyms in the Wayland host;
- keep keypad navigation keysyms unflagged;
- add regression coverage for both standard and keypad Insert/Delete/Home mappings;
- consume the shared `keytrans` fix from [unxed/keytrans#4](https://github.com/unxed/keytrans/pull/4) until it is merged and released.

This completes the GUI-side part of unxed/f4#464: Ebiten and Gogpu already distinguish their physical navigation keys, while X11 receives the corresponding flag from keytrans and Wayland now derives it from the delivered XKB keysym.

## Validation

- `go test . -run 'TestX11_EnhancedKeyMapping|TestWaylandEnhancedKeyMapping|TestWaylandHost_KeyRepeatLogic' -count=1`
- `go test . -run '^$'`
- Linux amd64 test binary cross-compilation

The local full suite still has the existing unrelated Python-bindings and Win32 drop-effect failures on this Windows runner.
