### PR TITLE
fix: open combo boxes from any click

### DIFF
--- a/combobox.go
+++ b/combobox.go
@@ -12,6 +12,7 @@ type ComboBox struct {
 	Menu              *VMenu
 	DropdownOnly      bool // If true, manual text entry is not allowed
 	editMouseCaptured bool
+	editMouseMoved    bool
 }
 
 func NewComboBox(x, y, width int, items []string) *ComboBox {
@@ -162,21 +163,33 @@ func (cb *ComboBox) ProcessMouse(e *vtinput.InputEvent) bool {
 	}
 	if cb.editMouseCaptured {
 		cb.Edit.ProcessMouse(e)
+		if e.MouseEventFlags&vtinput.MouseMoved != 0 && e.ButtonState != 0 {
+			cb.editMouseMoved = true
+		}
 		if e.ButtonState == 0 {
+			openMenu := !cb.editMouseMoved
 			cb.editMouseCaptured = false
+			cb.editMouseMoved = false
+			if openMenu {
+				cb.Open()
+			}
 			return true
 		}
 		return true
 	}
 	if e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown && e.MouseEventFlags&vtinput.MouseMoved == 0 {
 		mx := int(e.MouseX)
-		// If arrow clicked or DropdownOnly is true and clicked anywhere within the bounds
+		// The arrow and DropdownOnly controls open on press. For an editable
+		// control, defer opening until release so a drag can still select text.
 		if mx == cb.X2 || cb.DropdownOnly {
 			cb.Open()
 			return true
 		}
 		if cb.Edit.HitTest(mx, int(e.MouseY)) {
+			cb.Edit.ProcessMouse(e)
 			cb.editMouseCaptured = true
+			cb.editMouseMoved = false
+			return true
 		}
 	}
 	return cb.Edit.ProcessMouse(e)
@@ -228,6 +241,7 @@ func (cb *ComboBox) SetFocus(f bool) {
 	cb.Edit.SetFocus(f)
 	if !f {
 		cb.editMouseCaptured = false
+		cb.editMouseMoved = false
 	}
 }
 
@@ -236,6 +250,7 @@ func (cb *ComboBox) SetDisabled(d bool) {
 	cb.Edit.SetDisabled(d)
 	if d {
 		cb.editMouseCaptured = false
+		cb.editMouseMoved = false
 	}
 }
 func (cb *ComboBox) WantsChars() bool {

--- a/combobox_test.go
+++ b/combobox_test.go
@@ -59,6 +59,39 @@ func TestComboBox_DropdownOnly_Enter(t *testing.T) {
 		t.Error("Enter should open dropdown menu when DropdownOnly is true")
 	}
 }
+
+func TestComboBox_MouseClickAnywhereOpens(t *testing.T) {
+	for _, dropdownOnly := range []bool{false, true} {
+		SetDefaultPalette()
+		FrameManager.Init(NewSilentScreenBuf())
+
+		cb := NewComboBox(10, 3, 20, []string{"A", "B"})
+		cb.DropdownOnly = dropdownOnly
+
+		// The click is in the edit portion, not on the one-cell arrow.
+		handled := cb.ProcessMouse(&vtinput.InputEvent{
+			Type:        vtinput.MouseEventType,
+			KeyDown:     true,
+			ButtonState: vtinput.FromLeft1stButtonPressed,
+			MouseX:      12,
+			MouseY:      3,
+		})
+		if !handled {
+			t.Fatalf("clicking the ComboBox edit portion should be handled (DropdownOnly=%v)", dropdownOnly)
+		}
+		cb.ProcessMouse(&vtinput.InputEvent{
+			Type:        vtinput.MouseEventType,
+			MouseX:      12,
+			MouseY:      3,
+			KeyDown:     false,
+			ButtonState: 0,
+		})
+		if top := FrameManager.GetTopFrame(); top == nil || top.GetType() != TypeMenu {
+			t.Fatalf("clicking the ComboBox edit portion should open its menu (DropdownOnly=%v)", dropdownOnly)
+		}
+	}
+}
+
 func TestComboBox_OpenFlip(t *testing.T) {
 	SetDefaultPalette()
 	scr := NewSilentScreenBuf()


### PR DESCRIPTION
## Summary
- open a ComboBox when any in-bounds left click lands on the control
- keep the behavior consistent for editable and `DropdownOnly` variants
- add a regression test for clicks in the edit portion, away from the arrow cell

Fixes unxed/f4#623.

## Validation
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go test ./... -count=1`
- native ARM64 `cmd/test-app` build
- Windows amd64 `cmd/test-app` build with `CGO_ENABLED=0`
- `git diff --check`
- actual KDE Wayland ARM64 demo launch stayed alive for 8 seconds in the current session using the existing local `unxed/wayland` ARM64 swizzle workaround in a temporary verification worktree; that workaround is not part of this PR

`go vet ./...` reports the same pre-existing warnings on clean `origin/main` (`test_main_test.go:21` unreachable code and `x11_shm_unix.go:48` unsafe pointer use); the changed files introduce no vet findings.

— zoin-bot
