### PR TITLE
x11: preserve partial-cell margins after resize

### DIFF
--- a/ISSUE_283_SOLUTION_REVIEW.md
+++ b/ISSUE_283_SOLUTION_REVIEW.md
@@ -1,0 +1,57 @@
+# Issue 283 solution review
+
+## Symptom
+
+After an X11 GUI window is resized to dimensions that are not an exact
+multiple of the terminal cell size, stale pixels remain in the incomplete
+rightmost column and/or bottom row. The X11 host receives the real pixel
+dimensions, but the renderer replaces its image with a cell-aligned image and
+the subsequent `PutImage` covers only that smaller rectangle.
+
+## Candidate solutions
+
+1. **Keep the X11 image at the configured pixel dimensions (selected).**
+   The renderer will allocate an image matching `X11Host.width/height`, keep
+   the host dimensions unchanged, and continue to paint the cell grid inside
+   it. The unoccupied partial-cell margins stay cleared, and `flushImage`
+   uploads the complete configured surface.
+2. **Explicitly paint partial margins with a black rectangle.**
+   This would require special edge handling in every render path and would
+   still leave the X11 image/host dimensions inconsistent. Rejected as more
+   fragile and less general than preserving the actual surface size.
+3. **Resize the native X11 window down to the cell-aligned grid.**
+   This avoids margins but changes the user-requested window size and causes
+   resize feedback loops with the window manager. Rejected because incomplete
+   cells are a valid native window size and are expected to remain visible.
+
+## Three-pass review
+
+### Pass 1 — correctness
+
+The selected solution makes the image dimensions, dirty-line count, X11
+`PutImage` dimensions, and native window dimensions agree. A newly allocated
+image is zeroed, so pixels outside the cell grid cannot inherit data from the
+previous size. The cell renderer remains unchanged.
+
+### Pass 2 — regression surface
+
+Exact cell-aligned sizes still follow the same path. Non-aligned sizes now
+upload the partial margins as part of the same frame. Shared-memory uploads
+continue using the existing fixed segment; non-shared-memory uploads resize
+their conversion buffer with the image.
+
+### Pass 3 — portability and testability
+
+The change is isolated to the X11 backend and its platform-neutral unit tests.
+Wayland and gogpu are not modified. The regression test uses a fake host and
+checks both that the actual configured dimensions are preserved and that stale
+pixels in the partial margins are cleared.
+
+## Verification plan
+
+- Run the X11 renderer tests repeatedly, plus the full `vtui` test package and
+  `go vet`.
+- Build f4 against the updated local vtui module.
+- Launch f4 on this Linux ARM64 KDE Wayland machine through XWayland with
+  `--gui=x11`, resize to non-cell-aligned dimensions, and inspect the partial
+  right/bottom margins for stale pixels.

--- a/x11_host_test.go
+++ b/x11_host_test.go
@@ -1,6 +1,7 @@
 package vtui
 
 import (
+	"image"
 	"io"
 	"testing"
 	"time"
@@ -88,6 +89,51 @@ func TestX11Host_DirtySpanLogic(t *testing.T) {
 	}
 	if maxY != 51 {
 		t.Errorf("Expected maxY 51, got %d", maxY)
+	}
+}
+
+func TestX11RendererKeepsPartialWindowMarginsCleared(t *testing.T) {
+	const (
+		windowWidth  = 13
+		windowHeight = 7
+		cellWidth    = 5
+		cellHeight   = 3
+	)
+
+	host := &X11Host{
+		width:  windowWidth,
+		height: windowHeight,
+		cellW:  cellWidth,
+		cellH:  cellHeight,
+		// Simulate the cell-aligned backing image from the previous configure.
+		imgBuf:     image.NewRGBA(image.Rect(0, 0, 2*cellWidth, 2*cellHeight)),
+		dirtyLines: make([]bool, windowHeight),
+	}
+	for i := range host.imgBuf.Pix {
+		host.imgBuf.Pix[i] = 0xcc
+	}
+
+	renderer := NewX11Renderer(host, nil)
+	buf := make([]CharInfo, 2*2)
+	renderer.Render(buf, make([]CharInfo, len(buf)), 2, 2, true)
+
+	if got := host.imgBuf.Bounds().Size(); got.X != windowWidth || got.Y != windowHeight {
+		t.Fatalf("backing image size = %v, want %dx%d", got, windowWidth, windowHeight)
+	}
+	if host.width != windowWidth || host.height != windowHeight {
+		t.Fatalf("host window size changed to %dx%d, want %dx%d", host.width, host.height, windowWidth, windowHeight)
+	}
+
+	for y := 0; y < windowHeight; y++ {
+		for x := 0; x < windowWidth; x++ {
+			if x < 2*cellWidth && y < 2*cellHeight {
+				continue
+			}
+			r, g, b, _ := host.imgBuf.At(x, y).RGBA()
+			if r != 0 || g != 0 || b != 0 {
+				t.Fatalf("stale pixel at (%d,%d) = #%02x%02x%02x", x, y, r>>8, g>>8, b>>8)
+			}
+		}
 	}
 }
 

--- a/x11_renderer.go
+++ b/x11_renderer.go
@@ -189,18 +189,25 @@ func (r *X11Renderer) Render(buf, shadow []CharInfo, w, h int, forceRedraw bool)
 
 	cursorVisible := r.cursorVis && r.blinkState
 
-	reqWidth := uint16(w * r.host.cellW)
-	reqHeight := uint16(h * r.host.cellH)
-	if r.host.imgBuf == nil || uint16(r.host.imgBuf.Bounds().Dx()) != reqWidth || uint16(r.host.imgBuf.Bounds().Dy()) != reqHeight {
-		r.host.width = reqWidth
-		r.host.height = reqHeight
-		r.host.cols = w
-		r.host.rows = h
-		r.host.imgBuf = image.NewRGBA(image.Rect(0, 0, int(reqWidth), int(reqHeight)))
+	// Keep the backing image at the native window size, not at the nearest
+	// cell-aligned size. X11 configure events may describe a window with a
+	// partial cell at the right or bottom edge. If the image were truncated to
+	// w*cellW by h*cellH, PutImage would leave the old pixels in those partial
+	// margins visible after a resize.
+	windowWidth := int(r.host.width)
+	windowHeight := int(r.host.height)
+	if windowWidth <= 0 {
+		windowWidth = w * r.host.cellW
+	}
+	if windowHeight <= 0 {
+		windowHeight = h * r.host.cellH
+	}
+	if r.host.imgBuf == nil || r.host.imgBuf.Bounds().Dx() != windowWidth || r.host.imgBuf.Bounds().Dy() != windowHeight {
+		r.host.imgBuf = image.NewRGBA(image.Rect(0, 0, windowWidth, windowHeight))
 		if r.host.shmSeg == 0 {
 			r.host.bgraBuf = make([]byte, len(r.host.imgBuf.Pix))
 		}
-		r.host.dirtyLines = make([]bool, int(reqHeight))
+		r.host.dirtyLines = make([]bool, windowHeight)
 		for i := range r.host.dirtyLines {
 			r.host.dirtyLines[i] = true
 		}


### PR DESCRIPTION
## Summary

- keep the X11 backing image at the native window pixel dimensions after a configure event
- upload the complete surface so right/bottom partial-cell margins cannot retain pixels from the previous size
- add a regression test for stale pixels in non-cell-aligned margins
- document the three considered solutions and verification plan in `ISSUE_283_SOLUTION_REVIEW.md`

## Validation

- `go test . -count=1`
- `go test -race -p 1 . -run 'TestX11' -count=1`
- `go vet ./...`
- built f4 against this local vtui checkout
- real XWayland run resized repeatedly to `1301x803`, `1179x733`, and `1237x791`; captured window margins were clean black pixels rather than stale content
