### PR TITLE
fix: keep combo arrow adjacent after resize

### DIFF
--- a/combobox.go
+++ b/combobox.go
@@ -59,13 +59,15 @@ func (cb *ComboBox) MoveRelative(dx, dy int) {
 }
 
 func (cb *ComboBox) applyLayout() {
-	hbox := NewHBoxLayout(cb.X1, cb.Y1, cb.X2-cb.X1+1, 1)
-	hbox.Spacing = 0
-	hbox.Add(cb.Edit, Margins{}, AlignFill)
-	// Add a dummy text element for the arrow to participate in the layout math
-	arrow := NewText(0, 0, "↓", 0)
-	hbox.Add(arrow, Margins{}, AlignTop)
-	hbox.Apply()
+	// The arrow is painted by ComboBox.DisplayObject at X2. Keep the edit
+	// portion adjacent to it whenever the outer control is resized by a
+	// layout. A generic HBox cannot express this one-cell trailing affordance
+	// because its AlignFill mode only stretches the cross-axis.
+	editX2 := cb.X2
+	if cb.X2 > cb.X1 {
+		editX2--
+	}
+	cb.Edit.SetPosition(cb.X1, cb.Y1, editX2, cb.Y1)
 }
 
 func (cb *ComboBox) Show(scr *ScreenBuf) {
@@ -89,13 +91,16 @@ func (cb *ComboBox) DisplayObject(scr *ScreenBuf) {
 			bgIdx = cb.Edit.ColorSelectedIdx
 			fgIdx = ColDialogComboSelectedHighlight
 
+			oldTextIdx := cb.Edit.ColorTextIdx
 			oldStart, oldEnd := cb.Edit.selStart, cb.Edit.selEnd
 
+			cb.Edit.ColorTextIdx = cb.Edit.ColorSelectedIdx
 			cb.Edit.selStart = 0
 			cb.Edit.selEnd = len(cb.Edit.text)
 
 			cb.Edit.Show(scr)
 
+			cb.Edit.ColorTextIdx = oldTextIdx
 			cb.Edit.selStart, cb.Edit.selEnd = oldStart, oldEnd
 		} else {
 			cb.Edit.Show(scr)

--- a/combobox_color_test.go
+++ b/combobox_color_test.go
@@ -86,7 +86,7 @@ func TestVMenu_DefaultsToMenuPalette(t *testing.T) {
 			m.ColorTextIdx, m.ColorBoxIdx, m.ColorTitleIdx)
 	}
 }
-func TestComboBox_DropdownOnlyFocusedColorsOnlyTextPortion(t *testing.T) {
+func TestComboBox_DropdownOnlyFocusedFillsSelectionContinuously(t *testing.T) {
 	SetDefaultPalette()
 	Palette[ColDialogComboText] = SetRGBBoth(0, 0xEEEEEC, 0x37322C)
 	Palette[ColDialogComboSelectedText] = SetRGBBoth(0, 0x1E1A16, 0xE6B450)
@@ -101,20 +101,12 @@ func TestComboBox_DropdownOnlyFocusedColorsOnlyTextPortion(t *testing.T) {
 	cb.SetFocus(true)
 	cb.Show(scr)
 
-	normalBg := GetRGBBack(Palette[ColDialogComboText])
 	selectedBg := GetRGBBack(Palette[ColDialogComboSelectedText])
 
-	for x := cb.X1; x < cb.X1+3; x++ {
+	for x := cb.X1; x < cb.X2; x++ {
 		cellBg := GetRGBBack(scr.GetCell(x, cb.Y1).Attributes)
 		if cellBg != selectedBg {
 			t.Errorf("text cell X=%d background = #%06x, want selected background #%06x", x, cellBg, selectedBg)
-		}
-	}
-
-	for x := cb.X1 + 3; x < cb.X2; x++ {
-		cellBg := GetRGBBack(scr.GetCell(x, cb.Y1).Attributes)
-		if cellBg != normalBg {
-			t.Errorf("trailing cell X=%d background = #%06x, want normal combo background #%06x", x, cellBg, normalBg)
 		}
 	}
 

--- a/combobox_layout_test.go
+++ b/combobox_layout_test.go
@@ -1,0 +1,21 @@
+package vtui
+
+import "testing"
+
+func TestComboBox_ResizeKeepsEditAdjacentToArrow(t *testing.T) {
+	cb := NewComboBox(2, 3, 10, []string{"One", "Two"})
+	cb.SetPosition(4, 5, 39, 5)
+
+	if cb.Edit.X1 != cb.X1 || cb.Edit.Y1 != cb.Y1 {
+		t.Fatalf("edit origin = (%d,%d), want (%d,%d)", cb.Edit.X1, cb.Edit.Y1, cb.X1, cb.Y1)
+	}
+	if cb.Edit.X2 != cb.X2-1 {
+		t.Fatalf("edit right edge = %d, want %d before arrow at %d", cb.Edit.X2, cb.X2-1, cb.X2)
+	}
+
+	cb.MoveRelative(3, 2)
+	if cb.Edit.X1 != cb.X1 || cb.Edit.X2 != cb.X2-1 || cb.Edit.Y1 != cb.Y1 {
+		t.Fatalf("after MoveRelative combo = (%d,%d)-(%d,%d), edit = (%d,%d)-(%d,%d)",
+			cb.X1, cb.Y1, cb.X2, cb.Y2, cb.Edit.X1, cb.Edit.Y1, cb.Edit.X2, cb.Edit.Y2)
+	}
+}


### PR DESCRIPTION
I, zoin-bot, fixed the generic ComboBox rendering issues reported in unxed/f4#648.

Changes:
- Recalculate the embedded Edit bounds on every ComboBox SetPosition/MoveRelative so a stretched control keeps its one-cell arrow adjacent to the edit field.
- Fill the complete focused DropdownOnly field with the selected background, including trailing empty cells, so the arrow and field form one continuous selection.
- Added regression coverage for resize/move geometry and continuous focus colors.

Validation on Linux ARM64:
- `go test ./... -count=1`
- focused ComboBox tests under `go test -race`
- `go vet ./...`
- native `go build .`
- f4 `cmd/f4` tests and native f4 build against this local vtui worktree
- real f4 ARM64 TTY launch with Appearance dialog; arrow was adjacent after layout expansion and F10 exited cleanly

The full vtui race suite still reports unrelated pre-existing FrameManager/background-test races; focused ComboBox race tests pass.

— zoin-bot