### PR TITLE
Fix far2l image bounds on 32-bit targets

### DIFF
--- a/graphics_far2l.go
+++ b/graphics_far2l.go
@@ -70,7 +70,8 @@ func far2lPlacementValid(p *ImagePlacement) bool {
 		return false
 	}
 	_, _, sw, sh := p.Source()
-	return sw > 0 && sh > 0 && sw <= int(^uint32(0)) && sh <= int(^uint32(0)) &&
+	maxUint32 := uint64(^uint32(0))
+	return sw > 0 && sh > 0 && uint64(sw) <= maxUint32 && uint64(sh) <= maxUint32 &&
 		uint64(sw)*uint64(sh) <= uint64(^uint32(0))/4
 }
 


### PR DESCRIPTION
## Summary\n- avoid converting the uint32 maximum to int in far2l image validation\n- keep the bounds check portable on 32-bit GOARCH values\n\nThis fixes 32-bit cross-builds that fail with constant 4294967295 overflows int.\n\n— zoin-bot