### PR TITLE
Render underline attributes in pixel backends

### DIFF
--- a/ebiten_renderer.go
+++ b/ebiten_renderer.go
@@ -204,6 +204,9 @@ func (r *EbitenRenderer) Render(buf, shadow []CharInfo, w, h int, forceRedraw bo
 					}
 					r.drawCachedGlyph(img, curr.Char, px, py, rw, fg, cbg)
 				}
+				if curr.Attributes&CommonLvbUnderscore != 0 {
+					drawUnderline(img, currX*r.cellW, y*r.cellH, r.cellW*rw, r.cellH, r.scale, fg)
+				}
 
 				if cursorVisible && y == r.cursorY && r.cursorX >= currX && r.cursorX < currX+rw {
 					r.invertCursor(img, currX*r.cellW, y*r.cellH, rw)

--- a/gogpu_renderer.go
+++ b/gogpu_renderer.go
@@ -742,6 +742,7 @@ func (r *GogpuRenderer) drawFrame(dc *gg.Context, w, h int) gogpuFrameStats {
 				}
 
 				char := CellBaseRune(currCell.Char)
+				underlined := currCell.Attributes&CommonLvbUnderscore != 0
 
 				if isBoxDrawRune(char) {
 					tBox := gogpuProfNow()
@@ -749,17 +750,23 @@ func (r *GogpuRenderer) drawFrame(dc *gg.Context, w, h int) gogpuFrameStats {
 					prof.boxTime += gogpuProfSince(tBox)
 					if drawn {
 						prof.boxChars++
+						if underlined {
+							drawGogpuUnderline(dc, lx+float64(sx*r.cellW), ly, float64(rw*r.cellW), float64(r.cellH), fg)
+						}
 						sx += rw
 						continue
 					}
 				}
 
 				if r.face == nil {
+					if underlined {
+						drawGogpuUnderline(dc, lx+float64(sx*r.cellW), ly, float64(rw*r.cellW), float64(r.cellH), fg)
+					}
 					sx += rw
 					continue
 				}
 
-				if !r.noBatch && gogpuBatchRune(currCell.Char) {
+				if !underlined && !r.noBatch && gogpuBatchRune(currCell.Char) {
 					tTxt := gogpuProfNow()
 					run, consumed, f, batched := r.gogpuTextRun(r.renderBuf, rowOff, x, sx, spanW, drawCols, curFace, r.textRunBuf[:0])
 					r.textRunBuf = run
@@ -788,6 +795,9 @@ func (r *GogpuRenderer) drawFrame(dc *gg.Context, w, h int) gogpuFrameStats {
 					prof.textTime += gogpuProfSince(tTxt)
 					prof.strings++
 					prof.glyphs += gogpuRuneCount(str)
+				}
+				if underlined {
+					drawGogpuUnderline(dc, lx+float64(sx*r.cellW), ly, float64(rw*r.cellW), float64(r.cellH), fg)
 				}
 				sx += rw
 			}
@@ -828,6 +838,15 @@ func (r *GogpuRenderer) drawFrame(dc *gg.Context, w, h int) gogpuFrameStats {
 		dc.Fill()
 	}
 	return prof
+}
+
+func drawGogpuUnderline(dc *gg.Context, x, y, width, height float64, fg color.RGBA) {
+	if width <= 0 || height <= 0 {
+		return
+	}
+	dc.SetColor(fg)
+	dc.DrawRectangle(x, y+height-1, width, 1)
+	dc.Fill()
 }
 
 func (r *GogpuRenderer) DrawToScreen(ctx *gogpu.Context) {

--- a/text_decorations.go
+++ b/text_decorations.go
@@ -1,0 +1,49 @@
+package vtui
+
+import (
+	"image"
+	"image/color"
+)
+
+// drawUnderline paints the CommonLvbUnderscore decoration used by terminal
+// and URL-hover rendering. Pixel backends do not pass ANSI attributes to a
+// terminal, so they must render this decoration themselves.
+func drawUnderline(img *image.RGBA, px, py, width, height, scale int, rgb uint32) {
+	if img == nil || width <= 0 || height <= 0 {
+		return
+	}
+	thickness := 1
+	if scale > 1 {
+		thickness = 2
+	}
+	if thickness > height {
+		thickness = height
+	}
+	y := py + height - thickness
+	if px < 0 {
+		width += px
+		px = 0
+	}
+	if y < 0 {
+		thickness += y
+		y = 0
+	}
+	if px+width > img.Rect.Dx() {
+		width = img.Rect.Dx() - px
+	}
+	if y+thickness > img.Rect.Dy() {
+		thickness = img.Rect.Dy() - y
+	}
+	if width <= 0 || thickness <= 0 {
+		return
+	}
+
+	col := color.RGBA{R: uint8(rgb >> 16), G: uint8(rgb >> 8), B: uint8(rgb), A: 255}
+	for row := y; row < y+thickness; row++ {
+		off := row*img.Stride + px*4
+		for x := 0; x < width; x++ {
+			p := off + x*4
+			img.Pix[p], img.Pix[p+1], img.Pix[p+2], img.Pix[p+3] = col.R, col.G, col.B, col.A
+		}
+	}
+}

--- a/text_decorations_test.go
+++ b/text_decorations_test.go
@@ -1,0 +1,39 @@
+package vtui
+
+import (
+	"image"
+	"testing"
+)
+
+func TestDrawUnderlineUsesForegroundOnBottomRows(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 8, 6))
+	drawUnderline(img, 2, 1, 4, 5, 1, 0x123456)
+
+	for y := 0; y < 6; y++ {
+		for x := 0; x < 8; x++ {
+			p := img.RGBAAt(x, y)
+			underlined := y == 5 && x >= 2 && x < 6
+			if underlined && (p.R != 0x12 || p.G != 0x34 || p.B != 0x56 || p.A != 0xff) {
+				t.Fatalf("pixel (%d,%d) = %#v, want underline colour", x, y, p)
+			}
+			if !underlined && p.A != 0 {
+				t.Fatalf("pixel (%d,%d) = %#v, want untouched pixel", x, y, p)
+			}
+		}
+	}
+}
+
+func TestDrawUnderlineScalesThickness(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 4, 6))
+	drawUnderline(img, 0, 0, 4, 6, 2, 0xffffff)
+	for y := 0; y < 4; y++ {
+		if img.RGBAAt(1, y).A != 0 {
+			t.Fatalf("row %d unexpectedly contains underline pixels", y)
+		}
+	}
+	for y := 4; y < 6; y++ {
+		if img.RGBAAt(1, y).A != 0xff {
+			t.Fatalf("row %d is missing scaled underline", y)
+		}
+	}
+}

--- a/wayland_renderer.go
+++ b/wayland_renderer.go
@@ -240,6 +240,9 @@ func (r *WaylandRenderer) Render(buf, shadow []CharInfo, w, h int, forceRedraw b
 						r.drawCachedGlyph(img, currCell.Char, cpx, py, rw, cfg, cbg, fgColor, bgColor)
 					}
 				}
+				if currCell.Attributes&CommonLvbUnderscore != 0 {
+					drawUnderline(img, cpx, py, cw*rw, ch, int(math.Ceil(r.host.scale)), cfg)
+				}
 
 				if cursorVisible && y == r.cursorY && r.cursorX >= currX && r.cursorX < currX+rw {
 					var startY int

--- a/x11_renderer.go
+++ b/x11_renderer.go
@@ -305,6 +305,9 @@ func (r *X11Renderer) Render(buf, shadow []CharInfo, w, h int, forceRedraw bool)
 						r.drawCachedGlyph(img, currCell.Char, cpx, py, rw, cfg, cbg, fgColor, bgColor)
 					}
 				}
+				if currCell.Attributes&CommonLvbUnderscore != 0 {
+					drawUnderline(img, cpx, py, cw*rw, ch, r.host.scale, cfg)
+				}
 
 				if cursorVisible && y == r.cursorY && r.cursorX >= currX && r.cursorX < currX+rw {
 					var startY int


### PR DESCRIPTION
## Summary

- render `CommonLvbUnderscore` in the X11, Wayland, Ebiten, and gogpu pixel backends
- keep the existing ANSI path unchanged
- add shared raster-decoration coverage, including HiDPI thickness

This fixes GUI consumers that already mark hovered URLs with `CommonLvbUnderscore`; URL detection and Ctrl+click behavior remain in f4.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- focused renderer and decoration tests
- no CGO or platform-specific dependency added