### PR TITLE
fix: preserve Ctrl+Break in gogpu input

### DIFF
--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -1019,6 +1019,12 @@ func gogpuKeyToVK(k gpucontext.Key, mods vtinput.ControlKeyState) uint16 {
 		return vtinput.VK_CAPITAL
 	case gpucontext.KeyScrollLock:
 		return vtinput.VK_SCROLL
+	case gpucontext.KeyPause:
+		return vtinput.VK_PAUSE
+	case gpucontext.KeyCancel:
+		// Win32 reports Ctrl+Break as VK_CANCEL. Keep it distinct from
+		// the plain Pause key so f4 can translate the chord to ETX.
+		return vtinput.VK_CANCEL
 
 	// Where Super acts as Ctrl (macOS Command), the modifiers arrive on two
 	// channels, the way far2l separates them: both Cmd keys as VK_LCONTROL

--- a/gogpu_keys_test.go
+++ b/gogpu_keys_test.go
@@ -89,6 +89,8 @@ func TestGogpuKeyToVK_Numpad(t *testing.T) {
 		// Lock keys themselves were unmapped too.
 		{"numlock key", gpucontext.KeyNumLock, off, vtinput.VK_NUMLOCK},
 		{"capslock key", gpucontext.KeyCapsLock, off, vtinput.VK_CAPITAL},
+		{"pause key", gpucontext.KeyPause, off, vtinput.VK_PAUSE},
+		{"cancel key", gpucontext.KeyCancel, vtinput.LeftCtrlPressed, vtinput.VK_CANCEL},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes the gogpu input path for Ctrl+Break on Windows.

gpucontext now distinguishes KeyCancel (VK_CANCEL) from KeyPause, but vtui did not map either key in gogpuKeyToVK. As a result Ctrl+Break was dropped before f4 could translate it to ETX and send it to the active PTY in GUI mode.

Changes:
- map KeyPause to VK_PAUSE;
- map KeyCancel to VK_CANCEL;
- add regression coverage.

Validation:
- targeted gogpu key mapping tests pass;
- full vtui tests are currently blocked by two pre-existing Windows-environment failures: Python bindings cannot find Python, and the existing Win32 DnD effect test expects a different combined-effect value.

Downstream: https://github.com/unxed/f4/issues/362