### PR TITLE
Add workspace tab overlay mode

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -243,11 +243,14 @@ type frameManager struct {
 	capturedFrame Frame // Points to the active screen's captured frame
 
 	// Switcher State
-	ctrlPressed              bool
-	workspaceTabPreview      bool
-	switcherMenu             *VMenu
-	WorkspaceTabMode         WorkspaceTabMode
-	WorkspaceCtrlTabMode     WorkspaceCtrlTabMode
+	ctrlPressed          bool
+	workspaceTabPreview  bool
+	switcherMenu         *VMenu
+	WorkspaceTabMode     WorkspaceTabMode
+	WorkspaceCtrlTabMode WorkspaceCtrlTabMode
+	// WorkspaceTabOverlay keeps the transient WorkspaceTabsOnCtrl strip on
+	// top of the first frame row instead of reserving a row for it.
+	WorkspaceTabOverlay      bool
 	WorkspaceAltNumberSwitch bool
 	WorkspaceTabBarAttr      uint64
 	WorkspaceActiveAttr      uint64
@@ -395,7 +398,7 @@ func (fm *frameManager) tickAnimations() {
 func (fm *frameManager) WorkspaceTopInset() int {
 	if fm.WorkspaceTabMode == WorkspaceTabsAlways ||
 		(fm.WorkspaceTabMode == WorkspaceTabsMultiple && len(fm.Screens) > 1) ||
-		(fm.WorkspaceTabMode == WorkspaceTabsOnCtrl && fm.ctrlPressed && fm.workspaceTabPreview) {
+		(fm.WorkspaceTabMode == WorkspaceTabsOnCtrl && fm.ctrlPressed && fm.workspaceTabPreview && !fm.WorkspaceTabOverlay) {
 		return 1
 	}
 	return 0
@@ -413,6 +416,19 @@ func (fm *frameManager) ConfigureWorkspaceTabs(tabMode WorkspaceTabMode, ctrlTab
 	oldInset := fm.WorkspaceTopInset()
 	fm.WorkspaceTabMode = tabMode
 	fm.WorkspaceCtrlTabMode = ctrlTabMode
+	if oldInset != fm.WorkspaceTopInset() {
+		fm.ResizeAllScreens()
+	}
+	fm.Redraw()
+}
+
+// ConfigureWorkspaceTabOverlay controls whether the transient
+// WorkspaceTabsOnCtrl strip overlays the first frame row. When disabled, the
+// strip reserves its own row after the first Ctrl+Tab, preserving the default
+// layout-safe behavior for full-screen frame content.
+func (fm *frameManager) ConfigureWorkspaceTabOverlay(enabled bool) {
+	oldInset := fm.WorkspaceTopInset()
+	fm.WorkspaceTabOverlay = enabled
 	if oldInset != fm.WorkspaceTopInset() {
 		fm.ResizeAllScreens()
 	}

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -1805,6 +1805,13 @@ func TestFrameManager_OnCtrlInsetTracksCtrlState(t *testing.T) {
 	if got := fm.WorkspaceTopInset(); got != 1 {
 		t.Fatalf("on-ctrl mode after Ctrl+Tab inset = %d, want 1", got)
 	}
+	fm.ConfigureWorkspaceTabOverlay(true)
+	if !fm.workspaceTabsVisible() {
+		t.Fatal("overlay mode must keep the transient tabs visible")
+	}
+	if got := fm.WorkspaceTopInset(); got != 0 {
+		t.Fatalf("on-ctrl overlay mode inset = %d, want 0", got)
+	}
 	fm.ctrlPressed = false
 	if got := fm.WorkspaceTopInset(); got != 0 {
 		t.Fatalf("on-ctrl mode without ctrl inset = %d, want 0", got)


### PR DESCRIPTION
Fixes downstream layout regression reported in unxed/f4#688.

`WorkspaceTabsOnCtrl` currently reserves the first row after the first Ctrl+Tab so full-screen frame content cannot paint over the transient tab strip. That is layout-safe but makes the panels jump vertically whenever the strip appears. Add an explicit `ConfigureWorkspaceTabOverlay` option: when enabled, the tab strip remains visible but overlays row 0 and the frame geometry stays stable; the existing reserved-row behavior remains the default for embedders that do not opt in.

Validation:
- `go test . -run 'TestFrameManager_(WorkspaceTopInsetModes|OnCtrlInsetTracksCtrlState|OnCtrlTabsArmAfterFirstCtrlTab|WorkspaceTabsAndCounterRendering)$' -count=1`
- full `go test ./... -count=1` reaches existing environment failures: Python is unavailable for bindings integration and the pre-existing Win32 DnD expectation fails

— zoin-bot