### PR TITLE
arch: gate native backends on the architectures goffi supports

### DIFF
--- a/ebiten_dragdrop.go
+++ b/ebiten_dragdrop.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build (linux || windows || darwin) && (amd64 || arm64)
 
 package vtui
 

--- a/ebiten_host.go
+++ b/ebiten_host.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build (linux || windows || darwin) && (amd64 || arm64)
 
 package vtui
 

--- a/ebiten_keys.go
+++ b/ebiten_keys.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build (linux || windows || darwin) && (amd64 || arm64)
 
 package vtui
 

--- a/ebiten_renderer.go
+++ b/ebiten_renderer.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build (linux || windows || darwin) && (amd64 || arm64)
 
 package vtui
 

--- a/ebiten_renderer_test.go
+++ b/ebiten_renderer_test.go
@@ -1,4 +1,4 @@
-//go:build (linux || windows || darwin) && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build (linux || windows || darwin) && (amd64 || arm64)
 
 package vtui
 
@@ -9,16 +9,6 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/unxed/vtinput"
 )
-
-// mkGrid builds a buf/shadow pair of w*h cells filled with ch and attributes.
-func mkGrid(w, h int, ch uint64, attr uint64) (buf, shadow []CharInfo) {
-	buf = make([]CharInfo, w*h)
-	shadow = make([]CharInfo, w*h)
-	for i := range buf {
-		buf[i] = CharInfo{Char: ch, Attributes: attr}
-	}
-	return buf, shadow
-}
 
 func TestEbitenRenderer_AllocatesFramebufferForGrid(t *testing.T) {
 	r := NewEbitenRenderer(nil, nil, 8, 16, 1)

--- a/ebiten_stub.go
+++ b/ebiten_stub.go
@@ -1,4 +1,4 @@
-//go:build !(linux || windows || darwin) || arm || mips || mipsle || mips64 || mips64le || riscv64 || loong64 || ppc64 || ppc64le
+//go:build !(linux || windows || darwin) || !(amd64 || arm64)
 
 package vtui
 

--- a/gogpu_customchar_test.go
+++ b/gogpu_customchar_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
 
 package vtui
 

--- a/gogpu_dnd.go
+++ b/gogpu_dnd.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
 
 package vtui
 

--- a/gogpu_dnd_test.go
+++ b/gogpu_dnd_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
 
 package vtui
 

--- a/gogpu_glyphgen_test.go
+++ b/gogpu_glyphgen_test.go
@@ -1,3 +1,5 @@
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
+
 package vtui
 
 // Glyph drawing tests + table tooling.

--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
 
 package vtui
 

--- a/gogpu_host_test.go
+++ b/gogpu_host_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
 
 package vtui
 

--- a/gogpu_keys_test.go
+++ b/gogpu_keys_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
 
 package vtui
 

--- a/gogpu_profile.go
+++ b/gogpu_profile.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
 
 package vtui
 

--- a/gogpu_renderer.go
+++ b/gogpu_renderer.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
 
 package vtui
 

--- a/gogpu_renderer_test.go
+++ b/gogpu_renderer_test.go
@@ -1,4 +1,4 @@
-//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build !freebsd && !dragonfly && !openbsd && !netbsd && !illumos && !solaris && (amd64 || arm64)
 
 package vtui
 

--- a/gogpu_stub.go
+++ b/gogpu_stub.go
@@ -1,4 +1,4 @@
-//go:build freebsd || dragonfly || openbsd || netbsd || illumos || solaris || arm || mips || mipsle || mips64 || mips64le || riscv64 || loong64 || ppc64 || ppc64le
+//go:build freebsd || dragonfly || openbsd || netbsd || illumos || solaris || !(amd64 || arm64)
 
 package vtui
 

--- a/test_main_test.go
+++ b/test_main_test.go
@@ -8,3 +8,13 @@ import (
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
+
+// mkGrid builds a buf/shadow pair of w*h cells filled with ch and attributes.
+func mkGrid(w, h int, ch uint64, attr uint64) (buf, shadow []CharInfo) {
+	buf = make([]CharInfo, w*h)
+	shadow = make([]CharInfo, w*h)
+	for i := range buf {
+		buf[i] = CharInfo{Char: ch, Attributes: attr}
+	}
+	return buf, shadow
+}

--- a/wayland_host.go
+++ b/wayland_host.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build linux && (amd64 || arm64)
 
 package vtui
 

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build linux && (amd64 || arm64)
 
 package vtui
 

--- a/wayland_present_test.go
+++ b/wayland_present_test.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build linux && (amd64 || arm64)
 
 package vtui
 

--- a/wayland_renderer.go
+++ b/wayland_renderer.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm && !mips && !mipsle && !mips64 && !mips64le && !riscv64 && !loong64 && !ppc64 && !ppc64le
+//go:build linux && (amd64 || arm64)
 
 package vtui
 

--- a/wayland_stub.go
+++ b/wayland_stub.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || dragonfly || openbsd || netbsd || arm || mips || mipsle || mips64 || mips64le || riscv64 || loong64 || ppc64 || ppc64le
+//go:build darwin || freebsd || dragonfly || openbsd || netbsd || !(amd64 || arm64)
 
 package vtui
 


### PR DESCRIPTION
Follow-up to the Linux architectures added in unxed/f4#669.

**What.** The gogpu, ebiten and wayland backends are gated by a list of architectures to exclude — now nine of them, repeated across 21 files. This replaces the list with the condition it stands for: `(amd64 || arm64)`.

**Why.** All three backends bottom out in `go-webgpu/goffi`, which ships assembly for amd64 and arm64 only, so that is the actual condition. Written as an exclusion list, every architecture Go adds is assumed to work until the build breaks and someone appends another negation to all 21 files. The list had already drifted: `gogpu_customchar_test.go`, `gogpu_host_test.go` and `gogpu_renderer_test.go` were missing `!arm`, so on linux/arm they compiled against a stubbed-out backend and the test binary could not be built at all.

**What for.** A new GOARCH lands on the stub by default and the list never needs another update. It also makes linux/386 — the one ordinary architecture absent from the current list — build without one.

It also fixes the test gating this exposed. `mergeGlyphRectsV` is gogpu's own code, so its test moves behind the same tag. `mkGrid` is a plain `CharInfo` grid helper with nothing ebiten-specific about it, so it moves next to `TestMain` instead — that way the ungated tests using it keep running everywhere rather than being switched off too.

**Verified.** `go test -c` now builds for linux amd64/arm64/arm/386/riscv64/loong64/mips/mipsle/mips64/mips64le/ppc64/ppc64le, darwin amd64/arm64 and windows/amd64 — previously only amd64 and arm64. `go test ./...` passes on the host. f4 builds unchanged for all of its existing targets, and for the new cells.

Note this does not remove the need for `-tags noffi`: keytrans and ffibridge gate their FFI separately, and vtui does not know that tag.
