### PR TITLE
vtui: support cross-builds on unsupported Linux architectures

### DIFF
--- a/ebiten_dragdrop.go
+++ b/ebiten_dragdrop.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm
+//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/ebiten_host.go
+++ b/ebiten_host.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm
+//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/ebiten_keys.go
+++ b/ebiten_keys.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm
+//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/ebiten_renderer.go
+++ b/ebiten_renderer.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm
+//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/ebiten_renderer_test.go
+++ b/ebiten_renderer_test.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm
+//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/ebiten_stub.go
+++ b/ebiten_stub.go
@@ -1,4 +1,4 @@
-//go:build !(linux || windows || darwin) || arm
+//go:build !(linux || windows || darwin) || arm || mips || mipsle || mips64 || mips64le || riscv64 || loong64 || ppc64 || ppc64le
 
 package vtui
 

--- a/gogpu_customchar_test.go
+++ b/gogpu_customchar_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/gogpu_dnd.go
+++ b/gogpu_dnd.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/gogpu_dnd_test.go
+++ b/gogpu_dnd_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/gogpu_host_test.go
+++ b/gogpu_host_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/gogpu_keys_test.go
+++ b/gogpu_keys_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/gogpu_profile.go
+++ b/gogpu_profile.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/gogpu_renderer.go
+++ b/gogpu_renderer.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/gogpu_renderer_test.go
+++ b/gogpu_renderer_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/gogpu_stub.go
+++ b/gogpu_stub.go
@@ -1,4 +1,4 @@
-//go:build freebsd || dragonfly || openbsd || netbsd || illumos || solaris || arm
+//go:build freebsd || dragonfly || openbsd || netbsd || illumos || solaris || arm || mips || mipsle || mips64 || mips64le || riscv64 || loong64 || ppc64 || ppc64le
 
 package vtui
 
@@ -15,7 +15,7 @@ func (r *GogpuRenderer) SetWindowTitle(title string)                            
 func (r *GogpuRenderer) ResizeWindow(cols, rows int)                                        {}
 func (r *GogpuRenderer) Flush()                                                             {}
 
-// RunGogpuHost — заглушка функции запуска для BSD.
+// RunGogpuHost — заглушка функции запуска для платформ без gogpu backend.
 func RunGogpuHost(cols, rows int, fontName string, fontSize float64, setupApp func()) error {
 	return fmt.Errorf("gogpu backend is not supported on BSDs")
 }

--- a/wayland_host.go
+++ b/wayland_host.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm
+//go:build linux && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm
+//go:build linux && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/wayland_present_test.go
+++ b/wayland_present_test.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm
+//go:build linux && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/wayland_renderer.go
+++ b/wayland_renderer.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm
+//go:build linux && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
 
 package vtui
 

--- a/wayland_stub.go
+++ b/wayland_stub.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || dragonfly || openbsd || netbsd || arm
+//go:build darwin || freebsd || dragonfly || openbsd || netbsd || arm || mips || mipsle || mips64 || mips64le || riscv64 || loong64 || ppc64 || ppc64le
 
 package vtui
 


### PR DESCRIPTION
The Go toolchain supports Linux mips, mipsle, mips64, mips64le, riscv64, loong64, ppc64, and ppc64le, but vtui currently selects gogpu/Wayland/Ebiten and keytrans FFI on those architectures. Their goffi/purego dependencies have no matching syscall implementation, so downstream cross-builds fail before application code is compiled.

Treat these architectures like the existing non-GPU targets: keep the ANSI/TUI core available, select vtui stubs for gogpu, Wayland, and Ebiten, and use the `noffi` build tag for keytrans's X11 FFI backends.

Validation on Windows amd64 with Go 1.26.7:
- `go build ./...`
- `GOOS=linux GOARCH=<each target> go build -tags noffi ./...` for all eight targets

Related: unxed/f4#642