### PR TITLE
table, autocomplete: rework QuickSearch ranking and layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bindings/c/build
 bindings/cpp/build
 afix.ap
 afailed.*
+test-app.exe

--- a/autocomplete.go
+++ b/autocomplete.go
@@ -1,6 +1,7 @@
 package vtui
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/mattn/go-runewidth"
@@ -88,7 +89,7 @@ func NewAutoCompleteMenu(edit *Edit) *AutoCompleteMenu {
 
 	ac.lb = NewListBox(0, 0, 10, 10, nil)
 	ac.lb.ColorTextIdx = ColDialogText
-	ac.lb.ColorSelectedTextIdx = ColDialogSelectedButton
+	ac.lb.ColorSelectedTextIdx = ColMenuBarSelected
 	ac.lb.ShowScrollBar = true
 	ac.lb.IsSelectable = func(i int) bool {
 		return i >= 0 && i < len(ac.items) && !ac.items[i].Separator
@@ -249,21 +250,49 @@ func (ac *AutoCompleteMenu) UpdateMatches() {
 	}
 	pathCount := len(ac.items)
 
-	// Legacy history: case-insensitive prefix match, deduplicated.
+	// Legacy history: matched by the fuzzy matcher, deduplicated. Ranking
+	// (highest first): exact match (score remapped to -1), prefix, substring
+	// (the further left, the better), everything else by ascending score —
+	// a plain (score, match start) ordering implements all of it.
 	text := ac.Edit.GetText()
 	if text != "" {
-		textLower := strings.ToLower(text)
-		needleEnd := len([]rune(text)) - 1
+		matcher := NewFuzzyMatcher(text, false)
 		seen := make(map[string]bool)
+		type histMatch struct {
+			text       string
+			score      int
+			start, end int
+		}
+
+		var hist []histMatch
 		for _, h := range ac.Edit.History {
-			if !strings.HasPrefix(strings.ToLower(h), textLower) || seen[h] {
+			if seen[h] {
+				continue
+			}
+			score, start, end, ok := matcher.Match(h)
+			if !ok {
 				continue
 			}
 			seen[h] = true
-			if pathCount > 0 && len(ac.items) == pathCount {
+			if matcher.IsMatchExact() {
+				score = -1 // exact match always wins sort
+			}
+			hist = append(hist, histMatch{h, score, start, end})
+		}
+
+		sort.SliceStable(hist, func(a, b int) bool {
+			if hist[a].score != hist[b].score {
+				return hist[a].score < hist[b].score
+			}
+
+			return hist[a].start < hist[b].start
+		})
+
+		for i, hm := range hist {
+			if pathCount > 0 && i == 0 {
 				ac.items = append(ac.items, AutoCompleteItem{Separator: true, MatchStart: -1, MatchEnd: -1})
 			}
-			ac.items = append(ac.items, AutoCompleteItem{Text: h, MatchStart: 0, MatchEnd: needleEnd})
+			ac.items = append(ac.items, AutoCompleteItem{Text: hm.text, MatchStart: hm.start, MatchEnd: hm.end})
 		}
 	}
 

--- a/autocomplete_test.go
+++ b/autocomplete_test.go
@@ -54,6 +54,29 @@ func TestAutoComplete_Matching(t *testing.T) {
 	}
 }
 
+func TestAutoComplete_MatchRanking(t *testing.T) {
+	SetDefaultPalette()
+	edit := NewEdit(0, 0, 20, "git")
+	edit.History = []string{
+		"got",        // fuzzy: 1 error (k = 1)
+		"a git x",    // substring at 2
+		"git status", // prefix
+		"git",        // exact, must win despite being last in history
+	}
+
+	ac := NewAutoCompleteMenu(edit)
+
+	want := []string{"git", "git status", "a git x", "got"}
+	if len(ac.Matches) != len(want) {
+		t.Fatalf("expected %d matches, got %d: %v", len(want), len(ac.Matches), ac.Matches)
+	}
+	for i := range want {
+		if ac.Matches[i] != want[i] {
+			t.Errorf("match %d: expected %q, got %q (all: %v)", i, want[i], ac.Matches[i], ac.Matches)
+		}
+	}
+}
+
 func TestAutoComplete_TabCompletion(t *testing.T) {
 	SetDefaultPalette()
 	FrameManager.Init(NewSilentScreenBuf())

--- a/autocomplete_trigger_test.go
+++ b/autocomplete_trigger_test.go
@@ -54,8 +54,10 @@ func TestAutoComplete_OpensOnTypingInHistoryField(t *testing.T) {
 	if got := edit.GetText(); got != "git c" {
 		t.Fatalf("typing did not reach the edit: text is %q", got)
 	}
-	if len(ac.Matches) != 1 || ac.Matches[0] != "git commit" {
-		t.Errorf("menu did not filter down while typing: %v", ac.Matches)
+	// Fuzzy matching keeps "git status" (1 error, k = 1) as a tail result,
+	// but the prefix match must rank first.
+	if len(ac.Matches) != 2 || ac.Matches[0] != "git commit" || ac.Matches[1] != "git status" {
+		t.Errorf("menu did not rank matches while typing: %v", ac.Matches)
 	}
 }
 

--- a/fuzzy.go
+++ b/fuzzy.go
@@ -6,45 +6,63 @@ import (
 	"unicode/utf8"
 )
 
-// fuzzyMatcher implements approximate substring search using Myers'
+// FuzzyMatcher implements approximate substring search using Myers'
 // bit-vector algorithm. For needles of up to 64 runes the edit distance is
-// computed in O(len(text)) bit-parallel operations over a single uint64.
+// computed in O(len(haystack)) bit-parallel operations over a single uint64.
 // Longer needles degrade to exact substring search.
 //
 // The matcher reports the best (lowest) edit distance between the needle and
-// any substring of the text, plus the starting position of that match.
+// any substring of the haystack, plus the starting position of that match.
 // Case-insensitive matching is done by indexing both cases of every needle
-// character, so the text is looked up as-is.
-type fuzzyMatcher struct {
-	m int // needle length in runes
-	k int // max edit distance accepted as a match
+// character, so the haystack is looked up as-is.
+//
+// Canonical ranking of match results (guideline for all search UIs, highest
+// priority first):
+//  1. exact match — needle equals the whole haystack, score remapped to -1;
+//  2. prefix match (score 0, start 0);
+//  3. substring match (score 0) — the further left, the better;
+//  4. everything else by ascending score.
+//
+// Sorting by (score, match start) with the exact-match remap implements the
+// whole list. The exact-match test is matcher.IsMatchExact(), called right
+// after matcher.Match(haystack).
+type FuzzyMatcher struct {
+	needleLen   int // needle length in runes
+	maxDistance int // max edit distance accepted as a match
 
 	needle        string
 	caseSensitive bool
 
 	ascii    bool
-	peqAscii [256]uint64     // L1-resident fast path for ASCII needles and texts
-	peqRune  map[rune]uint64 // built lazily on the first non-ASCII text
+	peqAscii [256]uint64     // L1-resident fast path for ASCII needles and haystacks
+	peqRune  map[rune]uint64 // built lazily on the first non-ASCII haystack
 
 	exactOnly  bool   // needle longer than 64 runes
 	needleFold string // needle (folded in case-insensitive mode) for exactOnly
 	fold       bool   // fold the haystack too (case-insensitive exactOnly)
 
-	rev *fuzzyMatcher // lazy reversed-needle matcher used to locate match starts
+	rev *FuzzyMatcher // lazy reversed-needle matcher used to locate match starts
+
+	// last match results, consulted by IsMatchExact; haystackLen is refreshed
+	// only when an exact hit is possible (score == 0 && start == 0), because
+	// IsMatchExact short-circuits on score and start first
+	score, start, end, haystackLen int
 }
 
-// newFuzzyMatcher builds a matcher for the given needle. It returns nil for
+// NewFuzzyMatcher builds a matcher for the given needle. It returns nil for
 // an empty needle. The acceptance threshold is len(needle)/3 errors: exact
 // substring matches always pass (score 0), short needles stay almost strict,
-// longer ones tolerate more typos.
-func newFuzzyMatcher(needle string, caseSensitive bool) *fuzzyMatcher {
+// longer ones tolerate more typos. Construction precomputes the needle tables
+// once; Match is then linear in the haystack length per candidate.
+func NewFuzzyMatcher(needle string, caseSensitive bool) *FuzzyMatcher {
 	if needle == "" {
 		return nil
 	}
-	fm := &fuzzyMatcher{m: utf8.RuneCountInString(needle), needle: needle, caseSensitive: caseSensitive}
-	fm.k = fm.m / 3
 
-	if fm.m > 64 {
+	fm := &FuzzyMatcher{needleLen: utf8.RuneCountInString(needle), needle: needle, caseSensitive: caseSensitive}
+	fm.maxDistance = fm.needleLen / 3
+
+	if fm.needleLen > 64 {
 		fm.exactOnly = true
 		fm.fold = !caseSensitive
 		if caseSensitive {
@@ -71,14 +89,15 @@ func newFuzzyMatcher(needle string, caseSensitive bool) *fuzzyMatcher {
 	} else {
 		fm.buildRuneTable()
 	}
+
 	return fm
 }
 
 // buildRuneTable populates the Unicode peq table. For ASCII needles it is
-// built lazily on the first non-ASCII text, so the common all-ASCII case
+// built lazily on the first non-ASCII haystack, so the common all-ASCII case
 // never pays for the map.
-func (fm *fuzzyMatcher) buildRuneTable() {
-	fm.peqRune = make(map[rune]uint64, fm.m)
+func (fm *FuzzyMatcher) buildRuneTable() {
+	fm.peqRune = make(map[rune]uint64, fm.needleLen)
 	i := 0
 	for _, r := range fm.needle {
 		bit := uint64(1) << uint(i)
@@ -91,110 +110,136 @@ func (fm *fuzzyMatcher) buildRuneTable() {
 	}
 }
 
-// match searches the needle inside text. It returns the best edit distance,
-// the starting position (in runes) of the best matching substring, and
-// whether the distance is within the acceptance threshold.
-// match searches the needle inside text. It returns the best edit distance,
-// the span [start, end] (inclusive, in runes) of the best matching substring,
-// and whether the distance is within the acceptance threshold.
-func (fm *fuzzyMatcher) match(text string) (score, start, end int, ok bool) {
+// Match searches the needle inside haystack. It returns the best edit
+// distance, the span [start, end] (inclusive, in runes) of the best matching
+// substring, and whether the distance is within the acceptance threshold.
+// The results are also stored in the matcher for IsMatchExact.
+func (fm *FuzzyMatcher) Match(haystack string) (score, start, end int, ok bool) {
 	if fm.exactOnly {
-		hay := text
+		folded := haystack
 		if fm.fold {
-			hay = strings.ToLower(text)
+			folded = strings.ToLower(haystack)
 		}
-		idx := strings.Index(hay, fm.needleFold)
+
+		idx := strings.Index(folded, fm.needleFold)
 		if idx < 0 {
+			// Keep the stored state a definite non-match for IsMatchExact.
+			fm.score, fm.start, fm.end = fm.needleLen, 0, 0
 			return 0, 0, 0, false
 		}
-		start = utf8.RuneCountInString(text[:idx])
-		return 0, start, start + fm.m - 1, true
+
+		start = utf8.RuneCountInString(haystack[:idx])
+		fm.score, fm.start, fm.end = 0, start, start+fm.needleLen-1
+		if start == 0 {
+			fm.haystackLen = utf8.RuneCountInString(haystack)
+		}
+		return 0, start, start + fm.needleLen - 1, true
 	}
-	if fm.ascii && isASCIIString(text) {
-		score, end = fm.matchASCII(text)
+
+	if fm.ascii && isASCIIString(haystack) {
+		score, end = fm.matchASCII(haystack)
 	} else {
 		if fm.peqRune == nil {
 			fm.buildRuneTable()
 		}
-		score, end = fm.matchRunes(text)
+
+		score, end = fm.matchRunes(haystack)
 	}
-	score = clampScore(score, fm.m)
+
+	score = clampScore(score, fm.needleLen)
 	if score == 0 {
-		// An exact match spans exactly m runes.
-		start = end - fm.m + 1
+		// An exact match spans exactly needleLen runes.
+		start = end - fm.needleLen + 1
 	} else {
-		start = fm.findStart(text, end)
+		start = fm.findStart(haystack, end)
 	}
+
 	if start < 0 {
 		start = 0
 	}
-	return score, start, end, score <= fm.k
+
+	fm.score = score
+	fm.start = start
+	fm.end = end
+	if score == 0 && start == 0 {
+		fm.haystackLen = utf8.RuneCountInString(haystack)
+	}
+
+	return score, start, end, score <= fm.maxDistance
 }
 
 // findStart locates the beginning of the best fuzzy match ending at end
 // (rune index). It runs a second bit-vector pass with the reversed needle
-// over the reversed text prefix; edit distance is symmetric under reversal,
-// so the reverse pass reproduces the same score and its end position maps
-// back to the start of the forward match. Only used for inexact matches, so
-// it runs at most once per matched row per filter rebuild — never in the
-// render hot path.
-func (fm *fuzzyMatcher) findStart(text string, end int) int {
+// over the reversed haystack prefix; edit distance is symmetric under
+// reversal, so the reverse pass reproduces the same score and its end
+// position maps back to the start of the forward match. Only used for
+// inexact matches, so it runs at most once per matched row per filter
+// rebuild — never in the render hot path.
+func (fm *FuzzyMatcher) findStart(haystack string, end int) int {
 	rev := fm.reverseMatcher()
 
-	runes := []rune(text)
+	runes := []rune(haystack)
 	if end+1 < len(runes) {
 		runes = runes[:end+1]
 	}
+
 	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
 		runes[i], runes[j] = runes[j], runes[i]
 	}
+
 	if rev.peqRune == nil {
 		rev.buildRuneTable()
 	}
+
 	_, revEnd := rev.matchRunes(string(runes))
 	return end - revEnd
 }
 
 // reverseMatcher lazily builds the matcher for the reversed needle.
-func (fm *fuzzyMatcher) reverseMatcher() *fuzzyMatcher {
+func (fm *FuzzyMatcher) reverseMatcher() *FuzzyMatcher {
 	if fm.rev == nil {
 		r := []rune(fm.needle)
 		for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
 			r[i], r[j] = r[j], r[i]
 		}
-		fm.rev = newFuzzyMatcher(string(r), fm.caseSensitive)
+		fm.rev = NewFuzzyMatcher(string(r), fm.caseSensitive)
 	}
+
 	return fm.rev
 }
 
-// matchASCII runs the bit-vector scan over bytes; text must be pure ASCII,
-// so byte positions equal rune positions. Returns the best score and the
-// end position of the best match.
-func (fm *fuzzyMatcher) matchASCII(s string) (bestScore, bestEnd int) {
-	m := fm.m
-	top := uint64(1) << uint(m-1)
+// matchASCII runs the bit-vector scan over bytes; haystack must be pure
+// ASCII, so byte positions equal rune positions. Returns the best score and
+// the end position of the best match.
+func (fm *FuzzyMatcher) matchASCII(haystack string) (bestScore, bestEnd int) {
+	needleLen := fm.needleLen
+	top := uint64(1) << uint(needleLen-1)
 	pv := ^uint64(0)
 	mv := uint64(0)
-	score := m
-	bestScore = m + 1
+	score := needleLen
+	bestScore = needleLen + 1
 	bestEnd = 0
-	for j := 0; j < len(s); j++ {
-		eq := fm.peqAscii[s[j]]
+
+	for j := 0; j < len(haystack); j++ {
+		eq := fm.peqAscii[haystack[j]]
 		xv := eq | mv
 		xh := (((eq & pv) + pv) ^ pv) | eq
 		ph := mv | ^(xh | pv)
 		mh := pv & xh
+
 		if ph&top != 0 {
 			score++
 		} else if mh&top != 0 {
 			score--
 		}
+
 		// Substring search: D[0][j] = 0, so the horizontal delta injected
 		// into row 0 is 0 and both vectors shift in a zero bit.
 		ph <<= 1
 		mh <<= 1
 		pv = mh | ^(xv | ph)
 		mv = ph & xv
+
 		if score < bestScore {
 			bestScore = score
 			bestEnd = j
@@ -211,30 +256,34 @@ func (fm *fuzzyMatcher) matchASCII(s string) (bestScore, bestEnd int) {
 }
 
 // matchRunes is the Unicode fallback of the same algorithm.
-func (fm *fuzzyMatcher) matchRunes(s string) (bestScore, bestEnd int) {
-	m := fm.m
-	top := uint64(1) << uint(m-1)
+func (fm *FuzzyMatcher) matchRunes(haystack string) (bestScore, bestEnd int) {
+	needleLen := fm.needleLen
+	top := uint64(1) << uint(needleLen-1)
 	pv := ^uint64(0)
 	mv := uint64(0)
-	score := m
-	bestScore = m + 1
+	score := needleLen
+	bestScore = needleLen + 1
 	bestEnd = 0
 	j := 0
-	for _, r := range s {
+
+	for _, r := range haystack {
 		eq := fm.peqRune[r]
 		xv := eq | mv
 		xh := (((eq & pv) + pv) ^ pv) | eq
 		ph := mv | ^(xh | pv)
 		mh := pv & xh
+
 		if ph&top != 0 {
 			score++
 		} else if mh&top != 0 {
 			score--
 		}
+
 		ph <<= 1
 		mh <<= 1
 		pv = mh | ^(xv | ph)
 		mv = ph & xv
+
 		if score < bestScore {
 			bestScore = score
 			bestEnd = j
@@ -244,48 +293,34 @@ func (fm *fuzzyMatcher) matchRunes(s string) (bestScore, bestEnd int) {
 		} else if score == bestScore {
 			bestEnd = j // see matchASCII: latest end gives the fullest span
 		}
+
 		j++
 	}
+
 	return bestScore, bestEnd
+}
+
+// IsMatchExact reports whether the last Match call found the needle equal to
+// the whole haystack (the canonical exact-hit test of the ranking guideline
+// above).
+func (fm *FuzzyMatcher) IsMatchExact() bool {
+	return fm.score == 0 && fm.start == 0 && fm.haystackLen == fm.needleLen
 }
 
 // clampScore converts the "no text scanned" sentinel into the real distance
 // (needle length: deleting the whole needle matches the empty substring).
-func clampScore(bestScore, m int) int {
-	if bestScore > m {
-		return m
+func clampScore(bestScore, needleLen int) int {
+	if bestScore > needleLen {
+		return needleLen
 	}
 	return bestScore
 }
 
-func isASCIIString(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] >= 0x80 {
+func isASCIIString(str string) bool {
+	for i := 0; i < len(str); i++ {
+		if str[i] >= 0x80 {
 			return false
 		}
 	}
 	return true
-}
-
-// FuzzyMatcher is the exported handle over the Myers bit-vector matcher for
-// applications embedding vtui (Table.QuickSearch uses the unexported one).
-// Construction precomputes the needle tables once; Match is then linear in
-// the text length per candidate.
-type FuzzyMatcher struct{ fm *fuzzyMatcher }
-
-// NewFuzzyMatcher builds a matcher for needle, or nil for an empty needle.
-// The acceptance threshold is len(needle)/3 errors: exact substring matches
-// always pass, longer needles tolerate more typos.
-func NewFuzzyMatcher(needle string, caseSensitive bool) *FuzzyMatcher {
-	if fm := newFuzzyMatcher(needle, caseSensitive); fm != nil {
-		return &FuzzyMatcher{fm: fm}
-	}
-	return nil
-}
-
-// Match reports the best match of the needle inside text: the edit distance
-// score and the matched span as rune indices, end inclusive. ok is false
-// when the best distance exceeds the acceptance threshold.
-func (m *FuzzyMatcher) Match(text string) (score, start, end int, ok bool) {
-	return m.fm.match(text)
 }

--- a/fuzzy_test.go
+++ b/fuzzy_test.go
@@ -79,8 +79,8 @@ func TestFuzzyMatcher_AgainstReference(t *testing.T) {
 			copy(text[start:start+m], needle)
 		}
 
-		fm := newFuzzyMatcher(string(needle), true)
-		score, pos, _, _ := fm.match(string(text))
+		fm := NewFuzzyMatcher(string(needle), true)
+		score, pos, _, _ := fm.Match(string(text))
 		wantScore, wantEnd := refSubstringMatch(string(needle), string(text), false)
 		wantPos := wantEnd - m + 1
 		if wantPos < 0 {
@@ -111,8 +111,8 @@ func TestFuzzyMatcher_Unicode(t *testing.T) {
 			text[i] = alphabet[rng.Intn(len(alphabet))]
 		}
 
-		fm := newFuzzyMatcher(string(needle), true)
-		score, _, _, _ := fm.match(string(text))
+		fm := NewFuzzyMatcher(string(needle), true)
+		score, _, _, _ := fm.Match(string(text))
 		wantScore, _ := refSubstringMatch(string(needle), string(text), false)
 		if score != wantScore {
 			t.Errorf("needle=%q text=%q: score %d, want %d", string(needle), string(text), score, wantScore)
@@ -136,8 +136,8 @@ func TestFuzzyMatcher_CaseInsensitive(t *testing.T) {
 			text[i] = alphabet[rng.Intn(len(alphabet))]
 		}
 
-		fm := newFuzzyMatcher(string(needle), false)
-		score, _, _, _ := fm.match(string(text))
+		fm := NewFuzzyMatcher(string(needle), false)
+		score, _, _, _ := fm.Match(string(text))
 		wantScore, _ := refSubstringMatch(string(needle), string(text), true)
 		if score != wantScore {
 			t.Errorf("needle=%q text=%q: folded score %d, want %d", string(needle), string(text), score, wantScore)
@@ -147,33 +147,33 @@ func TestFuzzyMatcher_CaseInsensitive(t *testing.T) {
 
 func TestFuzzyMatcher_Threshold(t *testing.T) {
 	// k = len/3: needle of 3..5 runes allows 1 error.
-	fm := newFuzzyMatcher("abc", true)
-	if fm.k != 1 {
-		t.Fatalf("expected k=1, got %d", fm.k)
+	fm := NewFuzzyMatcher("abc", true)
+	if fm.maxDistance != 1 {
+		t.Fatalf("expected k=1, got %d", fm.maxDistance)
 	}
-	if _, _, _, ok := fm.match("xxabcxx"); !ok {
+	if _, _, _, ok := fm.Match("xxabcxx"); !ok {
 		t.Error("exact substring must pass")
 	}
-	if _, _, _, ok := fm.match("xxabdxx"); !ok {
+	if _, _, _, ok := fm.Match("xxabdxx"); !ok {
 		t.Error("one error must pass for k=1")
 	}
-	if _, _, _, ok := fm.match("xxaexx"); ok {
+	if _, _, _, ok := fm.Match("xxaexx"); ok {
 		t.Error("two errors must not pass for k=1")
 	}
 
 	// Needles of 1-2 runes are exact-only (k=0).
-	fm = newFuzzyMatcher("ab", true)
-	if _, _, _, ok := fm.match("ac"); ok {
+	fm = NewFuzzyMatcher("ab", true)
+	if _, _, _, ok := fm.Match("ac"); ok {
 		t.Error("k=0 must reject any error")
 	}
-	if _, _, _, ok := fm.match("xxabyy"); !ok {
+	if _, _, _, ok := fm.Match("xxabyy"); !ok {
 		t.Error("k=0 must accept exact substring")
 	}
 }
 
 func TestFuzzyMatcher_ExactPosition(t *testing.T) {
-	fm := newFuzzyMatcher("needle", true)
-	score, pos, _, ok := fm.match("find the needle here")
+	fm := NewFuzzyMatcher("needle", true)
+	score, pos, _, ok := fm.Match("find the needle here")
 	if !ok || score != 0 {
 		t.Fatalf("expected exact match, score=%d ok=%v", score, ok)
 	}
@@ -184,31 +184,78 @@ func TestFuzzyMatcher_ExactPosition(t *testing.T) {
 
 func TestFuzzyMatcher_LongNeedleExactOnly(t *testing.T) {
 	needle := strings.Repeat("a", 70)
-	fm := newFuzzyMatcher(needle, true)
+	fm := NewFuzzyMatcher(needle, true)
 	if !fm.exactOnly {
 		t.Fatal("needle > 64 runes must degrade to exact search")
 	}
-	if _, _, _, ok := fm.match("xx" + needle + "yy"); !ok {
+	if _, _, _, ok := fm.Match("xx" + needle + "yy"); !ok {
 		t.Error("exact long needle must match")
 	}
-	if _, _, _, ok := fm.match(strings.Repeat("a", 69)); ok {
+	if _, _, _, ok := fm.Match(strings.Repeat("a", 69)); ok {
 		t.Error("one error must not pass in exactOnly mode")
 	}
 
 	// Case-insensitive long needle.
-	fm = newFuzzyMatcher(strings.Repeat("Ab", 35), false)
-	if _, pos, _, ok := fm.match("zz" + strings.Repeat("aB", 35) + "zz"); !ok || pos != 2 {
+	fm = NewFuzzyMatcher(strings.Repeat("Ab", 35), false)
+	if _, pos, _, ok := fm.Match("zz" + strings.Repeat("aB", 35) + "zz"); !ok || pos != 2 {
 		t.Errorf("case-insensitive exactOnly failed: ok=%v pos=%d", ok, pos)
 	}
 }
 
+func TestFuzzyMatcher_IsMatchExact(t *testing.T) {
+	fm := NewFuzzyMatcher("abc", false)
+
+	if _, _, _, ok := fm.Match("abc"); !ok || !fm.IsMatchExact() {
+		t.Error("full equality must be exact")
+	}
+	if _, _, _, ok := fm.Match("ABC"); !ok || !fm.IsMatchExact() {
+		t.Error("case-folded full equality must be exact for a case-insensitive matcher")
+	}
+	if _, _, _, ok := fm.Match("abcd"); !ok || fm.IsMatchExact() {
+		t.Error("prefix-only match must not be exact")
+	}
+	if _, _, _, ok := fm.Match("xabc"); !ok || fm.IsMatchExact() {
+		t.Error("substring match must not be exact")
+	}
+	if _, _, _, ok := fm.Match("abd"); !ok || fm.IsMatchExact() {
+		t.Error("inexact fuzzy match must not be exact")
+	}
+}
+
+func TestFuzzyMatcher_IsMatchExactExactOnly(t *testing.T) {
+	needle := strings.Repeat("a", 70)
+	fm := NewFuzzyMatcher(needle, true)
+
+	// A failed match must reset the stored state: an equal-length haystack
+	// that does not contain the needle is not an exact hit.
+	if _, _, _, ok := fm.Match(strings.Repeat("b", 70)); ok {
+		t.Fatal("no match expected")
+	}
+	if fm.IsMatchExact() {
+		t.Error("failed exactOnly match must not report exact")
+	}
+
+	// A longer haystack starting with the needle is a prefix, not exact.
+	if _, _, _, ok := fm.Match(needle + "x"); !ok {
+		t.Fatal("expected match")
+	}
+	if fm.IsMatchExact() {
+		t.Error("prefix match in exactOnly mode must not be exact")
+	}
+
+	// Full equality is exact.
+	if _, _, _, ok := fm.Match(needle); !ok || !fm.IsMatchExact() {
+		t.Error("full equality in exactOnly mode must be exact")
+	}
+}
+
 func TestFuzzyMatcher_Empty(t *testing.T) {
-	if fm := newFuzzyMatcher("", true); fm != nil {
+	if fm := NewFuzzyMatcher("", true); fm != nil {
 		t.Error("empty needle must produce nil matcher")
 	}
 
-	fm := newFuzzyMatcher("abc", true)
-	score, _, _, ok := fm.match("")
+	fm := NewFuzzyMatcher("abc", true)
+	score, _, _, ok := fm.Match("")
 	if ok {
 		t.Error("empty text must not match a non-empty needle")
 	}
@@ -219,8 +266,8 @@ func TestFuzzyMatcher_Empty(t *testing.T) {
 
 func TestFuzzyMatcher_RunePositions(t *testing.T) {
 	// Position must be in runes even for the Unicode path.
-	fm := newFuzzyMatcher("game", true)
-	_, pos, _, ok := fm.match("моя game")
+	fm := NewFuzzyMatcher("game", true)
+	_, pos, _, ok := fm.Match("моя game")
 	if !ok {
 		t.Fatal("expected match")
 	}

--- a/layout_validator.go
+++ b/layout_validator.go
@@ -201,14 +201,6 @@ func ValidateLayoutWithRules(c Container, rules LayoutRules) []error {
 				continue
 			}
 
-			// Horizontal proximity: mandatory 1 cell air for non-decorative items
-			if gapX == 0 && gapY <= 0 && !isDecorative(item) && !isDecorative(other) {
-				errs = append(errs, LayoutError{
-					Element1: item, Element2: other,
-					Message: fmt.Sprintf("Elements [%s] and [%s] are too close horizontally (need 1 cell air)", id, oid),
-				})
-			}
-
 			// Vertical proximity: Buttons must always have air
 			if gapY == 0 && gapX <= 0 {
 				isBtn := func(el UIElement) bool { _, b := el.(*Button); return b }

--- a/layout_validator_test.go
+++ b/layout_validator_test.go
@@ -45,25 +45,6 @@ func TestLayoutValidator_Logic(t *testing.T) {
 		}
 	})
 
-	t.Run("Glued elements (horizontal air required)", func(t *testing.T) {
-		dlg := NewDialog(0, 0, 30, 20, "Test")
-		b1 := NewButton(2, 2, "B1") // x1:2, x2:7
-		b2 := NewButton(8, 2, "B2") // x1:8, touching b1 horizontally
-		dlg.AddItem(b1)
-		dlg.AddItem(b2)
-
-		errs := ValidateLayout(dlg)
-		found := false
-		for _, e := range errs {
-			if strings.Contains(e.Error(), "horizontally") {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("Failed to detect horizontal air violation")
-		}
-	})
-
 	t.Run("Compact TUI (vertical touch allowed for labels)", func(t *testing.T) {
 		dlg := NewDialog(0, 0, 30, 20, "Test")
 		l1 := NewText(2, 2, "Line 1", 0)

--- a/table.go
+++ b/table.go
@@ -97,10 +97,11 @@ type Table struct {
 	SortCompare   func(a, b TableRow, col int) int
 
 	// QuickSearch enables type-to-filter: while the table is focused,
-	// printable characters go into a search string shown in a line below the
-	// table, and rows are filtered by fuzzy match (Myers' bit-vector
+	// printable characters go into a search string shown in a line above the
+	// table header, and rows are filtered by fuzzy match (Myers' bit-vector
 	// algorithm) against all columns, best match wins. The filtered list is
-	// ranked by (edit distance, match position). Default is false.
+	// ranked by (edit distance, match position), best match at the top —
+	// closest to the search line. Default is false.
 	QuickSearch bool
 	// SearchCaseSensitive makes QuickSearch case-sensitive (default false).
 	SearchCaseSensitive bool
@@ -116,6 +117,9 @@ type Table struct {
 	ColorItemSelectCursorIdx int
 	ColorTitleIdx            int
 	ColorBoxIdx              int
+	// ColorHighlightIdx is the QuickSearch match highlight; applied last, on
+	// top of every other cell color. Defaults to ColMenuHighlight.
+	ColorHighlightIdx int
 
 	// colWidths caches the resolved column widths (flexible columns expanded);
 	// reused across frames to avoid allocations in the render hot path.
@@ -159,6 +163,7 @@ func NewTable(x, y, w, h int, columns []TableColumn) *Table {
 		ColorItemSelectCursorIdx: ColTableSelectedText,
 		ColorTitleIdx:            ColTableColumnTitle,
 		ColorBoxIdx:              ColTableBox,
+		ColorHighlightIdx:        ColMenuHighlight,
 		SortColumn:               -1,
 	}
 	t.canFocus = true
@@ -358,6 +363,9 @@ func (t *Table) resort() {
 
 	if len(t.searchRunes) > 0 {
 		t.ItemCount = len(t.order)
+		// While a query is being typed, keep the focus on the most
+		// relevant row (the top one, right below the search line).
+		t.SelectPos = 0
 	} else {
 		t.ItemCount = n
 	}
@@ -374,25 +382,33 @@ func (t *Table) resort() {
 // match across all columns wins) and ranks them by (distance, position).
 // The matched cell span is remembered per row for needle highlighting.
 func (t *Table) applySearchFilter() {
-	matcher := newFuzzyMatcher(string(t.searchRunes), t.SearchCaseSensitive)
+	matcher := NewFuzzyMatcher(string(t.searchRunes), t.SearchCaseSensitive)
 	t.matchBuf = t.matchBuf[:0]
 	rowCount := len(t.Rows)
+
 	if t.cellProvider != nil {
 		rowCount = t.cellProvider.RowCount()
 	} else if t.rowProvider != nil {
 		rowCount = t.rowProvider.RowCount()
 	}
+
 	if cap(t.matchSpans) < rowCount {
 		t.matchSpans = make([]cellHighlight, rowCount)
 	} else {
 		t.matchSpans = t.matchSpans[:rowCount]
 	}
+
 	for i := range t.matchSpans {
 		t.matchSpans[i].col = -1
 	}
+
+	hasExact := false
+
 	for i := 0; i < rowCount; i++ {
 		bestScore := -1
 		bestStart, bestEnd, bestCol := 0, 0, 0
+		exactHit := false
+
 		for col := range t.Columns {
 			cellText := ""
 			if t.cellProvider != nil {
@@ -405,35 +421,37 @@ func (t *Table) applySearchFilter() {
 			} else {
 				cellText = t.Rows[i].GetCellText(col)
 			}
-			score, start, end, ok := matcher.match(cellText)
+
+			score, start, end, ok := matcher.Match(cellText)
 			if ok && (bestScore < 0 || score < bestScore || (score == bestScore && start < bestStart)) {
 				bestScore, bestStart, bestEnd, bestCol = score, start, end, col
 			}
+
+			exactHit = exactHit || matcher.IsMatchExact()
 		}
+
 		if bestScore >= 0 {
+			if exactHit {
+				bestScore = -1 // exact match always wins sort
+				hasExact = true
+			}
 			t.matchBuf = append(t.matchBuf, searchMatch{i, bestScore, bestStart})
 			t.matchSpans[i] = cellHighlight{bestCol, bestStart, bestEnd}
 		}
 	}
-	if t.SearchExactOnHit {
-		hasExact := false
+
+	if t.SearchExactOnHit && hasExact {
+		// Exact matches exist: drop rows with a greater distance as irrelevant.
+		write := 0
 		for _, m := range t.matchBuf {
-			if t.rowHasExactSearchHit(m.idx, string(t.searchRunes)) {
-				hasExact = true
-				break
+			if m.score == -1 {
+				t.matchBuf[write] = m
+				write++
 			}
 		}
-		if hasExact {
-			write := 0
-			for _, m := range t.matchBuf {
-				if t.rowHasExactSearchHit(m.idx, string(t.searchRunes)) {
-					t.matchBuf[write] = m
-					write++
-				}
-			}
-			t.matchBuf = t.matchBuf[:write]
-		}
+		t.matchBuf = t.matchBuf[:write]
 	}
+
 	sort.Slice(t.matchBuf, func(a, b int) bool {
 		ma, mb := t.matchBuf[a], t.matchBuf[b]
 		if ma.score != mb.score {
@@ -444,34 +462,16 @@ func (t *Table) applySearchFilter() {
 		}
 		return ma.idx < mb.idx
 	})
+
 	if cap(t.order) < len(t.matchBuf) {
 		t.order = make([]int, len(t.matchBuf))
 	} else {
 		t.order = t.order[:len(t.matchBuf)]
 	}
+
 	for i, m := range t.matchBuf {
 		t.order[i] = m.idx
 	}
-}
-
-func (t *Table) rowHasExactSearchHit(row int, query string) bool {
-	for col := range t.Columns {
-		cellText := ""
-		if t.cellProvider != nil {
-			cellText = t.cellProvider.GetCellText(row, col)
-		} else if t.rowProvider != nil {
-			cells := t.rowProvider.Row(row)
-			if col < len(cells) {
-				cellText = cells[col]
-			}
-		} else if row >= 0 && row < len(t.Rows) {
-			cellText = t.Rows[row].GetCellText(col)
-		}
-		if strings.EqualFold(cellText, query) {
-			return true
-		}
-	}
-	return false
 }
 
 // SearchText returns the current QuickSearch string.
@@ -537,28 +537,29 @@ func (t *Table) DisplayObject(scr *ScreenBuf) {
 
 	yOffset := 0
 
-	// 1. Draw Header
-	widths := t.resolvedWidths()
-	if t.ShowHeader {
-		t.drawRow(scr, t.Y1, -1, -1, Palette[t.ColorTitleIdx], widths)
+	// 1. Draw the QuickSearch line above everything else
+	if t.QuickSearch {
+		t.drawSearchLine(scr)
 		yOffset++
 	}
 
-	// 2. Draw Data Rows (ViewHeight already excludes header and search line).
-	// While a search is active, results are shown bottom-up (best match right
-	// above the search line), telescope-style.
+	// 2. Draw Header
+	widths := t.resolvedWidths()
+	if t.ShowHeader {
+		t.drawRow(scr, t.Y1+yOffset, -1, -1, Palette[t.ColorTitleIdx], widths)
+		yOffset++
+	}
+
+	// 3. Draw Data Rows (ViewHeight already excludes header and search line).
+	// Search results rank top-down: the best match sits right below the
+	// header, closest to the search line.
 	dataHeight := t.ViewHeight
 	if dataHeight < 0 {
 		dataHeight = 0
 	}
-	bottomUp := len(t.searchRunes) > 0
-	dataBottom := t.Y1 + yOffset + dataHeight - 1
 	for i := 0; i < dataHeight; i++ {
 		displayPos := t.TopPos + i
 		currY := t.Y1 + yOffset + i
-		if bottomUp {
-			currY = dataBottom - i
-		}
 
 		if displayPos < t.ItemCount {
 			rowIdx := t.rowAt(displayPos)
@@ -572,26 +573,24 @@ func (t *Table) DisplayObject(scr *ScreenBuf) {
 		}
 	}
 
-	// 3. Draw Vertical Separators if needed
+	// 4. Draw Vertical Separators if needed
 	if t.ShowSeparators {
 		p := NewPainter(scr)
 		currX := t.X1
-		sepChar := boxSymbols[bsV]     // │
-		sepY2 := t.Y2 - t.MarginBottom // do not cross the search line
+		sepChar := boxSymbols[bsV] // │
+		sepY1 := t.Y1
+		if t.QuickSearch {
+			sepY1++ // do not cross the search line
+		}
 		for i := 0; i < len(t.Columns)-1; i++ {
 			currX += widths[i]
-			p.Fill(currX, t.Y1, currX, sepY2, sepChar, Palette[t.ColorBoxIdx])
+			p.Fill(currX, sepY1, currX, t.Y2, sepChar, Palette[t.ColorBoxIdx])
 			currX++
 		}
 	}
 
-	// 4. Draw Scrollbar
+	// 5. Draw Scrollbar
 	t.DrawScrollBar(scr)
-
-	// 5. Draw the QuickSearch line
-	if t.QuickSearch {
-		t.drawSearchLine(scr)
-	}
 }
 
 func (t *Table) drawRow(scr *ScreenBuf, y int, rowIdx int, displayPos int, attr uint64, widths []int) {
@@ -671,7 +670,8 @@ func (t *Table) drawRow(scr *ScreenBuf, y int, rowIdx int, displayPos int, attr 
 		} else {
 			t.cellBuf = FillCharInfoAligned(t.cellBuf, text, widths[colIdx], col.Alignment, cellAttr)
 		}
-		// Invert the colors of the matched substring (QuickSearch highlight).
+		// Paint the matched substring with the highlight color (QuickSearch).
+		// Goes last, on top of all other colors.
 		if rowIdx >= 0 && len(t.searchRunes) > 0 && rowIdx < len(t.matchSpans) {
 			if span := t.matchSpans[rowIdx]; span.col == colIdx {
 				t.applyCellHighlight(t.cellBuf, text, widths[colIdx], col.Alignment, span)
@@ -693,9 +693,10 @@ func (t *Table) drawRow(scr *ScreenBuf, y int, rowIdx int, displayPos int, attr 
 	}
 }
 
-// applyCellHighlight inverts the colors of the cells covered by the matched
-// substring. span.start/span.end are rune indices in the original cell text;
-// they are mapped to display cells accounting for truncation, alignment
+// applyCellHighlight repaints the cells covered by the matched substring with
+// the highlight color, overriding whatever state/selection attributes were
+// resolved before. span.start/span.end are rune indices in the original cell
+// text; they are mapped to display cells accounting for truncation, alignment
 // padding and wide runes.
 func (t *Table) applyCellHighlight(cis []CharInfo, text string, width int, align Alignment, span cellHighlight) {
 	truncated := TruncateString(text, width, "")
@@ -720,7 +721,7 @@ func (t *Table) applyCellHighlight(cis []CharInfo, text string, width int, align
 		}
 		if runeIdx >= span.start && runeIdx <= span.end {
 			for k := 0; k < w && cellPos+k < len(cis); k++ {
-				cis[cellPos+k].Attributes = InvertColors(cis[cellPos+k].Attributes)
+				cis[cellPos+k].Attributes = Palette[t.ColorHighlightIdx]
 			}
 		}
 		cellPos += w
@@ -769,33 +770,14 @@ func (t *Table) ProcessKey(e *vtinput.InputEvent) bool {
 		return false
 	}
 
-	searchActive := len(t.searchRunes) > 0
 	switch e.VirtualKeyCode {
 	case vtinput.VK_UP:
-		// With bottom-up search results Up moves towards worse matches.
-		if searchActive {
-			if t.SelectPos == t.ItemCount-1 {
-				return false
-			}
-		} else if t.SelectPos == 0 {
+		if t.SelectPos == 0 {
 			return false
 		}
 	case vtinput.VK_DOWN:
-		if searchActive {
-			if t.SelectPos == 0 {
-				return false
-			}
-		} else if t.SelectPos == t.ItemCount-1 {
+		if t.SelectPos == t.ItemCount-1 {
 			return false
-		}
-	}
-
-	if searchActive {
-		switch e.VirtualKeyCode {
-		case vtinput.VK_UP:
-			return t.MoveSelection(1)
-		case vtinput.VK_DOWN:
-			return t.MoveSelection(-1)
 		}
 	}
 
@@ -965,31 +947,6 @@ func (t *Table) ProcessMouse(e *vtinput.InputEvent) bool {
 		}
 	}
 
-	// With bottom-up search results, clicks in the data area map to rows
-	// counted from the bottom; consume them all so the generic handler does
-	// not mis-map empty rows above the results.
-	if len(t.searchRunes) > 0 && e.Type == vtinput.MouseEventType && e.ButtonState != 0 && e.KeyDown {
-		dataTop := t.Y1 + t.MarginTop
-		dataBottom := dataTop + t.ViewHeight - 1
-		mx, my := int(e.MouseX), int(e.MouseY)
-		if my >= dataTop && my <= dataBottom && mx >= t.X1 && mx < t.X1+t.GetContentWidth() {
-			idx := t.TopPos + (dataBottom - my)
-			if idx >= 0 && idx < t.ItemCount {
-				oldPos := t.SelectPos
-				t.SelectPos = idx
-				if t.SelectPos != oldPos && t.OnSelect != nil {
-					t.OnSelect(t.SelectPos)
-				}
-				isLeftDoubleClick := e.ButtonState == vtinput.FromLeft1stButtonPressed && (e.MouseEventFlags&vtinput.DoubleClick) != 0
-				isMiddleClick := e.ButtonState == vtinput.FromLeft2ndButtonPressed
-				if (isLeftDoubleClick || isMiddleClick) && t.OnAction != nil {
-					t.OnAction(t.SelectPos)
-				}
-			}
-			return true
-		}
-	}
-
 	handled := t.HandleMouse(e)
 	if !handled && colChanged {
 		t.SelectCol = originalCol
@@ -998,15 +955,16 @@ func (t *Table) ProcessMouse(e *vtinput.InputEvent) bool {
 }
 
 func (t *Table) SetPosition(x1, y1, x2, y2 int) {
-	t.MarginTop = map[bool]int{true: 1, false: 0}[t.ShowHeader]
-	t.MarginBottom = map[bool]int{true: 1, false: 0}[t.QuickSearch]
+	t.MarginTop = map[bool]int{true: 1, false: 0}[t.ShowHeader] + map[bool]int{true: 1, false: 0}[t.QuickSearch]
+	t.MarginBottom = 0
 	t.ScrollView.SetPosition(x1, y1, x2, y2)
 }
 
-// drawSearchLine renders the QuickSearch string in the bottom line of the
-// table: "> text" with a hardware cursor while the table is focused.
+// drawSearchLine renders the QuickSearch string in the top line of the
+// table, above the header: "> text" with a hardware cursor while the table
+// is focused.
 func (t *Table) drawSearchLine(scr *ScreenBuf) {
-	y := t.Y2
+	y := t.Y1
 	attr := Palette[t.ColorTextIdx]
 	scr.FillRect(t.X1, y, t.X2, y, ' ', attr)
 

--- a/table_test.go
+++ b/table_test.go
@@ -916,6 +916,70 @@ func TestTable_QuickSearchExactOnHit(t *testing.T) {
 	}
 }
 
+func TestTable_QuickSearchExactRanksFirst(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{
+		mockRow{"файлы", ""}, // exact substring at 0, but longer than the needle
+		mockRow{"файл", ""},  // full-cell equality, must win despite the position
+	})
+
+	typeSearch(tbl, "файл") // non-ASCII: guards against rune/byte unit mixups
+
+	if tbl.ItemCount != 2 {
+		t.Fatalf("expected 2 rows, got %d", tbl.ItemCount)
+	}
+	if got := tbl.Rows[tbl.RowAt(0)].(mockRow).col1; got != "файл" {
+		t.Errorf("full-cell exact match must rank first, got %q", got)
+	}
+}
+
+func TestTable_QuickSearchExactOnHitNonASCII(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SearchExactOnHit = true
+	tbl.SetRows([]TableRow{
+		mockRow{"файлы", ""},
+		mockRow{"файл", ""},
+	})
+
+	typeSearch(tbl, "файл")
+	if tbl.ItemCount != 1 {
+		t.Fatalf("expected only the exact match, got %d rows", tbl.ItemCount)
+	}
+	if got := tbl.Rows[tbl.RowAt(0)].(mockRow).col1; got != "файл" {
+		t.Fatalf("exact match = %q, want файл", got)
+	}
+}
+
+func TestTable_QuickSearchExactInAnyColumn(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}, {Title: "C2", Width: 10}}
+	tbl := NewTable(0, 0, 21, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SearchExactOnHit = true
+	tbl.SetRows([]TableRow{
+		mockRow{"abc", "zzz"},  // exact in column 0, no match in the last column
+		mockRow{"xabc", "zzz"}, // substring only
+	})
+
+	typeSearch(tbl, "abc")
+
+	if tbl.ItemCount != 1 {
+		t.Fatalf("expected only the row with an exact cell, got %d", tbl.ItemCount)
+	}
+	if got := tbl.Rows[tbl.RowAt(0)].(mockRow).col1; got != "abc" {
+		t.Fatalf("kept row = %q, want abc", got)
+	}
+}
+
 func TestTable_QuickSearchCaseInsensitive(t *testing.T) {
 	SetDefaultPalette()
 
@@ -1054,9 +1118,10 @@ func TestTable_QuickSearchLineRendering(t *testing.T) {
 		t.Errorf("expected ViewHeight 3 (5 - header - search line), got %d", tbl.ViewHeight)
 	}
 
-	checkCell(t, scr, 0, 4, '>', Palette[ColTableText])
-	checkCell(t, scr, 2, 4, 'a', Palette[ColTableText])
-	checkCell(t, scr, 3, 4, 'b', Palette[ColTableText])
+	// The search line sits at the very top, above the header.
+	checkCell(t, scr, 0, 0, '>', Palette[ColTableText])
+	checkCell(t, scr, 2, 0, 'a', Palette[ColTableText])
+	checkCell(t, scr, 3, 0, 'b', Palette[ColTableText])
 }
 
 func TestTable_QuickSearchDisabledByDefault(t *testing.T) {
@@ -1118,15 +1183,15 @@ func TestTable_QuickSearchHighlight(t *testing.T) {
 	typeSearch(tbl, "abc")
 	tbl.Show(scr)
 
-	// Single match drawn bottom-up: ViewHeight=3, data rows y=1..3, row at y=3.
+	// Single match: ViewHeight=3, data rows y=2..4, the row at the top (y=2).
 	base := Palette[ColTableText]
-	inv := InvertColors(base)
-	checkCell(t, scr, 0, 3, 'x', base)
-	checkCell(t, scr, 1, 3, 'x', base)
-	checkCell(t, scr, 2, 3, 'a', inv)
-	checkCell(t, scr, 3, 3, 'b', inv)
-	checkCell(t, scr, 4, 3, 'c', inv)
-	checkCell(t, scr, 5, 3, 'x', base)
+	hl := Palette[ColMenuHighlight]
+	checkCell(t, scr, 0, 2, 'x', base)
+	checkCell(t, scr, 1, 2, 'x', base)
+	checkCell(t, scr, 2, 2, 'a', hl)
+	checkCell(t, scr, 3, 2, 'b', hl)
+	checkCell(t, scr, 4, 2, 'c', hl)
+	checkCell(t, scr, 5, 2, 'x', base)
 }
 
 func TestTable_QuickSearchHighlightFuzzySpan(t *testing.T) {
@@ -1144,15 +1209,14 @@ func TestTable_QuickSearchHighlightFuzzySpan(t *testing.T) {
 	typeSearch(tbl, "abc")
 	tbl.Show(scr)
 
-	base := Palette[ColTableText]
-	inv := InvertColors(base)
-	checkCell(t, scr, 0, 3, 'a', inv)
-	checkCell(t, scr, 1, 3, 'b', inv)
-	checkCell(t, scr, 2, 3, 'x', inv)
-	checkCell(t, scr, 3, 3, 'c', inv)
+	hl := Palette[ColMenuHighlight]
+	checkCell(t, scr, 0, 2, 'a', hl)
+	checkCell(t, scr, 1, 2, 'b', hl)
+	checkCell(t, scr, 2, 2, 'x', hl)
+	checkCell(t, scr, 3, 2, 'c', hl)
 }
 
-func TestTable_QuickSearchBottomUp(t *testing.T) {
+func TestTable_QuickSearchTopDown(t *testing.T) {
 	SetDefaultPalette()
 	scr := NewSilentScreenBuf()
 	scr.AllocBuf(11, 6)
@@ -1169,15 +1233,15 @@ func TestTable_QuickSearchBottomUp(t *testing.T) {
 	typeSearch(tbl, "ab")
 	tbl.Show(scr)
 
-	// ViewHeight = 6 - header - search = 4; data rows y=1..4, bottom y=4.
-	// Best match ("abx", displayPos 0) at the bottom, next one above it.
+	// ViewHeight = 6 - search line - header = 4; data rows y=2..5.
+	// Best match ("abx", displayPos 0) at the top, next one below it.
 	base := Palette[ColTableText]
-	inv := InvertColors(base)
-	checkCell(t, scr, 0, 4, 'a', inv)  // "abx" at the bottom, needle highlighted
-	checkCell(t, scr, 2, 4, 'x', base) // 'x' is outside the match span
-	checkCell(t, scr, 0, 3, 'x', base) // "xab" above
-	checkCell(t, scr, 0, 2, ' ', base) // empty space at the top
-	checkCell(t, scr, 0, 1, ' ', base)
+	hl := Palette[ColMenuHighlight]
+	checkCell(t, scr, 0, 2, 'a', hl)   // "abx" at the top, needle highlighted
+	checkCell(t, scr, 2, 2, 'x', base) // 'x' is outside the match span
+	checkCell(t, scr, 0, 3, 'x', base) // "xab" below
+	checkCell(t, scr, 0, 4, ' ', base) // empty space at the bottom
+	checkCell(t, scr, 0, 5, ' ', base)
 }
 
 func TestTable_QuickSearchCursorFollowsFilteredPosition(t *testing.T) {
@@ -1197,13 +1261,13 @@ func TestTable_QuickSearchCursorFollowsFilteredPosition(t *testing.T) {
 	typeSearch(tbl, "ab")
 	tbl.Show(scr)
 
-	// Search results are drawn bottom-up. The selected display position 0 is
-	// the underlying row 1, so the cursor must be on the bottom "abx" row.
-	checkCell(t, scr, 2, 3, 'x', Palette[ColTableSelectedText])
-	checkCell(t, scr, 0, 2, 'x', Palette[ColTableText])
+	// Search results are drawn top-down. The selected display position 0 is
+	// the underlying row 1, so the cursor must be on the top "abx" data row.
+	checkCell(t, scr, 2, 2, 'x', Palette[ColTableSelectedText])
+	checkCell(t, scr, 0, 3, 'x', Palette[ColTableText])
 }
 
-func TestTable_QuickSearchBottomUpKeys(t *testing.T) {
+func TestTable_QuickSearchKeys(t *testing.T) {
 	SetDefaultPalette()
 
 	cols := []TableColumn{{Title: "C1", Width: 10}}
@@ -1220,22 +1284,51 @@ func TestTable_QuickSearchBottomUpKeys(t *testing.T) {
 		return tbl.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vk})
 	}
 
-	// Up moves to the next (worse) match, Down moves back.
-	if !key(vtinput.VK_UP) || tbl.SelectPos != 1 {
-		t.Errorf("Up must move to the next match, SelectPos=%d", tbl.SelectPos)
-	}
-	if key(vtinput.VK_UP) {
-		t.Error("Up past the last match must propagate")
-	}
-	if !key(vtinput.VK_DOWN) || tbl.SelectPos != 0 {
-		t.Errorf("Down must move back towards the best match, SelectPos=%d", tbl.SelectPos)
+	// Down moves to the next (worse) match, Up moves back.
+	if !key(vtinput.VK_DOWN) || tbl.SelectPos != 1 {
+		t.Errorf("Down must move to the next match, SelectPos=%d", tbl.SelectPos)
 	}
 	if key(vtinput.VK_DOWN) {
-		t.Error("Down below the best match must propagate")
+		t.Error("Down past the last match must propagate")
+	}
+	if !key(vtinput.VK_UP) || tbl.SelectPos != 0 {
+		t.Errorf("Up must move back towards the best match, SelectPos=%d", tbl.SelectPos)
+	}
+	if key(vtinput.VK_UP) {
+		t.Error("Up above the best match must propagate")
 	}
 }
 
-func TestTable_QuickSearchBottomUpMouse(t *testing.T) {
+func TestTable_QuickSearchFocusFollowsBestMatch(t *testing.T) {
+	SetDefaultPalette()
+
+	cols := []TableColumn{{Title: "C1", Width: 10}}
+	tbl := NewTable(0, 0, 11, 5, cols)
+	tbl.QuickSearch = true
+	tbl.SetRows([]TableRow{mockRow{"xab", ""}, mockRow{"abx", ""}, mockRow{"abz", ""}})
+
+	typeSearch(tbl, "ab")
+	if tbl.SelectPos != 0 {
+		t.Fatalf("cursor must start at the best match, got %d", tbl.SelectPos)
+	}
+
+	// Navigate away from the best match...
+	tbl.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_DOWN})
+	if tbl.SelectPos != 1 {
+		t.Fatalf("Down must move to the second match, got %d", tbl.SelectPos)
+	}
+
+	// ...typing another character must refocus the new best match.
+	typeSearch(tbl, "x")
+	if tbl.SelectPos != 0 {
+		t.Errorf("typing must refocus the best match, got SelectPos=%d", tbl.SelectPos)
+	}
+	if got := tbl.Rows[tbl.RowAt(0)].(mockRow).col1; got != "abx" {
+		t.Errorf("best match for %q = %q, want abx", tbl.SearchText(), got)
+	}
+}
+
+func TestTable_QuickSearchMouse(t *testing.T) {
 	SetDefaultPalette()
 
 	cols := []TableColumn{{Title: "C1", Width: 10}}
@@ -1255,17 +1348,17 @@ func TestTable_QuickSearchBottomUpMouse(t *testing.T) {
 		})
 	}
 
-	// Data rows y=1..3 (ViewHeight 3); the best match is at the bottom (y=3).
-	click(3)
-	if tbl.SelectPos != 0 {
-		t.Errorf("click on the bottom row must select the best match, got %d", tbl.SelectPos)
-	}
+	// Data rows y=2..4 (ViewHeight 3); the best match is at the top (y=2).
 	click(2)
-	if tbl.SelectPos != 1 {
-		t.Errorf("click one row above must select the second match, got %d", tbl.SelectPos)
+	if tbl.SelectPos != 0 {
+		t.Errorf("click on the top row must select the best match, got %d", tbl.SelectPos)
 	}
-	// Click on the empty area above the results must not move the cursor.
-	click(1)
+	click(3)
+	if tbl.SelectPos != 1 {
+		t.Errorf("click one row below must select the second match, got %d", tbl.SelectPos)
+	}
+	// Click on the empty area below the results must not move the cursor.
+	click(4)
 	if tbl.SelectPos != 1 {
 		t.Errorf("click on empty space must be ignored, got %d", tbl.SelectPos)
 	}


### PR DESCRIPTION
 touch unxed/f4#491
 
 Переписал логику поиска в таблице. Там ИИшка наворотила четырехкратный обходвсех ячеек таблицы для поиска точного совпадения с запросом. Сделал проще и изящнее: fuzzyMatcher теперь сам сообщает, если запрос совпадет со кандидатом и назначает ему score = -1. Ну а дальше сортировка выталкивает точные совпадения на самый верх списка.
 
 В таблицах поиск теперь сверху, оно так логичнее вроде. А автокомплит истории ищет через fuzzyMatcher . 