### PR TITLE
fix(help): correct HelpView layout and escape handling

### DIFF
--- a/help_view.go
+++ b/help_view.go
@@ -27,6 +27,15 @@ type helpHistoryEntry struct {
 
 const helpBackButton = "[←]"
 
+type helpViewLayout struct {
+	contentX1, contentY1 int
+	contentX2, contentY2 int
+	contentWidth         int
+	contentHeight        int
+	scrollBarX           int
+	showScrollBar        bool
+}
+
 func NewHelpView(engine *HelpEngine, startTopic string) *HelpView {
 	hv := &HelpView{
 		BaseWindow:  *NewBaseWindow(0, 0, 76, 20, " Help "),
@@ -118,16 +127,16 @@ func (hv *HelpView) Show(scr *ScreenBuf) {
 		return
 	}
 
-	x1, y1, x2, y2 := hv.X1+1, hv.Y1+1, hv.X2-1, hv.Y2-1
-	width := x2 - x1 + 1
-	height := y2 - y1 + 1
-
-	if hv.scrollBar != nil {
-		width--
+	layout := hv.layout()
+	if layout.contentWidth <= 0 || layout.contentHeight <= 0 {
+		return
 	}
+	x1, y1 := layout.contentX1, layout.contentY1
+	width, height := layout.contentWidth, layout.contentHeight+hv.current.StickyRows
 
 	// Fill background
-	scr.FillRect(x1, y1, x2, y2, ' ', Palette[ColHelpText])
+	scr.PushClipRect(layout.contentX1, layout.contentY1, layout.contentX2, layout.contentY2)
+	scr.FillRect(layout.contentX1, layout.contentY1, layout.contentX2, layout.contentY2, ' ', Palette[ColHelpText])
 
 	// 1. Draw Sticky Headers
 	for i := 0; i < hv.current.StickyRows; i++ {
@@ -144,16 +153,41 @@ func (hv *HelpView) Show(scr *ScreenBuf) {
 		}
 		hv.renderLine(scr, x1, contentY+i, hv.current.Lines[lineIdx], width, lineIdx)
 	}
+	scr.PopClipRect()
 
-	if hv.scrollBar != nil {
-		totalScrollable := len(hv.current.Lines) - hv.current.StickyRows
-		if totalScrollable > contentH {
-			hv.scrollBar.SetParams(hv.scrollTop, 0, totalScrollable-contentH)
-			hv.scrollBar.SetPosition(hv.X2-1, hv.Y1+1+hv.current.StickyRows, hv.X2-1, hv.Y2-1)
-			hv.scrollBar.PgStep = contentH
-			hv.scrollBar.Show(scr)
-		}
+	if layout.showScrollBar {
+		hv.scrollBar.SetParams(hv.scrollTop, 0, len(hv.current.Lines)-hv.current.StickyRows-layout.contentHeight)
+		hv.scrollBar.SetPosition(layout.scrollBarX, hv.Y1+1+hv.current.StickyRows, layout.scrollBarX, hv.Y2-1)
+		hv.scrollBar.PgStep = layout.contentHeight
+		hv.scrollBar.Show(scr)
 	}
+}
+
+func (hv *HelpView) layout() helpViewLayout {
+	l := helpViewLayout{
+		contentX1:  hv.X1 + 2,
+		contentY1:  hv.Y1 + 1,
+		contentX2:  hv.X2 - 2,
+		contentY2:  hv.Y2 - 1,
+		scrollBarX: hv.X2 - 2,
+	}
+	stickyRows := 0
+	if hv.current != nil {
+		stickyRows = hv.current.StickyRows
+	}
+	l.contentHeight = l.contentY2 - l.contentY1 + 1 - stickyRows
+	if l.contentHeight <= 0 {
+		return l
+	}
+	if hv.current != nil {
+		totalScrollable := len(hv.current.Lines) - stickyRows
+		l.showScrollBar = hv.scrollBar != nil && totalScrollable > l.contentHeight
+	}
+	if l.showScrollBar {
+		l.contentX2--
+	}
+	l.contentWidth = l.contentX2 - l.contentX1 + 1
+	return l
 }
 func (hv *HelpView) renderLine(scr *ScreenBuf, x, y int, line string, width int, lineIdx int) {
 	isCentered := strings.HasPrefix(line, "^")
@@ -226,14 +260,34 @@ func (hv *HelpView) renderLine(scr *ScreenBuf, x, y int, line string, width int,
 	offX := 0
 	if isCentered {
 		vLen := 0
-		for _, c := range cells {
-			if c.Char != WideCharFiller {
-				vLen++
-			}
+		vLen = len(cells)
+		if vLen > width {
+			cells = fitHelpCells(cells, width)
+			vLen = len(cells)
 		}
 		offX = (width - vLen) / 2
+	} else {
+		cells = fitHelpCells(cells, width)
 	}
 	scr.Write(x+offX, y, cells)
+}
+
+func fitHelpCells(cells []CharInfo, width int) []CharInfo {
+	if width <= 0 {
+		return nil
+	}
+	if len(cells) <= width {
+		return cells
+	}
+	cells = cells[:width]
+	// Do not leave the base cell of a wide rune without its filler cell at
+	// the edge of the viewport. It would otherwise be rendered as a clipped
+	// half-glyph by some terminal backends.
+	if len(cells) > 0 && cells[len(cells)-1].Char != WideCharFiller &&
+		runewidth.RuneWidth(rune(cells[len(cells)-1].Char)) > 1 {
+		cells = cells[:len(cells)-1]
+	}
+	return cells
 }
 
 func (hv *HelpView) ProcessKey(e *vtinput.InputEvent) bool {
@@ -273,6 +327,12 @@ func (hv *HelpView) ProcessKey(e *vtinput.InputEvent) bool {
 
 	case vtinput.VK_BACK:
 		hv.PopTopic()
+		return true
+
+	case vtinput.VK_ESCAPE:
+		// Escape always closes the help window. Backspace is the explicit
+		// history-navigation key and must remain separate from window closing.
+		hv.Close()
 		return true
 
 	case vtinput.VK_UP:
@@ -457,13 +517,10 @@ func (hv *HelpView) ResizeConsole(w, h int) {
 }
 
 func (hv *HelpView) findLinkAt(mx, my int) int {
-	x1, y1, x2, y2 := hv.X1+1, hv.Y1+1, hv.X2-1, hv.Y2-1
-	width := x2 - x1 + 1
-	if hv.scrollBar != nil {
-		width--
-	}
+	layout := hv.layout()
+	x1, y1, width := layout.contentX1, layout.contentY1, layout.contentWidth
 
-	if my < y1 || my > y2 || mx < x1 || mx > x1+width-1 {
+	if width <= 0 || my < y1 || my > layout.contentY2 || mx < x1 || mx > x1+width-1 {
 		return -1
 	}
 
@@ -541,6 +598,9 @@ func (hv *HelpView) findLinkAt(mx, my int) int {
 
 	offX := 0
 	if isCentered {
+		if visualX > width {
+			visualX = width
+		}
 		offX = (width - visualX) / 2
 	}
 

--- a/help_view_test.go
+++ b/help_view_test.go
@@ -197,19 +197,19 @@ func TestHelpView_VisualRendering(t *testing.T) {
 	scr.AllocBuf(32, 7)
 	hv.Show(scr)
 
-	// Check "Normal" (X=1..6 in local, X=1..6 in global because hv is at 0)
-	checkCell(t, scr, 1, 1, 'N', Palette[ColHelpText])
+	// Help text has one blank cell between it and each vertical frame border.
+	checkCell(t, scr, 2, 1, 'N', Palette[ColHelpText])
 
-	// Check "Bold" (starts at X=8)
-	checkCell(t, scr, 8, 1, 'B', Palette[ColHelpBold])
+	// Check "Bold" (starts at X=9)
+	checkCell(t, scr, 9, 1, 'B', Palette[ColHelpBold])
 
-	// Check "Link" (starts at X=13)
-	checkCell(t, scr, 13, 1, 'L', Palette[ColHelpLink])
+	// Check "Link" (starts at X=14)
+	checkCell(t, scr, 14, 1, 'L', Palette[ColHelpLink])
 
 	// 2. Select link and check highlight
 	hv.selectedIdx = 0
 	hv.Show(scr)
-	checkCell(t, scr, 13, 1, 'L', Palette[ColHelpSelectedLink])
+	checkCell(t, scr, 14, 1, 'L', Palette[ColHelpSelectedLink])
 }
 
 func TestHelpView_History_Empty(t *testing.T) {
@@ -326,16 +326,66 @@ func TestHelpView_MultiLinkLineRendering(t *testing.T) {
 	// 1. Выбрана первая ссылка (L1)
 	hv.selectedIdx = 0
 	hv.Show(scr)
-	// Текст: "L1 and L2". Отступ окна 1.
-	// L1: X=1. " and ": 5 символов. L2: X=1+2+5 = 8.
-	checkCell(t, scr, 1, 1, 'L', Palette[ColHelpSelectedLink])
-	checkCell(t, scr, 8, 1, 'L', Palette[ColHelpLink])
+	// Текст: "L1 and L2". Отступ от рамки — один столбец.
+	// L1: X=2. " and ": 5 символов. L2: X=2+2+5 = 9.
+	checkCell(t, scr, 2, 1, 'L', Palette[ColHelpSelectedLink])
+	checkCell(t, scr, 9, 1, 'L', Palette[ColHelpLink])
 
 	// 2. Выбираем вторую ссылку (L2)
 	hv.selectedIdx = 1
 	hv.Show(scr)
-	checkCell(t, scr, 1, 1, 'L', Palette[ColHelpLink])
-	checkCell(t, scr, 8, 1, 'L', Palette[ColHelpSelectedLink])
+	checkCell(t, scr, 2, 1, 'L', Palette[ColHelpLink])
+	checkCell(t, scr, 9, 1, 'L', Palette[ColHelpSelectedLink])
+}
+
+func TestHelpView_LayoutClipsLongLinesAndPositionsScrollBar(t *testing.T) {
+	SetDefaultPalette()
+	engine := NewHelpEngine(&mockHelpVFS{})
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = "This line is deliberately much longer than the help window viewport"
+	}
+	engine.AddTopic(&HelpTopic{Name: "Long", Lines: lines})
+	hv := NewHelpView(engine, "Long")
+	hv.SetPosition(2, 1, 30, 8)
+
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(40, 12)
+	hv.Show(scr)
+	layout := hv.layout()
+	if !layout.showScrollBar {
+		t.Fatal("long topic did not request a scrollbar")
+	}
+	if got, want := hv.scrollBar.X1, hv.X2-2; got != want {
+		t.Fatalf("scrollbar x = %d, want right padding column %d", got, want)
+	}
+	if got := rune(scr.GetCell(hv.X2-1, hv.Y1+1).Char); got != ' ' {
+		t.Fatalf("cell next to right border = %q, want padding", got)
+	}
+	if got := rune(scr.GetCell(hv.X2, hv.Y1+1).Char); got != '║' {
+		t.Fatalf("right border was overwritten by help text: got %q", got)
+	}
+	if got := rune(scr.GetCell(hv.X1+1, hv.Y1+1).Char); got != ' ' {
+		t.Fatalf("cell next to left border = %q, want padding", got)
+	}
+	if got := rune(scr.GetCell(hv.X1+2, hv.Y1+1).Char); got != 'T' {
+		t.Fatalf("text did not start after left padding: got %q", got)
+	}
+}
+
+func TestHelpView_EscapeClosesWithoutGoingBack(t *testing.T) {
+	engine := NewHelpEngine(&mockHelpVFS{})
+	engine.AddTopic(&HelpTopic{Name: "Root", Lines: []string{"root"}})
+	engine.AddTopic(&HelpTopic{Name: "Nested", Lines: []string{"nested"}})
+	hv := NewHelpView(engine, "Root")
+	hv.SwitchTopic("Nested")
+
+	if !hv.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_ESCAPE}) {
+		t.Fatal("Escape was not handled")
+	}
+	if !hv.IsDone() {
+		t.Fatal("Escape did not close HelpView")
+	}
 }
 func TestHelpView_BorderColors(t *testing.T) {
 	SetDefaultPalette()


### PR DESCRIPTION
## Summary
- clip HelpView content so long and wide-character lines cannot overwrite the frame
- add horizontal padding and place the scrollbar in the right padding column only when needed
- make Escape close HelpView while keeping Backspace for topic history
- add regression tests for layout, scrollbar geometry, and navigation

## Validation
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go test ./...`
- `git diff --check`

— zoin-bot