### PR TITLE
zoin-bot: expose debug logs to stderr and tests

### DIFF
--- a/UI_TESTING.md
+++ b/UI_TESTING.md
@@ -42,3 +42,22 @@ func TestMyNewDialog_Layout(t *testing.T) {
 
 ## AI Instructions
 When generating code for new dialogs, you **MUST** include a test file using `AssertLayout`. If the validation fails, you must adjust the dialog dimensions or margins until the test passes.
+
+## Debug logging from tests
+
+Production code must use `DebugLog` for diagnostic output; do not add direct
+`fmt.Fprintf(os.Stderr, ...)` calls just to make a failing test observable.
+
+Use `VTUI_DEBUG=stderr` when a local run should keep the normal timestamped
+debug records on standard error. For test output, install the test logger in a
+scoped setup and use the `test` mode:
+
+```go
+restore := vtui.SetTestLogger(t.Logf)
+defer restore()
+t.Setenv("VTUI_DEBUG", "test")
+```
+
+The callback is safe to use from background goroutines. `VTUI_DEBUG=test`
+falls back to standard error when no test logger is installed, which keeps
+manual `go test -v` diagnostics useful.

--- a/debug.go
+++ b/debug.go
@@ -14,6 +14,7 @@ var (
 	logRotated         bool
 	logFile            *os.File
 	currentLogFilename string
+	testLogger         func(string, ...any)
 )
 
 func rotateLogs(basePath string) {
@@ -49,6 +50,26 @@ func ConfigDiskLogging(enabled bool) {
 	logMu.Unlock()
 }
 
+// SetTestLogger installs the callback used by DebugLog when VTUI_DEBUG=test.
+// It returns a restore function so a test can scope the global logger safely:
+//
+//	restore := SetTestLogger(t.Logf)
+//	defer restore()
+//
+// The callback may be called from any goroutine, just like DebugLog itself.
+func SetTestLogger(logger func(string, ...any)) func() {
+	logMu.Lock()
+	previous := testLogger
+	testLogger = logger
+	logMu.Unlock()
+
+	return func() {
+		logMu.Lock()
+		testLogger = previous
+		logMu.Unlock()
+	}
+}
+
 // DebugLog writes a timestamped message to debug.log file.
 // If the file exists at the start of the session, it is rotated
 // (up to 3 files: debug.log, debug.1.log, debug.2.log).
@@ -61,6 +82,29 @@ func DebugLog(format string, a ...any) {
 
 	env := os.Getenv("VTUI_DEBUG")
 	if env == "" {
+		return
+	}
+
+	if env == "stderr" {
+		logMu.Lock()
+		_, _ = fmt.Fprintln(os.Stderr, fullMsg)
+		logMu.Unlock()
+		return
+	}
+
+	if env == "test" {
+		logMu.Lock()
+		logger := testLogger
+		logMu.Unlock()
+		if logger != nil {
+			logger("%s", fullMsg)
+			return
+		}
+		// Keep VTUI_DEBUG=test useful for ad-hoc test commands even when the
+		// caller did not install a testing.T logger.
+		logMu.Lock()
+		_, _ = fmt.Fprintln(os.Stderr, fullMsg)
+		logMu.Unlock()
 		return
 	}
 

--- a/debug_test.go
+++ b/debug_test.go
@@ -1,6 +1,8 @@
 package vtui
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,5 +99,47 @@ func TestDebugLog_Rotation(t *testing.T) {
 	c2, _ := os.ReadFile(log2)
 	if !strings.Contains(string(c2), "Session 1") {
 		t.Error("Rotated log.2 has wrong content")
+	}
+}
+
+func TestDebugLog_StderrMode(t *testing.T) {
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		_ = r.Close()
+		_ = w.Close()
+	})
+	t.Setenv("VTUI_DEBUG", "stderr")
+
+	DebugLog("stderr message %d", 42)
+	_ = w.Close()
+	os.Stderr = oldStderr
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stderr capture: %v", err)
+	}
+	if !strings.Contains(string(data), "stderr message 42") {
+		t.Fatalf("stderr output = %q, want debug message", data)
+	}
+}
+
+func TestDebugLog_TestLogger(t *testing.T) {
+	var messages []string
+	restore := SetTestLogger(func(format string, args ...any) {
+		messages = append(messages, fmt.Sprintf(format, args...))
+	})
+	defer restore()
+	t.Setenv("VTUI_DEBUG", "test")
+
+	DebugLog("test message %d", 7)
+
+	if len(messages) != 1 || !strings.Contains(messages[0], "test message 7") {
+		t.Fatalf("test logger messages = %#v, want one formatted message", messages)
 	}
 }


### PR DESCRIPTION
## Summary

- add `VTUI_DEBUG=stderr` for timestamped diagnostic output without a debug file
- add `VTUI_DEBUG=test` and scoped `SetTestLogger` for `testing.T.Logf` sinks
- document the test logging rule in `UI_TESTING.md`

## Validation

- `CGO_ENABLED=0 go test ./...`
- `go vet ./...`
- targeted `CGO_ENABLED=1 go test -race -run '^TestDebugLog_' .`

A full repository race run was also attempted; it reports pre-existing races in unrelated frame-manager/far2l/protocol tests, while the new debug logger tests pass under the race detector.

— zoin-bot
