### PR TITLE
Make exact table search match whole cells

### DIFF
--- a/table.go
+++ b/table.go
@@ -418,7 +418,7 @@ func (t *Table) applySearchFilter() {
 	if t.SearchExactOnHit {
 		hasExact := false
 		for _, m := range t.matchBuf {
-			if m.score == 0 {
+			if t.rowHasExactSearchHit(m.idx, string(t.searchRunes)) {
 				hasExact = true
 				break
 			}
@@ -426,7 +426,7 @@ func (t *Table) applySearchFilter() {
 		if hasExact {
 			write := 0
 			for _, m := range t.matchBuf {
-				if m.score == 0 {
+				if t.rowHasExactSearchHit(m.idx, string(t.searchRunes)) {
 					t.matchBuf[write] = m
 					write++
 				}
@@ -452,6 +452,26 @@ func (t *Table) applySearchFilter() {
 	for i, m := range t.matchBuf {
 		t.order[i] = m.idx
 	}
+}
+
+func (t *Table) rowHasExactSearchHit(row int, query string) bool {
+	for col := range t.Columns {
+		cellText := ""
+		if t.cellProvider != nil {
+			cellText = t.cellProvider.GetCellText(row, col)
+		} else if t.rowProvider != nil {
+			cells := t.rowProvider.Row(row)
+			if col < len(cells) {
+				cellText = cells[col]
+			}
+		} else if row >= 0 && row < len(t.Rows) {
+			cellText = t.Rows[row].GetCellText(col)
+		}
+		if strings.EqualFold(cellText, query) {
+			return true
+		}
+	}
+	return false
 }
 
 // SearchText returns the current QuickSearch string.

--- a/table_test.go
+++ b/table_test.go
@@ -898,6 +898,7 @@ func TestTable_QuickSearchExactOnHit(t *testing.T) {
 	tbl.SetRows([]TableRow{
 		mockRow{"CtrlUp", ""},
 		mockRow{"CtrlA", ""},
+		mockRow{"CtrlAltA", ""},
 		mockRow{"CtrlPgUp", ""},
 	})
 


### PR DESCRIPTION
## Summary

- make SearchExactOnHit retain only rows whose full cell equals the query;
- keep fuzzy matches when no full-cell exact hit exists;
- extend the regression test so CtrlA does not incorrectly keep the CtrlAltA prefix match.

## Validation

- go test . -run TestTable_QuickSearchExactOnHit -count=1 -v
- go vet -unsafeptr=false ./...

The full Windows test suite is currently blocked by two unrelated existing environment failures: the Python bindings test cannot find Python (exit 9009), and the existing Win32 drag/drop test expects copy|move for effect 3 while this host reports copy.

— zoin-bot