### PR TITLE
graphics: fix a bounds check that does not compile on 32-bit targets

### DIFF
--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Build
         run: go build ./...
 
+      # A 32-bit target as well. Nothing else here builds one, and the class of
+      # bug this guards against — a constant that does not fit a 32-bit int —
+      # is a compile error rather than a test failure, so only a build of such
+      # a target catches it. f4 ships linux/arm, mips and mipsle.
+      - name: Build for a 32-bit target
+        run: GOOS=linux GOARCH=arm go build ./...
+
       - name: Vet
         run: go vet ./...
 

--- a/graphics_far2l.go
+++ b/graphics_far2l.go
@@ -70,8 +70,13 @@ func far2lPlacementValid(p *ImagePlacement) bool {
 		return false
 	}
 	_, _, sw, sh := p.Source()
-	return sw > 0 && sh > 0 && sw <= int(^uint32(0)) && sh <= int(^uint32(0)) &&
-		uint64(sw)*uint64(sh) <= uint64(^uint32(0))/4
+	// Compared in uint64 rather than int: int(^uint32(0)) is a constant
+	// conversion, so where int is 32 bits it does not compile at all. sw and sh
+	// are known positive by the time they are widened.
+	const maxDimension = uint64(^uint32(0))
+	return sw > 0 && sh > 0 &&
+		uint64(sw) <= maxDimension && uint64(sh) <= maxDimension &&
+		uint64(sw)*uint64(sh) <= maxDimension/4
 }
 
 func far2lImageIdentity(id uint32) string {


### PR DESCRIPTION
`far2lPlacementValid` guards against an image whose dimensions overflow the `uint32` field far2l's protocol uses. It wrote the bound as `int(^uint32(0))` — a constant conversion, evaluated at compile time — and 4294967295 does not fit an `int` where `int` is 32 bits:

```
./graphics_far2l.go:73:39: constant 4294967295 overflows int
```

So the overflow check was itself the overflow.

This is not a runtime bug. The package simply does not build for `GOARCH=arm`, `mips` or `mipsle`, which is why it surfaced as three red build cells downstream rather than as a failing test: f4's `main` has been red on every 32-bit target since it picked up v0.1.267.

Widening to `uint64` before comparing keeps the bound exact and portable. `sw` and `sh` are known positive by the time they are converted, so nothing wraps.

## The guard

CI cross-builds a 32-bit target now. Nothing here built one, and this class of bug is a compile error rather than a test failure — no unit test could have caught it, only a build of such a target can. `linux/arm` stands in for the three architectures f4 ships.

Verified: `GOOS=linux GOARCH=arm go build ./...` fails on `main` and passes with this; the native build is unaffected and the suite is green with the same skips CI uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
