### PR TITLE
zoin-bot: render images through far2l FARTTY

### DIFF
--- a/far2l_extensions.go
+++ b/far2l_extensions.go
@@ -33,7 +33,7 @@ func Far2lInteractTimeout(stk *vtinput.Far2lStack, wait bool, timeout time.Durat
 
 	id, payload := far2lInteractionPayloadLocked(stk)
 	DebugLog("VTUI_FAR2L_INTERACT: Sending ID=%d, payload_len=%d, wait=%v", id, len(payload), wait)
-	os.Stdout.Write(payload)
+	_, _ = os.Stdout.Write(payload)
 
 	if wait && FrameManager != nil {
 		return FrameManager.WaitFar2lResponse(id, timeout)

--- a/far2l_extensions.go
+++ b/far2l_extensions.go
@@ -31,22 +31,41 @@ func Far2lInteractTimeout(stk *vtinput.Far2lStack, wait bool, timeout time.Durat
 	far2lInteractMu.Lock()
 	defer far2lInteractMu.Unlock()
 
-	far2lIDCounter++
-	if far2lIDCounter == 0 {
-		far2lIDCounter = 1
-	}
-	id := far2lIDCounter
-	stk.PushU8(id)
-
-	b64 := base64.StdEncoding.EncodeToString(*stk)
-	DebugLog("VTUI_FAR2L_INTERACT: Sending ID=%d, payload_len=%d, wait=%v", id, len(b64), wait)
-	os.Stdout.WriteString("\x1b_far2l:" + b64 + "\x07")
+	id, payload := far2lInteractionPayloadLocked(stk)
+	DebugLog("VTUI_FAR2L_INTERACT: Sending ID=%d, payload_len=%d, wait=%v", id, len(payload), wait)
+	os.Stdout.Write(payload)
 
 	if wait && FrameManager != nil {
 		return FrameManager.WaitFar2lResponse(id, timeout)
 	}
 	DebugLog("VTUI_FAR2L: Processed without waiting for ID=%d", id)
 	return nil
+}
+
+// far2lInteractionPayload returns a complete APC request and allocates its
+// response ID. Renderers use it to put asynchronous requests into the frame
+// being composed, keeping far2l bytes ordered with the text they accompany.
+// The caller must not wait for the response while composing a frame.
+func far2lInteractionPayload(stk *vtinput.Far2lStack) []byte {
+	far2lInteractMu.Lock()
+	defer far2lInteractMu.Unlock()
+	_, payload := far2lInteractionPayloadLocked(stk)
+	return payload
+}
+
+func far2lInteractionPayloadLocked(stk *vtinput.Far2lStack) (uint8, []byte) {
+	far2lIDCounter++
+	if far2lIDCounter == 0 {
+		far2lIDCounter = 1
+	}
+	id := far2lIDCounter
+	stk.PushU8(id)
+	b64 := base64.StdEncoding.EncodeToString(*stk)
+	payload := make([]byte, 0, len(b64)+10)
+	payload = append(payload, "\x1b_far2l:"...)
+	payload = append(payload, b64...)
+	payload = append(payload, '\x07')
+	return id, payload
 }
 
 // SetFar2lClipboard attempts to set the clipboard using far2l extensions.

--- a/framemanager.go
+++ b/framemanager.go
@@ -2602,6 +2602,12 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 		if ev.Far2lCommand == "ok" {
 			DebugLog("FM_DISPATCH: Far2l extensions successfully negotiated with host. Setting Far2lEnabled = true")
 			Far2lEnabled = true
+			// A screen may have asked for its graphics protocol before the
+			// asynchronous far2l acknowledgement arrived. Switch it now so
+			// image viewers do not retain the initial GraphicsNone/kitty choice.
+			if fm.scr != nil {
+				fm.scr.Graphics().SetProtocol(GraphicsFar2l)
+			}
 			return
 		}
 		if ev.Far2lCommand == "reply" {

--- a/graphics.go
+++ b/graphics.go
@@ -18,6 +18,7 @@ const (
 	GraphicsKitty
 	GraphicsITerm2
 	GraphicsSixel
+	GraphicsFar2l
 	GraphicsNative
 )
 
@@ -29,6 +30,8 @@ func (p GraphicsProtocol) String() string {
 		return "iterm2"
 	case GraphicsSixel:
 		return "sixel"
+	case GraphicsFar2l:
+		return "far2l"
 	case GraphicsNative:
 		return "native"
 	}
@@ -44,6 +47,8 @@ func ParseGraphicsProtocol(s string) (GraphicsProtocol, bool) {
 		return GraphicsITerm2, true
 	case "sixel":
 		return GraphicsSixel, true
+	case "far2l":
+		return GraphicsFar2l, true
 	case "native":
 		return GraphicsNative, true
 	case "none", "off", "no", "0":
@@ -388,7 +393,13 @@ func (g *GraphicsLayer) Protocol() GraphicsProtocol {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if !g.protocolValid {
-		g.protocol = DetectGraphicsProtocol()
+		// far2l explicitly acknowledges the extension negotiation. Prefer its
+		// native image channel over inherited kitty/sixel environment markers.
+		if Far2lEnabled {
+			g.protocol = GraphicsFar2l
+		} else {
+			g.protocol = DetectGraphicsProtocol()
+		}
 		g.protocolValid = true
 	}
 	return g.protocol

--- a/graphics_far2l.go
+++ b/graphics_far2l.go
@@ -92,17 +92,17 @@ func (e *far2lEncoder) set(out *byteBuffer, p *ImagePlacement) {
 	// IMAGE_SET documentation: data, dimensions, area, flags, identity,
 	// subcommand, category.
 	stk.PushBytes(cropped.Pix)
-	stk.PushU32(uint32(cropped.Height))
-	stk.PushU32(uint32(cropped.Width))
-	stk.PushU16(uint16(bottom))
-	stk.PushU16(uint16(right))
-	stk.PushU16(uint16(p.Row))
-	stk.PushU16(uint16(p.Col))
+	stk.PushU32(uint32(cropped.Height)) //nolint:gosec // far2lPlacementValid bounds the dimensions
+	stk.PushU32(uint32(cropped.Width))  //nolint:gosec // far2lPlacementValid bounds the dimensions
+	stk.PushU16(uint16(bottom))         //nolint:gosec // far2lPlacementValid bounds the area
+	stk.PushU16(uint16(right))          //nolint:gosec // far2lPlacementValid bounds the area
+	stk.PushU16(uint16(p.Row))          //nolint:gosec // far2lPlacementValid bounds the area
+	stk.PushU16(uint16(p.Col))          //nolint:gosec // far2lPlacementValid bounds the area
 	stk.PushU64(far2lImageRGBA)
 	stk.PushString(far2lImageIdentity(p.ID))
 	stk.PushU8(far2lImageSet)
 	stk.PushU8(far2lImageCategory)
-	out.Write(far2lInteractionPayload(stk))
+	_, _ = out.Write(far2lInteractionPayload(stk))
 }
 
 func (e *far2lEncoder) delete(out *byteBuffer, id uint32) {
@@ -110,5 +110,5 @@ func (e *far2lEncoder) delete(out *byteBuffer, id uint32) {
 	stk.PushString(far2lImageIdentity(id))
 	stk.PushU8(far2lImageDelete)
 	stk.PushU8(far2lImageCategory)
-	out.Write(far2lInteractionPayload(stk))
+	_, _ = out.Write(far2lInteractionPayload(stk))
 }

--- a/graphics_far2l.go
+++ b/graphics_far2l.go
@@ -1,0 +1,114 @@
+package vtui
+
+import (
+	"strconv"
+
+	"github.com/unxed/vtinput"
+)
+
+const (
+	far2lImageCategory = 'i'
+	far2lImageSet      = 's'
+	far2lImageDelete   = 'd'
+	far2lImageRGBA     = 0
+	far2lMaxCell       = 1<<16 - 2 // -1 is reserved by FARTTY for "unchanged".
+)
+
+// far2lEncoder maps vtui placements to the native FARTTY image channel. The
+// channel is asynchronous here: waiting for replies from RenderGraphics
+// would re-enter the frame manager while ScreenBuf is holding its mutex.
+type far2lEncoder struct {
+	active map[uint32]struct{}
+}
+
+func newFar2lEncoder() *far2lEncoder {
+	return &far2lEncoder{active: make(map[uint32]struct{})}
+}
+
+func (e *far2lEncoder) Reset(out *byteBuffer) {
+	if e == nil {
+		return
+	}
+	for id := range e.active {
+		e.delete(out, id)
+	}
+	e.active = make(map[uint32]struct{})
+}
+
+func (e *far2lEncoder) Render(out *byteBuffer, list []ImagePlacement) {
+	if e == nil || out == nil {
+		return
+	}
+
+	next := make(map[uint32]struct{}, len(list))
+	for _, p := range list {
+		if !far2lPlacementValid(&p) {
+			continue
+		}
+		next[p.ID] = struct{}{}
+	}
+	for id := range e.active {
+		if _, ok := next[id]; !ok {
+			e.delete(out, id)
+		}
+	}
+	for i := range list {
+		p := &list[i]
+		if !far2lPlacementValid(p) {
+			continue
+		}
+		e.set(out, p)
+	}
+	e.active = next
+}
+
+func far2lPlacementValid(p *ImagePlacement) bool {
+	if p == nil || p.ID == 0 || p.Surface == nil || !p.Surface.Valid() ||
+		p.Cols <= 0 || p.Rows <= 0 || p.Col < 0 || p.Row < 0 ||
+		p.Col > far2lMaxCell || p.Row > far2lMaxCell ||
+		p.Cols > far2lMaxCell-p.Col+1 || p.Rows > far2lMaxCell-p.Row+1 {
+		return false
+	}
+	_, _, sw, sh := p.Source()
+	return sw > 0 && sh > 0 && sw <= int(^uint32(0)) && sh <= int(^uint32(0)) &&
+		uint64(sw)*uint64(sh) <= uint64(^uint32(0))/4
+}
+
+func far2lImageIdentity(id uint32) string {
+	return "vtui-image-" + strconv.FormatUint(uint64(id), 10)
+}
+
+func (e *far2lEncoder) set(out *byteBuffer, p *ImagePlacement) {
+	sx, sy, sw, sh := p.Source()
+	cropped := p.Surface.Crop(sx, sy, sw, sh)
+	if cropped == nil || !cropped.Valid() {
+		return
+	}
+	right := p.Col + p.Cols - 1
+	bottom := p.Row + p.Rows - 1
+
+	stk := &vtinput.Far2lStack{}
+	// Far2l's StackSerializer is LIFO, so push in the reverse order of the
+	// IMAGE_SET documentation: data, dimensions, area, flags, identity,
+	// subcommand, category.
+	stk.PushBytes(cropped.Pix)
+	stk.PushU32(uint32(cropped.Height))
+	stk.PushU32(uint32(cropped.Width))
+	stk.PushU16(uint16(bottom))
+	stk.PushU16(uint16(right))
+	stk.PushU16(uint16(p.Row))
+	stk.PushU16(uint16(p.Col))
+	stk.PushU64(far2lImageRGBA)
+	stk.PushString(far2lImageIdentity(p.ID))
+	stk.PushU8(far2lImageSet)
+	stk.PushU8(far2lImageCategory)
+	out.Write(far2lInteractionPayload(stk))
+}
+
+func (e *far2lEncoder) delete(out *byteBuffer, id uint32) {
+	stk := &vtinput.Far2lStack{}
+	stk.PushString(far2lImageIdentity(id))
+	stk.PushU8(far2lImageDelete)
+	stk.PushU8(far2lImageCategory)
+	out.Write(far2lInteractionPayload(stk))
+}

--- a/graphics_far2l_test.go
+++ b/graphics_far2l_test.go
@@ -1,0 +1,143 @@
+package vtui
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/unxed/vtinput"
+)
+
+func decodeFar2lAPC(t *testing.T, raw string) vtinput.Far2lStack {
+	t.Helper()
+	if !strings.HasPrefix(raw, "\x1b_far2l:") || !strings.HasSuffix(raw, "\x07") {
+		t.Fatalf("not a far2l APC: %q", raw)
+	}
+	b64 := strings.TrimSuffix(strings.TrimPrefix(raw, "\x1b_far2l:"), "\x07")
+	payload, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("decode far2l APC: %v", err)
+	}
+	return vtinput.Far2lStack(payload)
+}
+
+func TestFar2lGraphicsProtocolSelection(t *testing.T) {
+	old := Far2lEnabled
+	Far2lEnabled = true
+	t.Cleanup(func() { Far2lEnabled = old })
+
+	var layer GraphicsLayer
+	got := layer.Protocol()
+	if got != GraphicsFar2l {
+		t.Fatalf("far2l must take precedence over inherited kitty markers, got %v", got)
+	}
+	if p, ok := ParseGraphicsProtocol("far2l"); !ok || p != GraphicsFar2l {
+		t.Fatalf("far2l protocol is not parseable: %v, %v", p, ok)
+	}
+}
+
+func TestFar2lAcknowledgementUpdatesExistingScreen(t *testing.T) {
+	oldEnabled := Far2lEnabled
+	Far2lEnabled = false
+	t.Cleanup(func() { Far2lEnabled = oldEnabled })
+
+	fm := &frameManager{}
+	scr := NewSilentScreenBuf()
+	scr.Graphics().SetProtocol(GraphicsNone)
+	fm.Init(scr)
+	fm.dispatchEvent(&vtinput.InputEvent{Type: vtinput.Far2lEventType, Far2lCommand: "ok"}, false)
+
+	if got := scr.Graphics().Protocol(); got != GraphicsFar2l {
+		t.Fatalf("late far2l acknowledgement left protocol at %v", got)
+	}
+}
+
+func TestFar2lEncoderSetUsesPackedCropAndInclusiveArea(t *testing.T) {
+	oldID := far2lIDCounter
+	far2lIDCounter = 0
+	t.Cleanup(func() { far2lIDCounter = oldID })
+
+	// Two padded rows: the command must contain only the selected 2x2 crop,
+	// not the source stride or pixels outside the source rectangle.
+	pix := make([]byte, 32)
+	copy(pix[0:], []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
+	copy(pix[16:], []byte{13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24})
+	surf := NewImageSurfaceFromPix(3, 2, 16, pix)
+	e := newFar2lEncoder()
+	var out byteBuffer
+	e.Render(&out, []ImagePlacement{{
+		ID: 7, Surface: surf, Col: 2, Row: 3, Cols: 4, Rows: 5,
+		SrcX: 1, SrcY: 0, SrcW: 2, SrcH: 2,
+	}})
+
+	stk := decodeFar2lAPC(t, out.String())
+	if id := stk.PopU8(); id == 0 {
+		t.Fatal("request id must be non-zero")
+	}
+	if got := stk.PopU8(); got != far2lImageCategory {
+		t.Fatalf("category = %q, want %q", got, far2lImageCategory)
+	}
+	if got := stk.PopU8(); got != far2lImageSet {
+		t.Fatalf("subcommand = %q, want %q", got, far2lImageSet)
+	}
+	if got := stk.PopString(); got != far2lImageIdentity(7) {
+		t.Fatalf("identity = %q", got)
+	}
+	if got := stk.PopU64(); got != far2lImageRGBA {
+		t.Fatalf("flags = %#x", got)
+	}
+	if left, top, right, bottom := stk.PopU16(), stk.PopU16(), stk.PopU16(), stk.PopU16(); left != 2 || top != 3 || right != 5 || bottom != 7 {
+		t.Fatalf("area = %d,%d..%d,%d", left, top, right, bottom)
+	}
+	if w, h := stk.PopU32(), stk.PopU32(); w != 2 || h != 2 {
+		t.Fatalf("dimensions = %dx%d", w, h)
+	}
+	want := []byte{5, 6, 7, 8, 9, 10, 11, 12, 17, 18, 19, 20, 21, 22, 23, 24}
+	if got := stk.PopBytes(len(want)); string(got) != string(want) {
+		t.Fatalf("cropped RGBA = %v, want %v", got, want)
+	}
+}
+
+func TestFar2lEncoderDeletesStaleImages(t *testing.T) {
+	oldID := far2lIDCounter
+	far2lIDCounter = 0
+	t.Cleanup(func() { far2lIDCounter = oldID })
+
+	e := newFar2lEncoder()
+	surf := NewImageSurface(1, 1)
+	var out byteBuffer
+	e.Render(&out, []ImagePlacement{{ID: 9, Surface: surf, Cols: 1, Rows: 1}})
+	out.Reset()
+	e.Render(&out, nil)
+
+	stk := decodeFar2lAPC(t, out.String())
+	_ = stk.PopU8()
+	if got := stk.PopU8(); got != far2lImageCategory {
+		t.Fatalf("category = %q", got)
+	}
+	if got := stk.PopU8(); got != far2lImageDelete {
+		t.Fatalf("subcommand = %q", got)
+	}
+	if got := stk.PopString(); got != far2lImageIdentity(9) {
+		t.Fatalf("identity = %q", got)
+	}
+}
+
+func TestScreenBufFlushFar2lGraphics(t *testing.T) {
+	oldID := far2lIDCounter
+	far2lIDCounter = 0
+	t.Cleanup(func() { far2lIDCounter = oldID })
+
+	scr := NewScreenBuf()
+	var out bytes.Buffer
+	scr.Writer = &out
+	scr.AllocBuf(4, 2)
+	scr.Graphics().SetProtocol(GraphicsFar2l)
+	scr.Graphics().Add(ImagePlacement{ID: 1, Surface: NewImageSurface(1, 1), Cols: 1, Rows: 1})
+	scr.Flush()
+
+	if !strings.Contains(out.String(), "\x1b_far2l:") {
+		t.Fatal("far2l renderer did not append an APC to the frame")
+	}
+}

--- a/graphics_kitty.go
+++ b/graphics_kitty.go
@@ -239,8 +239,12 @@ func (r *AnsiRenderer) RenderGraphics(layer *GraphicsLayer, buf, shadow []CharIn
 
 	proto := layer.Protocol()
 	if proto != r.gfxProto {
+		if r.gfxFar2l != nil {
+			r.gfxFar2l.Reset(&r.frameOut)
+		}
 		r.gfxKitty = nil
 		r.gfxSixel = nil
+		r.gfxFar2l = nil
 		r.gfxProto = proto
 		force = true
 	}
@@ -271,10 +275,18 @@ func (r *AnsiRenderer) RenderGraphics(layer *GraphicsLayer, buf, shadow []CharIn
 		cw, ch := layer.CellSize()
 		r.gfxList, _ = layer.Snapshot(r.gfxList)
 		r.gfxSixel.Render(&r.frameOut, r.gfxList, cw, ch)
+	case GraphicsFar2l:
+		if r.gfxFar2l == nil {
+			r.gfxFar2l = newFar2lEncoder()
+		}
+		r.gfxList, _ = layer.Snapshot(r.gfxList)
+		r.gfxFar2l.Render(&r.frameOut, r.gfxList)
 	}
 
 	// Both protocols move the text cursor (kitty places relative to it, sixel
 	// leaves it below the image), so PrepareFlush must re-emit the cursor
 	// report this frame.
-	r.termCursorInvalid = true
+	if proto == GraphicsKitty || proto == GraphicsSixel {
+		r.termCursorInvalid = true
+	}
 }

--- a/screenbuf.go
+++ b/screenbuf.go
@@ -792,6 +792,7 @@ type AnsiRenderer struct {
 	gfxGen   uint64
 	gfxKitty *kittyEncoder
 	gfxSixel *sixelEncoder
+	gfxFar2l *far2lEncoder
 	gfxList  []ImagePlacement
 }
 


### PR DESCRIPTION
I, zoin-bot, am adding native image transport for applications running inside far2l TTY|Xi.

## What changed

- add `GraphicsFar2l` to vtui graphics protocol selection after `far2lok` negotiation;
- encode vtui RGBA surfaces and cell placements as FARTTY `IMAGE_SET` requests;
- crop padded/source-rect surfaces, remove stale image identities, and reset them on protocol changes;
- keep requests asynchronous during frame composition so the ScreenBuf mutex is never re-entered;
- switch an already-created screen to far2l when the negotiation acknowledgement arrives.

This lets f4's existing ImageView use far2l's native X-backed image path without f4-specific rendering code. Kitty, sixel, and native backends remain unchanged.

## Validation on Linux ARM64

- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go test ./...`
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go vet ./...`
- targeted new FARTTY tests under `go test -race`
- exact stack ordering, padded source crop, inclusive cell rectangle, stale-image deletion, and late negotiation are covered by tests

A far2l executable/broker is not installed in the current Fedora Asahi Wayland session, so the live TTY|Xi X-window path needs validation on a host with far2l available.

— zoin-bot
