### PR TITLE
fix: keep long submenus inside the screen

### DIFF
--- a/menubar.go
+++ b/menubar.go
@@ -161,7 +161,20 @@ func (mb *MenuBar) ActivateSubMenu(index int) {
 		}
 	}
 
-	m.SetPosition(x, mb.Y1+1, x+maxWidth-1, mb.Y1+1+m.GetItemCount()+1)
+	menuY := mb.Y1 + 1
+	menuBottom := menuY + m.GetItemCount() + 1
+	// VMenu already provides a scrolling viewport and scrollbar.  Keep the
+	// submenu inside the screen so that those controls can actually be used
+	// when a menu has more rows than the terminal or GUI window.
+	if FrameManager != nil {
+		if screenHeight := FrameManager.GetScreenHeight(); screenHeight > 0 && menuBottom >= screenHeight {
+			menuBottom = screenHeight - 1
+		}
+	}
+	if menuBottom < menuY+2 {
+		menuBottom = menuY + 2
+	}
+	m.SetPosition(x, menuY, x+maxWidth-1, menuBottom)
 
 	m.OnAction = func(idx int) { mb.Active = false }
 

--- a/menubar_test.go
+++ b/menubar_test.go
@@ -106,3 +106,43 @@ func TestMenuBar_MouseMoveSelectsCommandItemWithoutExecuting(t *testing.T) {
 		t.Fatalf("hover executed %d command(s)", commandCount)
 	}
 }
+
+func TestMenuBar_LongSubmenuUsesScrollingViewport(t *testing.T) {
+	fm := &frameManager{}
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 10)
+	fm.Init(scr)
+	fm.Push(NewDesktop())
+
+	oldFrameManager := FrameManager
+	FrameManager = fm
+	defer func() { FrameManager = oldFrameManager }()
+
+	items := make([]MenuItem, 30)
+	for i := range items {
+		items[i] = MenuItem{Text: "Item"}
+	}
+	mb := NewMenuBar(nil)
+	mb.Items = []MenuBarItem{{Label: "Commands", SubItems: items}}
+	mb.SetPosition(0, 0, 79, 0)
+	mb.Active = true
+	mb.ActivateSubMenu(0)
+
+	m, ok := mb.activeSubMenu.(*VMenu)
+	if !ok || m == nil {
+		t.Fatalf("active submenu = %T, want *VMenu", mb.activeSubMenu)
+	}
+	if m.Y2 >= scr.Height() {
+		t.Fatalf("long submenu bottom = %d, screen height = %d", m.Y2, scr.Height())
+	}
+	if m.ViewHeight >= len(items) {
+		t.Fatalf("long submenu viewport = %d rows for %d items", m.ViewHeight, len(items))
+	}
+	if !m.ShowScrollBar || m.ScrollBar == nil {
+		t.Fatal("long submenu did not expose a scrollbar")
+	}
+	m.SetSelectPos(len(items) - 1)
+	if m.TopPos == 0 {
+		t.Fatal("selecting the last item did not scroll the submenu")
+	}
+}


### PR DESCRIPTION
Fixes menu overflow when a submenu has more items than the available terminal or GUI height.

The submenu now uses the existing VMenu scrolling viewport and scrollbar instead of extending below the screen. Added a regression test covering a 30-item submenu on a 10-row screen.

Tested on Linux ARM64:
`GOTMPDIR=/home/zoin/.cache/f4-go-tmp GOMAXPROCS=2 go test -p 1 ./...`