### PR TITLE
fix: wake Wayland loop for deferred redraws

### DIFF
--- a/wayland_host.go
+++ b/wayland_host.go
@@ -14,6 +14,57 @@ import (
 	"github.com/unxed/vtinput"
 )
 
+// waylandPresentWake coalesces redraw requests until the Wayland event loop
+// has processed a sync callback. Flush can be called by FrameManager's
+// goroutine, while ScheduleRedraw must run on the DisplayRun goroutine.
+type waylandPresentWake struct {
+	mu          sync.Mutex
+	pending     bool
+	wakePending bool
+	closed      bool
+}
+
+func (w *waylandPresentWake) request(send func() error) {
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+	w.pending = true
+	if w.wakePending {
+		w.mu.Unlock()
+		return
+	}
+	w.wakePending = true
+	w.mu.Unlock()
+
+	if err := send(); err != nil {
+		w.mu.Lock()
+		w.wakePending = false
+		w.mu.Unlock()
+	}
+}
+
+func (w *waylandPresentWake) done() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return false
+	}
+	w.wakePending = false
+	pending := w.pending
+	w.pending = false
+	return pending
+}
+
+func (w *waylandPresentWake) close() {
+	w.mu.Lock()
+	w.closed = true
+	w.pending = false
+	w.wakePending = false
+	w.mu.Unlock()
+}
+
 // WaylandHost encapsulates the connection to the Wayland compositor.
 type WaylandHost struct {
 	mu      sync.Mutex
@@ -21,6 +72,7 @@ type WaylandHost struct {
 	win     *window.Window
 	widget  *window.Widget
 	reader  *vtinput.Reader
+	present waylandPresentWake
 
 	imgBuf     *image.RGBA
 	cols, rows int
@@ -290,6 +342,56 @@ func (h *WaylandHost) Close() {
 	h.mu.Lock()
 	h.reader = nil
 	h.mu.Unlock()
+	h.present.close()
+}
+
+// requestPresent asks the compositor to send a callback. The callback wakes
+// DisplayRun from its blocking socket read and schedules the deferred redraw
+// on the display goroutine, avoiding a cross-goroutine toolkit call.
+func (h *WaylandHost) requestPresent() {
+	h.mu.Lock()
+	var display *wl.Display
+	if h.display != nil {
+		display = h.display.Display
+	}
+	h.mu.Unlock()
+	if display == nil {
+		return
+	}
+
+	h.present.request(func() error {
+		ctx := display.Context()
+		if ctx == nil {
+			return wl.ErrContextNil
+		}
+		callback := wl.NewCallback(ctx)
+		// Register before sending the request: DisplayRun may receive the
+		// callback as soon as the compositor processes the sync request.
+		callback.AddDoneHandler(h)
+		if err := ctx.SendRequest(display, 0, callback); err != nil {
+			callback.RemoveDoneHandler(h)
+			callback.Unregister()
+			return err
+		}
+		return nil
+	})
+}
+
+// HandleCallbackDone implements wl.CallbackDoneHandler.
+func (h *WaylandHost) HandleCallbackDone(event wl.CallbackDoneEvent) {
+	if event.C != nil {
+		event.C.Unregister()
+	}
+	if !h.present.done() {
+		return
+	}
+
+	h.mu.Lock()
+	widget := h.widget
+	h.mu.Unlock()
+	if widget != nil {
+		widget.ScheduleRedraw()
+	}
 }
 
 // -- Pointer & Keyboard Handlers --

--- a/wayland_present_test.go
+++ b/wayland_present_test.go
@@ -1,0 +1,69 @@
+//go:build linux && !arm
+
+package vtui
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+)
+
+func TestWaylandPresentWakeCoalescesAndRearms(t *testing.T) {
+	var sends atomic.Int32
+	wake := waylandPresentWake{}
+	send := func() error {
+		sends.Add(1)
+		return nil
+	}
+
+	wake.request(send)
+	wake.request(send)
+	if got := sends.Load(); got != 1 {
+		t.Fatalf("coalesced sync requests = %d, want 1", got)
+	}
+	if !wake.done() {
+		t.Fatal("completed sync did not report a pending redraw")
+	}
+	if wake.done() {
+		t.Fatal("completed sync reported a second redraw")
+	}
+
+	wake.request(send)
+	if got := sends.Load(); got != 2 {
+		t.Fatalf("rearmed sync requests = %d, want 2", got)
+	}
+}
+
+func TestWaylandPresentWakeRetriesAfterSendFailure(t *testing.T) {
+	wake := waylandPresentWake{}
+	fail := true
+	send := func() error {
+		if fail {
+			fail = false
+			return errors.New("test send failure")
+		}
+		return nil
+	}
+
+	wake.request(send)
+	wake.request(send)
+	if !wake.done() {
+		t.Fatal("retry request did not leave a pending redraw")
+	}
+}
+
+func TestWaylandPresentWakeIgnoresRequestsAfterClose(t *testing.T) {
+	wake := waylandPresentWake{}
+	wake.close()
+	sent := false
+	wake.request(func() error {
+		sent = true
+		return nil
+	})
+	if sent {
+		t.Fatal("closed wake sent a sync request")
+	}
+	if wake.done() {
+		t.Fatal("closed wake reported a redraw")
+	}
+}

--- a/wayland_renderer.go
+++ b/wayland_renderer.go
@@ -332,8 +332,10 @@ func (r *WaylandRenderer) drawCustomChar(img *image.RGBA, char rune, px, py, cw,
 
 func (r *WaylandRenderer) Flush() {
 	start := time.Now()
-	// Trigger the Wayland host to push the buffer to the compositor
-	r.host.widget.ScheduleRedraw()
+	// Wake DisplayRun and let its callback schedule the deferred redraw on
+	// the Wayland goroutine. Direct ScheduleRedraw from FrameManager's
+	// goroutine can leave the queued redraw invisible until another event.
+	r.host.requestPresent()
 	r.stats.totalFlush += time.Since(start)
 	r.stats.frameCount++
 }


### PR DESCRIPTION
## Summary
- wake the Wayland event loop after `Flush()` schedules a deferred redraw
- coalesce concurrent redraw requests through a `wl_display.sync` callback
- register the callback handler before sending the request and schedule the redraw on the `DisplayRun` goroutine
- cover coalescing, retry, and shutdown behavior with tests

Fixes unxed/f4#346.

## Validation
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go test ./... -count=1`
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go vet ./...`
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go test -race . -run 'TestWaylandPresentWake' -count=1`
- native ARM64 demo build
- Windows amd64 demo build with `CGO_ENABLED=0`
- `git diff --check`

On the current KDE Wayland ARM64 device, launching the demo with the standard `github.com/neurlang/wayland` dependency still hits an unrelated pre-existing ARM64 BGRA swizzle panic while loading cursors. For an actual backend smoke test, I used the existing local `unxed/wayland` `fix/arm64-bgra-swizzle` workaround only in a temporary verification worktree; the demo then stayed alive for the full 5-second timeout without that crash. The workaround is not part of this PR.

A full ARM64 `go build ./...` remains blocked by the existing `bindings/c/cabi` goffi `R_CALLARM64` relocation errors.

— zoin-bot
