### PR TITLE
Keep Indic conjuncts atomic in bidi editing

### DIFF
--- a/bidi.go
+++ b/bidi.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/rivo/uniseg"
 	"golang.org/x/text/unicode/bidi"
 )
 
@@ -66,17 +65,9 @@ func VisualStringWithMap(s string) (string, []int) {
 	}
 
 	var logicalClusters []logicalCluster
-	runeIdx := 0
-	g := uniseg.NewGraphemes(s)
-	for g.Next() {
-		from, to := g.Positions()
-		logicalClusters = append(logicalClusters, logicalCluster{
-			text:    s[from:to],
-			byteOff: from,
-			runeIdx: runeIdx,
-		})
-		runeIdx += utf8.RuneCountInString(s[from:to])
-	}
+	forEachTerminalClusterRaw(s, func(text string, byteOff, runeIdx int) {
+		logicalClusters = append(logicalClusters, logicalCluster{text: text, byteOff: byteOff, runeIdx: runeIdx})
+	})
 
 	p := bidi.Paragraph{}
 	_, err := p.SetString(s)
@@ -129,11 +120,9 @@ func VisualStringWithMap(s string) (string, []int) {
 
 func trivialMap(s string) []int {
 	var offsets []int
-	g := uniseg.NewGraphemes(s)
-	for g.Next() {
-		from, _ := g.Positions()
-		offsets = append(offsets, from)
-	}
+	forEachTerminalClusterRaw(s, func(_ string, offset, _ int) {
+		offsets = append(offsets, offset)
+	})
 	return offsets
 }
 
@@ -150,16 +139,9 @@ func VisualStringWithRuneMap(s string) (string, []int) {
 	}
 
 	var logicalClusters []logicalCluster
-	runeIdx := 0
-	g := uniseg.NewGraphemes(s)
-	for g.Next() {
-		from, to := g.Positions()
-		logicalClusters = append(logicalClusters, logicalCluster{
-			text:    s[from:to],
-			runeIdx: runeIdx,
-		})
-		runeIdx += utf8.RuneCountInString(s[from:to])
-	}
+	forEachTerminalClusterRaw(s, func(text string, _, runeIdx int) {
+		logicalClusters = append(logicalClusters, logicalCluster{text: text, runeIdx: runeIdx})
+	})
 
 	p := bidi.Paragraph{}
 	_, err := p.SetString(s)
@@ -212,13 +194,9 @@ func VisualStringWithRuneMap(s string) (string, []int) {
 
 func trivialRuneMap(s string) []int {
 	var indices []int
-	runeIdx := 0
-	g := uniseg.NewGraphemes(s)
-	for g.Next() {
-		from, to := g.Positions()
+	forEachTerminalClusterRaw(s, func(_ string, _, runeIdx int) {
 		indices = append(indices, runeIdx)
-		runeIdx += utf8.RuneCountInString(s[from:to])
-	}
+	})
 	return indices
 }
 
@@ -234,17 +212,10 @@ type bidiClusterInfo struct {
 
 func BuildCaretMap(s string) CaretMap {
 	var logicalClusters []bidiClusterInfo
-	runeIdx := 0
-	g := uniseg.NewGraphemes(s)
-	for g.Next() {
-		from, to := g.Positions()
-		logicalClusters = append(logicalClusters, bidiClusterInfo{
-			logicalIdx: len(logicalClusters),
-			runeIdx:    runeIdx,
-		})
-		runeIdx += utf8.RuneCountInString(s[from:to])
-	}
-	totalRunes := runeIdx
+	forEachTerminalClusterRaw(s, func(_ string, _, runeIdx int) {
+		logicalClusters = append(logicalClusters, bidiClusterInfo{logicalIdx: len(logicalClusters), runeIdx: runeIdx})
+	})
+	totalRunes := utf8.RuneCountInString(s)
 	N := len(logicalClusters)
 
 	p := bidi.Paragraph{}

--- a/edit.go
+++ b/edit.go
@@ -4,7 +4,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/rivo/uniseg"
 	"github.com/unxed/vtinput"
 	"golang.org/x/text/unicode/bidi"
 )
@@ -99,26 +98,21 @@ func (e *Edit) Show(scr *ScreenBuf) {
 		}
 		vis, _ := VisualStringWithRuneMap(string(e.text))
 		width := 0
-		g := uniseg.NewGraphemes(vis)
 		vIdx := 0
-		for g.Next() {
-			from, to := g.Positions()
+		forEachTerminalCluster(vis, func(_ string, w, _, _ int) {
 			if vIdx >= e.leftPos && vIdx < vPos {
-				width += ClusterWidth(vis[from:to])
+				width += w
 			}
 			vIdx++
-		}
+		})
 		for e.leftPos < vPos && width >= visibleWidth {
-			g2 := uniseg.NewGraphemes(vis)
 			vIdx2 := 0
-			for g2.Next() {
-				from, to := g2.Positions()
+			forEachTerminalCluster(vis, func(_ string, w, _, _ int) {
 				if vIdx2 == e.leftPos {
-					width -= ClusterWidth(vis[from:to])
-					break
+					width -= w
 				}
 				vIdx2++
-			}
+			})
 			e.leftPos++
 		}
 	} else {
@@ -159,19 +153,16 @@ func (e *Edit) Show(scr *ScreenBuf) {
 			cmap := e.caretMap()
 			vPos := cmap.LogicalToVisual[e.curPos]
 			vis, _ := VisualStringWithRuneMap(string(e.text))
-			g := uniseg.NewGraphemes(vis)
 			vIdx := 0
-			for g.Next() {
+			forEachTerminalCluster(vis, func(_ string, w, _, _ int) {
 				if vIdx >= vPos {
-					break
+					return
 				}
-				from, to := g.Positions()
-				w := ClusterWidth(vis[from:to])
 				if vIdx >= e.leftPos {
 					vOffset += w
 				}
 				vIdx++
-			}
+			})
 		} else {
 			headText := string(e.text[e.leftPos:e.curPos])
 			vOffset = StringWidth(headText)
@@ -227,16 +218,13 @@ func (e *Edit) DisplayObject(scr *ScreenBuf) {
 	type logicalCluster struct {
 		text    string
 		runeIdx int
+		width   int
 		attr    uint64
 	}
 
 	var logicalClusters []logicalCluster
-	runeIdx := 0
 	sText := string(e.text)
-	g := uniseg.NewGraphemes(sText)
-	for g.Next() {
-		from, to := g.Positions()
-		clText := sText[from:to]
+	forEachTerminalCluster(sText, func(clText string, width, _, runeIdx int) {
 
 		attr := defaultAttr
 		if e.selStart != -1 && runeIdx >= e.selStart && runeIdx < e.selEnd {
@@ -253,10 +241,10 @@ func (e *Edit) DisplayObject(scr *ScreenBuf) {
 		logicalClusters = append(logicalClusters, logicalCluster{
 			text:    clText,
 			runeIdx: runeIdx,
+			width:   width,
 			attr:    attr,
 		})
-		runeIdx += utf8.RuneCountInString(clText)
-	}
+	})
 
 	var visualClusters []logicalCluster
 	s := string(e.text)
@@ -305,7 +293,7 @@ func (e *Edit) DisplayObject(scr *ScreenBuf) {
 		if i < e.leftPos {
 			continue
 		}
-		w := ClusterWidth(c.text)
+		w := c.width
 		if currX+w > visibleWidth {
 			break
 		}
@@ -1250,23 +1238,20 @@ func (e *Edit) cursorPositionAtX(x int) int {
 	if DefaultBidiMode == BidiFull {
 		cmap := e.caretMap()
 		vis, _ := VisualStringWithRuneMap(string(e.text))
-		g := uniseg.NewGraphemes(vis)
 		vIdx := 0
-		for g.Next() {
+		forEachTerminalCluster(vis, func(_ string, w, _, _ int) {
 			if found || vIdx < e.leftPos {
 				vIdx++
-				continue
+				return
 			}
-			from, to := g.Positions()
-			w := ClusterWidth(vis[from:to])
 			if currX+w > column {
 				result = cmap.VisualToLogical[vIdx]
 				found = true
-				break
+				return
 			}
 			currX += w
 			vIdx++
-		}
+		})
 		if !found {
 			result = cmap.VisualToLogical[vIdx]
 		}

--- a/highlight.go
+++ b/highlight.go
@@ -3,7 +3,6 @@ package vtui
 import (
 	"unicode/utf8"
 
-	"github.com/rivo/uniseg"
 	"golang.org/x/text/unicode/bidi"
 )
 
@@ -33,15 +32,12 @@ func StringToCharInfoWithAttrs(s string, attrs []uint64, baseAttr uint64) []Char
 	type logicalCluster struct {
 		text    string
 		runeIdx int
+		width   int
 		attr    uint64
 	}
 
 	var logicalClusters []logicalCluster
-	runeIdx := 0
-	g := uniseg.NewGraphemes(s)
-	for g.Next() {
-		from, to := g.Positions()
-		clText := s[from:to]
+	forEachTerminalCluster(s, func(clText string, width, _, runeIdx int) {
 		attr := baseAttr
 		if runeIdx >= 0 && runeIdx < len(attrs) {
 			attr = attrs[runeIdx]
@@ -49,17 +45,17 @@ func StringToCharInfoWithAttrs(s string, attrs []uint64, baseAttr uint64) []Char
 		logicalClusters = append(logicalClusters, logicalCluster{
 			text:    clText,
 			runeIdx: runeIdx,
+			width:   width,
 			attr:    attr,
 		})
-		runeIdx += utf8.RuneCountInString(clText)
-	}
+	})
 
 	p := bidi.Paragraph{}
 	_, err := p.SetString(s)
 	if err != nil {
 		res := make([]CharInfo, 0, len(s))
 		for _, c := range logicalClusters {
-			res = AppendCluster(res, c.text, ClusterWidth(c.text), c.attr)
+			res = AppendCluster(res, c.text, c.width, c.attr)
 		}
 		return res
 	}
@@ -67,7 +63,7 @@ func StringToCharInfoWithAttrs(s string, attrs []uint64, baseAttr uint64) []Char
 	if err != nil {
 		res := make([]CharInfo, 0, len(s))
 		for _, c := range logicalClusters {
-			res = AppendCluster(res, c.text, ClusterWidth(c.text), c.attr)
+			res = AppendCluster(res, c.text, c.width, c.attr)
 		}
 		return res
 	}
@@ -98,7 +94,7 @@ func StringToCharInfoWithAttrs(s string, attrs []uint64, baseAttr uint64) []Char
 		}
 
 		for _, c := range runClusters {
-			res = AppendCluster(res, c.text, ClusterWidth(c.text), c.attr)
+			res = AppendCluster(res, c.text, c.width, c.attr)
 		}
 	}
 

--- a/multilineedit.go
+++ b/multilineedit.go
@@ -163,7 +163,7 @@ type multiLineCluster struct {
 func logicalClusters(runes []rune) []multiLineCluster {
 	text := string(runes)
 	clusters := make([]multiLineCluster, 0, len(runes))
-	ForEachClusterAt(text, func(cluster string, width, _, runeIndex int) {
+	forEachTerminalCluster(text, func(cluster string, width, _, runeIndex int) {
 		clusters = append(clusters, multiLineCluster{
 			text:       cluster,
 			width:      width,
@@ -190,7 +190,7 @@ func visualClusters(runes []rune) []multiLineCluster {
 	visualText, logicalPositions := VisualStringWithRuneMap(string(runes))
 	visual := make([]multiLineCluster, 0, len(logical))
 	index := 0
-	ForEachClusterAt(visualText, func(cluster string, width, _, _ int) {
+	forEachTerminalCluster(visualText, func(cluster string, width, _, _ int) {
 		if index >= len(logicalPositions) {
 			return
 		}
@@ -814,7 +814,7 @@ func previousClusterBoundary(line []rune, pos int) int {
 		return 0
 	}
 	previous := 0
-	ForEachClusterAt(string(line), func(_ string, _, _ int, runeIndex int) {
+	forEachTerminalCluster(string(line), func(_ string, _, _ int, runeIndex int) {
 		if runeIndex < pos {
 			previous = runeIndex
 		}
@@ -825,7 +825,7 @@ func previousClusterBoundary(line []rune, pos int) int {
 func nextClusterBoundary(line []rune, pos int) int {
 	next := len(line)
 	found := false
-	ForEachClusterAt(string(line), func(_ string, _, _ int, runeIndex int) {
+	forEachTerminalCluster(string(line), func(_ string, _, _ int, runeIndex int) {
 		if !found && runeIndex > pos {
 			next = runeIndex
 			found = true

--- a/runewidth.go
+++ b/runewidth.go
@@ -1,7 +1,6 @@
 package vtui
 
 import (
-	"github.com/rivo/uniseg"
 	"golang.org/x/text/unicode/bidi"
 	"strings"
 	"unicode"
@@ -87,15 +86,12 @@ func StringToCharInfoHighlighted(s string, normalAttr, highAttr uint64) ([]CharI
 	type logicalCluster struct {
 		text    string
 		runeIdx int
+		width   int
 		attr    uint64
 	}
 
 	var logicalClusters []logicalCluster
-	runeIdx := 0
-	g := uniseg.NewGraphemes(clean)
-	for g.Next() {
-		from, to := g.Positions()
-		clText := clean[from:to]
+	forEachTerminalCluster(clean, func(clText string, width, _, runeIdx int) {
 		attr := normalAttr
 		if hkPos >= runeIdx && hkPos < runeIdx+utf8.RuneCountInString(clText) {
 			attr = highAttr
@@ -103,17 +99,17 @@ func StringToCharInfoHighlighted(s string, normalAttr, highAttr uint64) ([]CharI
 		logicalClusters = append(logicalClusters, logicalCluster{
 			text:    clText,
 			runeIdx: runeIdx,
+			width:   width,
 			attr:    attr,
 		})
-		runeIdx += utf8.RuneCountInString(clText)
-	}
+	})
 
 	p := bidi.Paragraph{}
 	_, err := p.SetString(clean)
 	if err != nil {
 		res := make([]CharInfo, 0, len(clean))
 		for _, c := range logicalClusters {
-			res = AppendCluster(res, c.text, ClusterWidth(c.text), c.attr)
+			res = AppendCluster(res, c.text, c.width, c.attr)
 		}
 		return res, hk
 	}
@@ -121,7 +117,7 @@ func StringToCharInfoHighlighted(s string, normalAttr, highAttr uint64) ([]CharI
 	if err != nil {
 		res := make([]CharInfo, 0, len(clean))
 		for _, c := range logicalClusters {
-			res = AppendCluster(res, c.text, ClusterWidth(c.text), c.attr)
+			res = AppendCluster(res, c.text, c.width, c.attr)
 		}
 		return res, hk
 	}
@@ -152,7 +148,7 @@ func StringToCharInfoHighlighted(s string, normalAttr, highAttr uint64) ([]CharI
 		}
 
 		for _, c := range runClusters {
-			res = AppendCluster(res, c.text, ClusterWidth(c.text), c.attr)
+			res = AppendCluster(res, c.text, c.width, c.attr)
 		}
 	}
 

--- a/textseg.go
+++ b/textseg.go
@@ -543,6 +543,107 @@ func ForEachClusterAt(s string, fn func(cluster string, width, offset, runeIndex
 	forEachClusterUniseg(s, fn)
 }
 
+// forEachTerminalCluster walks the clusters that the terminal treats as one
+// cell-level editing and rendering unit. Unicode grapheme tables used by
+// older terminal stacks can split an Indic virama from the following
+// consonant, even though the shaping engine renders the pair as one glyph.
+// Keep that virama-consonant join in the same path used by editors, bidi, and
+// screen rendering so a caret can never land in the middle of a shaped unit.
+func forEachTerminalCluster(s string, fn func(cluster string, width, offset, runeIndex int)) {
+	var previous string
+	previousOffset, previousRuneIndex := 0, 0
+	havePrevious := false
+	emit := func() {
+		if !havePrevious {
+			return
+		}
+		cluster, width := SanitizeCluster(previous)
+		if width > 0 {
+			fn(cluster, ClusterWidth(cluster), previousOffset, previousRuneIndex)
+		}
+	}
+
+	runeIndex := 0
+	g := uniseg.NewGraphemes(s)
+	for g.Next() {
+		from, to := g.Positions()
+		current := s[from:to]
+		if havePrevious && endsInIndicVirama(previous) && startsWithLetter(current) {
+			previous += current
+		} else {
+			emit()
+			previous = current
+			previousOffset, previousRuneIndex = from, runeIndex
+			havePrevious = true
+		}
+		runeIndex += utf8.RuneCountInString(current)
+	}
+	emit()
+}
+
+func forEachTerminalClusterRaw(s string, fn func(cluster string, offset, runeIndex int)) {
+	var previous string
+	previousOffset, previousRuneIndex := 0, 0
+	havePrevious := false
+	emit := func() {
+		if havePrevious {
+			fn(previous, previousOffset, previousRuneIndex)
+		}
+	}
+
+	runeIndex := 0
+	g := uniseg.NewGraphemes(s)
+	for g.Next() {
+		from, to := g.Positions()
+		current := s[from:to]
+		if havePrevious && endsInIndicVirama(previous) && startsWithLetter(current) {
+			previous += current
+		} else {
+			emit()
+			previous, previousOffset, previousRuneIndex = current, from, runeIndex
+			havePrevious = true
+		}
+		runeIndex += utf8.RuneCountInString(current)
+	}
+	emit()
+}
+
+func startsWithLetter(s string) bool {
+	r, _ := utf8.DecodeRuneInString(s)
+	return unicode.IsLetter(r)
+}
+
+func endsInIndicVirama(s string) bool {
+	r, _ := utf8.DecodeLastRuneInString(s)
+	switch r {
+	case
+		'\u094D',                     // Devanagari
+		'\u09CD',                     // Bengali
+		'\u0A4D',                     // Gurmukhi
+		'\u0ACD',                     // Gujarati
+		'\u0B4D',                     // Oriya
+		'\u0BCD',                     // Tamil
+		'\u0C4D',                     // Telugu
+		'\u0CCD',                     // Kannada
+		'\u0D3B', '\u0D3C', '\u0D4D', // Malayalam
+		'\u0DCA', // Sinhala
+		'\u1039', // Myanmar
+		'\u1714', // Tagalog
+		'\u17D2', // Khmer
+		'\u1A60', // Tai Tham
+		'\u1BAA', // Sundanese
+		'\uA806', // Syloti Nagri
+		'\uA8C4', // Saurashtra
+		'\uA953', // Rejang
+		'\uA9C0', // Javanese
+		'\uAAF6', // Meetei Mayek
+		'\uABED': // Meetei Mayek
+		return true
+	default:
+		return false
+	}
+}
+
 // AppendCluster puts a cluster into a cell slice, following it with as many
 // fillers as the extra columns it claims.
 func AppendCluster(target []CharInfo, cluster string, width int, attr uint64) []CharInfo {

--- a/textseg_test.go
+++ b/textseg_test.go
@@ -216,6 +216,48 @@ func TestStringToCharInfo_Devanagari(t *testing.T) {
 	}
 }
 
+func TestTerminalClustersKeepIndicConjunctsAtomic(t *testing.T) {
+	var got []string
+	var widths []int
+	forEachTerminalCluster("संस्कृतम्", func(cluster string, width, _, _ int) {
+		got = append(got, cluster)
+		widths = append(widths, width)
+	})
+	want := []string{"सं", "स्कृ", "त", "म्"}
+	if len(got) != len(want) {
+		t.Fatalf("terminal clusters = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] || widths[i] != 1 {
+			t.Errorf("cluster %d = %q width %d, want %q width 1", i, got[i], widths[i], want[i])
+		}
+	}
+}
+
+func TestBidiMapsUseTerminalClusterBoundaries(t *testing.T) {
+	oldMode := DefaultBidiMode
+	DefaultBidiMode = BidiFull
+	t.Cleanup(func() { DefaultBidiMode = oldMode })
+
+	text := "संस्कृतम् ދިވެހިބަސް"
+	_, runeMap := VisualStringWithRuneMap(text)
+	var clusters int
+	forEachTerminalCluster(text, func(string, int, int, int) { clusters++ })
+	if len(runeMap) != clusters {
+		t.Fatalf("bidi rune map has %d entries for %d terminal clusters", len(runeMap), clusters)
+	}
+	seen := make(map[int]bool, len(runeMap))
+	for _, runeIndex := range runeMap {
+		if seen[runeIndex] {
+			t.Fatalf("bidi rune map repeats logical cluster at rune %d: %v", runeIndex, runeMap)
+		}
+		seen[runeIndex] = true
+	}
+	if len(seen) != clusters {
+		t.Fatalf("bidi rune map covers %d clusters, want %d", len(seen), clusters)
+	}
+}
+
 func TestStringToCharInfo_BengaliShaping(t *testing.T) {
 	ci := StringToCharInfo("বাংলা", 0)
 	if len(ci) != 2 {


### PR DESCRIPTION
## Summary

- keep Indic virama-consonant conjuncts atomic in terminal editing and bidi maps
- make `Edit`, `MultiLineEdit`, highlighting, and truncation use the same terminal cluster boundaries
- preserve the existing public UAX grapheme/cell-width path
- add regression coverage for Devanagari conjuncts and mixed bidi text

This is the shared dependency fix for unxed/f4#546.

## Verification

- `GOTMPDIR=/home/zoin/.cache/f4-546-go-tmp GOMAXPROCS=2 go test -p 1 .`
- `GOTMPDIR=/home/zoin/.cache/f4-546-go-tmp GOMAXPROCS=2 go vet .`
