### PR TITLE
fix(win32): forward double-click mouse events

### DIFF
--- a/win32_gui_windows.go
+++ b/win32_gui_windows.go
@@ -702,6 +702,35 @@ func (h *Win32GuiHost) handleMessage(hwnd syscall.Handle, msg uint32, wParam, lP
 		})
 		return 0
 
+	case wmLButtonDblClk, wmRButtonDblClk, wmMButtonDblClk:
+		x := int16(int32(int16(lParam & 0xFFFF)))
+		y := int16(int32(int16((lParam >> 16) & 0xFFFF)))
+		cellX := int16(int(x) / h.cellW)
+		cellY := int16(int(y) / h.cellH)
+		var btn uint32
+		switch msg {
+		case wmLButtonDblClk:
+			btn = uint32(vtinput.FromLeft1stButtonPressed)
+		case wmRButtonDblClk:
+			btn = uint32(vtinput.RightmostButtonPressed)
+		case wmMButtonDblClk:
+			btn = uint32(vtinput.FromLeft2ndButtonPressed)
+		}
+		h.mu.Lock()
+		h.mouseBtn |= btn
+		currBtn := h.mouseBtn
+		h.mu.Unlock()
+		h.sendEvent(&vtinput.InputEvent{
+			Type:            vtinput.MouseEventType,
+			MouseX:          cellX,
+			MouseY:          cellY,
+			KeyDown:         true,
+			ButtonState:     currBtn,
+			MouseEventFlags: vtinput.DoubleClick,
+			ControlKeyState: h.getModifiers(),
+		})
+		return 0
+
 	case wmMouseMove:
 		x := int16(int32(int16(lParam & 0xFFFF)))
 		y := int16(int32(int16((lParam >> 16) & 0xFFFF)))


### PR DESCRIPTION
## Summary
Double-click was broken under the Win32 backend.

## Problem
The window is created with `CS_DBLCLKS`, so Windows sends `WM_*BUTTONDBLCLK`
instead of a second `WM_*BUTTONDOWN` when the user double-clicks. The message
handler had no case for those messages, so the second press was dropped. A
consumer counting presses needed three physical clicks to see two, and one
keying off `vtinput.DoubleClick` never saw the flag at all.

## Fix
- Added a `case wmLButtonDblClk, wmRButtonDblClk, wmMButtonDblClk:` to
  `handleMessage` in `win32_gui_windows.go`.
- It emits a `MouseEventType` event with `KeyDown: true`, the correct
  `ButtonState`, and `MouseEventFlags: vtinput.DoubleClick`.
- `mouseBtn` is updated (`|= btn`) so the subsequent `UP` still releases it.

## Testing
- `go build ./...` on `windows` (amd64/arm64) -- OK.
- Verified in f4 (Win32 backend): a left double-click now triggers the
  double-click action (e.g. Command Palette item open) on the second click.