### PR TITLE
fix: preserve ctrl word navigation in bidi edit fields

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -579,7 +579,9 @@ func (e *Edit) ProcessKey(event *vtinput.InputEvent) bool {
 		fullSelectionAtEnd := e.selStart == 0 && e.selEnd == len(e.text) && e.curPos == len(e.text)
 		isAtStart := false
 		var cmap CaretMap
-		if DefaultBidiMode == BidiFull {
+		// Keep Ctrl+Left/Right on the logical word-navigation path; see the
+		// corresponding branch above.
+		if DefaultBidiMode == BidiFull && !ctrl {
 			cmap = e.caretMap()
 			isAtStart = cmap.LogicalToVisual[e.curPos] == 0
 		} else {
@@ -597,7 +599,10 @@ func (e *Edit) ProcessKey(event *vtinput.InputEvent) bool {
 			e.selAnchor = -1
 		}
 
-		if DefaultBidiMode == BidiFull {
+		// Plain arrows follow visual caret order in full bidi mode. Word
+		// navigation is a logical-text operation, so Ctrl+Left/Right must
+		// stay on the branch below even when full bidi input is enabled.
+		if DefaultBidiMode == BidiFull && !ctrl {
 			vPos := cmap.LogicalToVisual[e.curPos]
 			if vPos > 0 {
 				vPos--
@@ -641,7 +646,7 @@ func (e *Edit) ProcessKey(event *vtinput.InputEvent) bool {
 	case vtinput.VK_RIGHT:
 		isAtEnd := false
 		var cmap CaretMap
-		if DefaultBidiMode == BidiFull {
+		if DefaultBidiMode == BidiFull && !ctrl {
 			cmap = e.caretMap()
 			isAtEnd = cmap.LogicalToVisual[e.curPos] == len(cmap.VisualToLogical)-1
 		} else {
@@ -667,7 +672,7 @@ func (e *Edit) ProcessKey(event *vtinput.InputEvent) bool {
 			e.selAnchor = -1
 		}
 
-		if DefaultBidiMode == BidiFull {
+		if DefaultBidiMode == BidiFull && !ctrl {
 			vPos := cmap.LogicalToVisual[e.curPos]
 			N := len(cmap.VisualToLogical) - 1
 			if vPos < N {

--- a/edit_test.go
+++ b/edit_test.go
@@ -643,6 +643,36 @@ func TestEdit_WordSelection_FarSpec(t *testing.T) {
 	}
 }
 
+func TestEdit_WordSelection_BidiFullKeepsCtrlWordNavigation(t *testing.T) {
+	oldMode := DefaultBidiMode
+	DefaultBidiMode = BidiFull
+	defer func() { DefaultBidiMode = oldMode }()
+
+	left := NewEdit(0, 0, 100, "select this word")
+	left.ClearSelection()
+	left.curPos = len(left.text)
+	left.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_LEFT,
+		ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed,
+	})
+	if left.selStart != 12 || left.selEnd != 16 {
+		t.Fatalf("BidiFull Ctrl+Shift+Left selected [%d:%d], want [12:16]", left.selStart, left.selEnd)
+	}
+
+	right := NewEdit(0, 0, 100, "select this word")
+	right.ClearSelection()
+	right.curPos = 0
+	right.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_RIGHT,
+		ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed,
+	})
+	if right.selStart != 0 || right.selEnd != 7 {
+		t.Fatalf("BidiFull Ctrl+Shift+Right selected [%d:%d], want [0:7]", right.selStart, right.selEnd)
+	}
+}
+
 func TestEdit_WordSelection_FromFullValuePreservesWholeWord(t *testing.T) {
 	SetDefaultPalette()
 


### PR DESCRIPTION
## Summary
- keep Ctrl+Left/Right on logical word navigation when full bidi mode is enabled
- preserve visual navigation for plain Left/Right arrows
- add regression coverage for Ctrl+Shift+Left/Right word selection

This fixes the shared `vtui.Edit` behavior used by f4 command-line and dialog input fields (f4 issue #787).

Tested with `go test ./...` on Linux aarch64.