### PR TITLE
Highlight default dialog buttons

### DIFF
--- a/button.go
+++ b/button.go
@@ -50,7 +50,11 @@ func (b *Button) DisplayObject(scr *ScreenBuf) {
 	if !b.IsVisible() {
 		return
 	}
-	n, h := b.GetStateAttrs(ColDialogButton, ColDialogSelectedButton, ColDialogHighlightButton, ColDialogHighlightSelectedButton)
+	normalIdx := ColDialogButton
+	if b.IsDefault {
+		normalIdx = ColDialogHighlightButton
+	}
+	n, h := b.GetStateAttrs(normalIdx, ColDialogSelectedButton, ColDialogHighlightButton, ColDialogHighlightSelectedButton)
 	if b.mousePressed {
 		n, h = b.GetStateAttrs(ColDialogSelectedButton, ColDialogSelectedButton, ColDialogHighlightSelectedButton, ColDialogHighlightSelectedButton)
 	}

--- a/button_test.go
+++ b/button_test.go
@@ -117,3 +117,22 @@ func TestButton_HotkeyParsing(t *testing.T) {
 		t.Errorf("Expected hotkey 'c' after SetText, got %c", b.GetHotkey())
 	}
 }
+
+func TestButton_DefaultUsesHighlightStyleWhenUnfocused(t *testing.T) {
+	SetDefaultPalette()
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(20, 3)
+
+	normal := NewButton(0, 0, "Normal")
+	defaultButton := NewButton(0, 1, "Default")
+	defaultButton.IsDefault = true
+	normal.Show(scr)
+	defaultButton.Show(scr)
+
+	checkCell(t, scr, 2, 0, 'N', Palette[ColDialogButton])
+	checkCell(t, scr, 2, 1, 'D', Palette[ColDialogHighlightButton])
+
+	defaultButton.SetFocus(true)
+	defaultButton.Show(scr)
+	checkCell(t, scr, 2, 1, 'D', Palette[ColDialogSelectedButton])
+}


### PR DESCRIPTION
## Summary\n- render unfocused Button.IsDefault controls with the existing highlight-button palette\n- preserve focused, pressed, hotkey, disabled, and warning-dialog palette behavior\n- add a regression test\n\nFixes the behavior reported in f4#320.\n\nValidation:\n- go test . -run 'TestButton_' -count=1 passed\n- full go test ./... -count=1 is blocked by the pre-existing Windows DnD expectation failure and missing Python runtime\n- go vet ./... reports existing unsafe.Pointer warnings in Win32 files