### PR TITLE
fix: remove duplicate window position declarations

### DIFF
--- a/win32_gui_common.go
+++ b/win32_gui_common.go
@@ -82,14 +82,6 @@ const (
 	swpNoActivate = 0x0010
 )
 
-// SetWindowPos flags used when moving the GUI window without changing its
-// size, z-order, or activation state.
-const (
-	swpNoSize     = 0x0001
-	swpNoZOrder   = 0x0004
-	swpNoActivate = 0x0010
-)
-
 // Win32 DIB and GDI Constants
 const (
 	biRGB        = 0

--- a/win32_gui_windows.go
+++ b/win32_gui_windows.go
@@ -293,56 +293,6 @@ func (r *Win32GuiRenderer) SetWindowPosition(x, y int) {
 	}
 }
 
-// WindowPosition returns the top-left screen position of the native window.
-// The bool is false while the host has not created a window or when Windows
-// cannot provide its rectangle.
-func (h *Win32GuiHost) WindowPosition() (x, y int, ok bool) {
-	h.mu.Lock()
-	hwnd := h.hwnd
-	h.mu.Unlock()
-	if hwnd == 0 {
-		return 0, 0, false
-	}
-
-	var rect win32Rect
-	ret, _, _ := procGetWindowRect.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&rect)))
-	if ret == 0 {
-		return 0, 0, false
-	}
-	return int(rect.left), int(rect.top), true
-}
-
-// SetWindowPosition moves the native window without resizing or activating
-// it. The call is also safe before the window is shown, which lets callers
-// restore a saved position during GUI startup.
-func (h *Win32GuiHost) SetWindowPosition(x, y int) {
-	h.mu.Lock()
-	hwnd := h.hwnd
-	h.mu.Unlock()
-	if hwnd == 0 {
-		return
-	}
-	procSetWindowPos.Call(
-		uintptr(hwnd), 0,
-		uintptr(uint32(int32(x))), uintptr(uint32(int32(y))),
-		0, 0,
-		uintptr(swpNoSize|swpNoZOrder|swpNoActivate),
-	)
-}
-
-func (r *Win32GuiRenderer) WindowPosition() (x, y int, ok bool) {
-	if r == nil || r.host == nil {
-		return 0, 0, false
-	}
-	return r.host.WindowPosition()
-}
-
-func (r *Win32GuiRenderer) SetWindowPosition(x, y int) {
-	if r != nil && r.host != nil {
-		r.host.SetWindowPosition(x, y)
-	}
-}
-
 func (h *Win32GuiHost) Invalidate() {
 	h.mu.Lock()
 	hwnd := h.hwnd


### PR DESCRIPTION
## Summary

- remove the duplicate Win32 `WindowPosition` methods introduced when the window-position and enhanced-navigation changes were merged together
- consolidate the duplicated `SetWindowPos` flag constants

The current `main` branch does not compile on Windows because these declarations are present twice. This cleanup is required for f4 #464 integration and also fixes the regression in the already merged window-position work.

## Validation

- `go test . -run 'TestX11_EnhancedKeyMapping|TestWaylandEnhancedKeyMapping|TestWaylandHost_KeyRepeatLogic' -count=1`
- `go test . -run '^$'`
- Linux/amd64 cross-compile: `go test -c -o C:/Temp/vtui-464-upstream-fix-linux.test .`
