### PR TITLE
Rate-limit debug log fsyncs

### DIFF
--- a/ISSUE_205_SOLUTION_REVIEW.md
+++ b/ISSUE_205_SOLUTION_REVIEW.md
@@ -1,0 +1,39 @@
+# Issue #205 solution review
+
+## Candidate 1: keep `File.Sync` in every `DebugLog` call
+
+- Preserves the strongest immediate durability guarantee.
+- Fails the reported workload: every debug message blocks the caller on a disk flush, which is especially visible on an HDD and can stall the UI/event loop.
+- Rejected.
+
+## Candidate 2: remove syncing entirely
+
+- Removes the per-message latency and is simple.
+- Weakens crash diagnostics: a process or machine failure shortly after a message could leave recent log data only in the OS cache.
+- Rejected because debug logging is primarily a diagnostic feature.
+
+## Candidate 3: rate-limit syncing and flush on close (chosen)
+
+- Append each formatted line under the existing mutex, sync at most once per two seconds, and sync before closing or switching the log file.
+- Keeps recent logs durable within the intended diagnostic window while removing the repeated HDD flush from the hot path.
+- Does not add a background worker or public lifecycle API, so there is no ticker/goroutine lifetime to coordinate with tests, reconfiguration, or process shutdown.
+
+## Three-pass review
+
+### Pass 1: correctness
+
+- Concurrent calls remain serialized by `logMu`.
+- A failed sync does not advance the sync timestamp, so a later call retries it.
+- Rotation, disk logging disablement, and filename changes flush before closing the file.
+
+### Pass 2: compatibility and failure modes
+
+- The existing file format, rotation policy, environment variable behavior, memory ring buffer, stderr mode, and test logger are unchanged.
+- Log write errors remain non-fatal, as before.
+- A process crash can still lose less than two seconds of OS-cached log data; this is the explicit trade-off for avoiding a flush on every message.
+
+### Pass 3: scope and regression risk
+
+- The change is isolated to the shared `vtui` logger, so it benefits f4 and other consumers of `DebugLog`.
+- Tests cover the two-second sync interval and close-time flush, in addition to existing content and rotation tests.
+- Native Windows validation will exercise a real f4 build with `VTUI_DEBUG` enabled and a high-volume startup/debug workload.

--- a/debug.go
+++ b/debug.go
@@ -14,14 +14,41 @@ var (
 	logRotated         bool
 	logFile            *os.File
 	currentLogFilename string
+	lastLogSync        time.Time
 	testLogger         func(string, ...any)
 )
 
-func rotateLogs(basePath string) {
-	if logFile != nil {
-		logFile.Close()
-		logFile = nil
+const debugLogSyncInterval = 2 * time.Second
+
+var syncLogFile = func(file *os.File) error {
+	return file.Sync()
+}
+
+func syncLogFileLocked(now time.Time, force bool) {
+	if logFile == nil {
+		return
 	}
+	if !force && !lastLogSync.IsZero() && now.Sub(lastLogSync) < debugLogSyncInterval {
+		return
+	}
+	if err := syncLogFile(logFile); err == nil {
+		lastLogSync = now
+	}
+}
+
+func closeLogFileLocked() {
+	if logFile == nil {
+		return
+	}
+	syncLogFileLocked(time.Now(), true)
+	_ = logFile.Close()
+	logFile = nil
+	currentLogFilename = ""
+	lastLogSync = time.Time{}
+}
+
+func rotateLogs(basePath string) {
+	closeLogFileLocked()
 	ext := filepath.Ext(basePath)
 	prefix := strings.TrimSuffix(basePath, ext)
 
@@ -43,9 +70,8 @@ var diskLoggingEnabled = true
 func ConfigDiskLogging(enabled bool) {
 	logMu.Lock()
 	diskLoggingEnabled = enabled
-	if !enabled && logFile != nil {
-		logFile.Close()
-		logFile = nil
+	if !enabled {
+		closeLogFileLocked()
 	}
 	logMu.Unlock()
 }
@@ -128,19 +154,19 @@ func DebugLog(format string, a ...any) {
 	}
 
 	if logFile != nil && currentLogFilename != filename {
-		logFile.Close()
-		logFile = nil
+		closeLogFileLocked()
 	}
 
 	if logFile == nil {
 		var err error
 		logFile, err = os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		currentLogFilename = filename
+		lastLogSync = time.Now()
 		recordLogMemory(fmt.Sprintf("[SYS] Opened new log file %q (Err: %v, PID: %d)", filename, err, os.Getpid()))
 	}
 	if logFile != nil {
-		fmt.Fprintln(logFile, fullMsg)
-		logFile.Sync()
+		_, _ = fmt.Fprintln(logFile, fullMsg)
+		syncLogFileLocked(time.Now(), false)
 	}
 	logMu.Unlock()
 }

--- a/debug_test.go
+++ b/debug_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDebugLog_CustomFile(t *testing.T) {
@@ -141,5 +142,54 @@ func TestDebugLog_TestLogger(t *testing.T) {
 
 	if len(messages) != 1 || !strings.Contains(messages[0], "test message 7") {
 		t.Fatalf("test logger messages = %#v, want one formatted message", messages)
+	}
+}
+
+func TestDebugLog_SyncIntervalAndClose(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "sync.log")
+	t.Setenv("VTUI_DEBUG", logPath)
+
+	logMu.Lock()
+	if logFile != nil {
+		_ = logFile.Close()
+		logFile = nil
+	}
+	logRotated = false
+	lastLogSync = time.Time{}
+	logMu.Unlock()
+
+	oldSyncLogFile := syncLogFile
+	syncCalls := 0
+	syncLogFile = func(*os.File) error {
+		syncCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		syncLogFile = oldSyncLogFile
+		logMu.Lock()
+		closeLogFileLocked()
+		logMu.Unlock()
+	})
+
+	DebugLog("first")
+	DebugLog("second")
+	if syncCalls != 0 {
+		t.Fatalf("sync calls before interval = %d, want 0", syncCalls)
+	}
+
+	logMu.Lock()
+	lastLogSync = time.Now().Add(-debugLogSyncInterval)
+	logMu.Unlock()
+	DebugLog("third")
+	DebugLog("fourth")
+	if syncCalls != 1 {
+		t.Fatalf("sync calls during interval = %d, want 1", syncCalls)
+	}
+
+	logMu.Lock()
+	closeLogFileLocked()
+	logMu.Unlock()
+	if syncCalls != 2 {
+		t.Fatalf("sync calls after close = %d, want 2", syncCalls)
 	}
 }


### PR DESCRIPTION
Fixes unxed/f4#205 by removing the synchronous file sync from every DebugLog call. Log lines are still appended under the existing mutex, the file is synced at most once per two seconds, and close/rotation/configuration changes flush before closing. This keeps diagnostic logs while avoiding HDD stalls during startup and TTY activity.\n\nValidation:\n- go test . -run 'TestDebugLog_' -count=1\n- go test ./... -run '^$' -count=1\n- native Windows x64 f4 build with local vtui, launched with --debug --tty ansi and verified debug.log output during ConPTY/UI activity\n- full vtui test run attempted; Python integration is unavailable on this host and the existing Windows DnD conversion test fails independently\n\n— zoin-bot