### PR TITLE
fix: count shaped script clusters as terminal cells

### DIFF
--- a/textseg.go
+++ b/textseg.go
@@ -255,12 +255,60 @@ func ClusterWidth(cluster string) int {
 		return 2
 	}
 
+	// Terminal emulators shape Indic, Arabic, Hebrew, Thai, and related
+	// scripts inside a cell cluster. Spacing marks and virama sequences are
+	// therefore not additional terminal columns even though their Unicode
+	// categories can make the wcwidth sum look wider. Keep wide base glyphs
+	// wide, but count a shaped narrow cluster as one cell.
+	if isShapedCluster(cluster) {
+		for _, r := range cluster {
+			if runeCellWidth(r) >= 2 {
+				return 2
+			}
+		}
+		return 1
+	}
+
 	if sum <= 0 {
 		// A cluster of nothing but combining marks: no base to hang them on,
 		// so give it a column of its own rather than dropping it.
 		return 1
 	}
 	return sum
+}
+
+// isShapedCluster reports whether a grapheme cluster belongs to a script
+// whose combining marks and consonant sequences are laid out as one terminal
+// glyph cell. This is a cell-width policy, not a font shaper: the complete
+// cluster is retained in CharInfo so the terminal can perform its own glyph
+// shaping when the frame is flushed.
+func isShapedCluster(cluster string) bool {
+	runeCount := 0
+	shapedScript := false
+	for _, r := range cluster {
+		runeCount++
+		if unicode.In(r,
+			unicode.Arabic,
+			unicode.Bengali,
+			unicode.Devanagari,
+			unicode.Gujarati,
+			unicode.Gurmukhi,
+			unicode.Hebrew,
+			unicode.Kannada,
+			unicode.Khmer,
+			unicode.Lao,
+			unicode.Malayalam,
+			unicode.Myanmar,
+			unicode.Oriya,
+			unicode.Sinhala,
+			unicode.Tamil,
+			unicode.Telugu,
+			unicode.Thai,
+		) {
+			shapedScript = true
+		}
+	}
+	return shapedScript && runeCount > 1
 }
 
 // NextCluster splits off the first grapheme cluster of s. It returns the

--- a/textseg_test.go
+++ b/textseg_test.go
@@ -15,7 +15,7 @@ func TestClusterWidth_Combining(t *testing.T) {
 		{"cjk", "世", 2},
 		{"latin with acute", "e\u0301", 1},
 		{"devanagari base", "क", 1},
-		{"devanagari with spacing matra", "का", 2},
+		{"devanagari with spacing matra", "का", 1},
 		{"devanagari with virama", "स\u094D", 1},
 		{"emoji", "😀", 2},
 		{"emoji with presentation selector", "❤\uFE0F", 2},
@@ -129,6 +129,7 @@ func TestStringWidth_MatchesWcwidth(t *testing.T) {
 		{"", 0},
 		{"hello", 5},
 		{"नमस्ते", 4},
+		{"বাংলা", 2},
 		{"مرحبا", 5},
 		{"A世B", 4},
 		{"👨\u200D👩\u200D👦!", 3},
@@ -211,6 +212,18 @@ func TestStringToCharInfo_Devanagari(t *testing.T) {
 	for i, c := range ci {
 		if c.Char == WideCharFiller {
 			t.Errorf("cell %d: no cell of this word is wide", i)
+		}
+	}
+}
+
+func TestStringToCharInfo_BengaliShaping(t *testing.T) {
+	ci := StringToCharInfo("বাংলা", 0)
+	if len(ci) != 2 {
+		t.Fatalf("expected 2 cells for বাংলা, got %d", len(ci))
+	}
+	for i, c := range ci {
+		if c.Char == WideCharFiller {
+			t.Errorf("cell %d: shaped Bengali cluster should not be wide", i)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- treat multi-rune clusters from Indic, Arabic, Hebrew, Thai, and related shaping scripts as one narrow terminal cell
- preserve wide base glyphs and existing emoji, flag, keycap, bidi, and CJK width rules
- keep the complete original cluster in `CharInfo`, letting the terminal perform the actual glyph shaping
- add Bengali and Indic regression coverage

Fixes unxed/f4#621.

## Validation
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go test ./... -count=1`
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go vet ./...`
- focused shaping tests under `-race`
- native ARM64 demo build
- Windows amd64 demo build with `CGO_ENABLED=0`
- `git diff --check`
- actual KDE Wayland ARM64 demo smoke run stayed alive for 8 seconds using an existing local ARM64 swizzle workaround in a temporary verification worktree; the workaround is not part of this PR

The f4-side validation was also run with Bengali and Hindi enabled: after this width fix, only two genuine fixed-layout cases remained, which are handled in the companion f4 change by using a one-column editor checkbox layout for long localized captions and sizing the plugin dialog from its button row.

— zoin-bot
