### PR TITLE
fix: resize demo separators with the window

### DIFF
--- a/cmd/test-app/main.go
+++ b/cmd/test-app/main.go
@@ -516,7 +516,9 @@ func main() {
 		opMenu.AddItem(vtui.MenuItem{Text: "&Attributes"})
 		dlg.AddItem(opMenu)
 
-		dlg.AddItem(vtui.NewSeparator(x1, y1+13, 76, true, true))
+		separator := vtui.NewSeparator(x1, y1+13, 76, true, true)
+		separator.SetGrowMode(vtui.GrowHiX)
+		dlg.AddItem(separator)
 
 		table := vtui.NewTable(x1+2, y1+14, 72, 5, []vtui.TableColumn{{Title: "Filename", Width: 48}, {Title: "Size", Width: 12, Alignment: vtui.AlignRight}})
 		table.SetRows([]vtui.TableRow{

--- a/cmd/test-app/main_test.go
+++ b/cmd/test-app/main_test.go
@@ -39,6 +39,18 @@ func TestReactiveDemoDialog_Layout(t *testing.T) {
 	vtui.AssertLayout(t, dlg)
 }
 
+func TestDemoSeparatorGrowsWithWindow(t *testing.T) {
+	dlg := vtui.NewWindow(0, 0, 79, 21, "demo")
+	separator := vtui.NewSeparator(2, 13, 76, true, true)
+	separator.SetGrowMode(vtui.GrowHiX)
+	dlg.AddItem(separator)
+
+	dlg.ChangeSize(100, 22)
+	if x1, _, x2, _ := separator.GetPosition(); x1 != 2 || x2 != 97 {
+		t.Fatalf("separator position after resize = (%d, %d), want (2, 97)", x1, x2)
+	}
+}
+
 func TestWorkspaceTabControlDemo(t *testing.T) {
 	vtui.SetDefaultPalette()
 


### PR DESCRIPTION
## Summary

- make the comprehensive `cmd/test-app` separator grow horizontally with its resizable demo window
- add a regression test that verifies the separator endpoint after `Window.ChangeSize`

This addresses unxed/f4#372, where resizing the vtui demo left the divider at its original width.

## Validation

- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go test ./... -count=1`
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go vet ./...`
- native ARM64 build of `cmd/test-app`
- Windows amd64 CGO=0 build of `cmd/test-app`
- real ANSI PTY demo run: drag-resize changed the separator from columns 22..97 to 22..110, then Ctrl+Q exited with code 0

— zoin-bot