### PR TITLE
Пять тестов на составные знаки не проверяли ничего

### DIFF
--- a/backspace_test.go
+++ b/backspace_test.go
@@ -14,7 +14,11 @@ func backspaceWalk(t *testing.T, text string, want []string) {
 	e := newBoundaryEdit(text)
 	e.curPos = len(e.text)
 	for i, expected := range want {
-		e.ProcessKey(&vtinput.InputEvent{VirtualKeyCode: vtinput.VK_BACK})
+		e.ProcessKey(&vtinput.InputEvent{
+			Type:           vtinput.KeyEventType,
+			KeyDown:        true,
+			VirtualKeyCode: vtinput.VK_BACK,
+		})
 		if got := e.GetText(); got != expected {
 			t.Fatalf("Backspace #%d on %q = %q, want %q", i+1, text, got, expected)
 		}

--- a/edit_cluster_boundary_test.go
+++ b/edit_cluster_boundary_test.go
@@ -119,7 +119,11 @@ func TestEditDeleteRemovesWholeTerminalCluster(t *testing.T) {
 		"",
 	}
 	for i, expected := range want {
-		e.ProcessKey(&vtinput.InputEvent{VirtualKeyCode: vtinput.VK_DELETE})
+		e.ProcessKey(&vtinput.InputEvent{
+			Type:           vtinput.KeyEventType,
+			KeyDown:        true,
+			VirtualKeyCode: vtinput.VK_DELETE,
+		})
 		if got := e.GetText(); got != expected {
 			t.Fatalf("Delete #%d = %q, want %q", i+1, got, expected)
 		}

--- a/multilineedit_test.go
+++ b/multilineedit_test.go
@@ -241,7 +241,7 @@ func TestMultiLineEdit_CtrlEnterLeavesEvent(t *testing.T) {
 	}
 }
 
-func TestMultiLineEdit_CombiningClustersMoveAndDeleteTogether(t *testing.T) {
+func TestMultiLineEdit_CombiningClustersMoveTogetherAndBackspacePeelsMarks(t *testing.T) {
 	m := NewMultiLineEdit(0, 0, 20, 2, "e\u0301x")
 	m.SetCursorPos(0, 3)
 
@@ -250,8 +250,8 @@ func TestMultiLineEdit_CombiningClustersMoveAndDeleteTogether(t *testing.T) {
 		t.Fatalf("left moved into a grapheme cluster: col=%d, want 2", col)
 	}
 	m.ProcessKey(mleKey(vtinput.VK_BACK, 0, 0))
-	if got := m.GetText(); got != "x" {
-		t.Fatalf("backspace split the combining cluster: %q, want %q", got, "x")
+	if got := m.GetText(); got != "ex" {
+		t.Fatalf("backspace did not peel the combining mark: %q, want %q", got, "ex")
 	}
 }
 


### PR DESCRIPTION
`go test ./...` падает на пяти тестах про удаление составных знаков — деванагари, тана, латиница с раздельными надстрочными знаками. Оказалось, что дело не в коде.

**Четыре из пяти вообще не запускали то, что проверяют.** Общий помощник для Backspace собирал событие клавиши без признака нажатия, а тест на Delete делал ту же ошибку отдельно. `ProcessKey` выходил сразу, текст оставался прежним, и тест падал не потому, что что-то не так, а потому, что ничего не произошло.

С настоящим событием поведение оказывается ровно тем, что записано в `TEXTSEG.md`, и **исходные ожидания проходят**: Backspace отщипывает одну кодовую точку с конца предыдущего знака, Delete вперёд забирает знак целиком.

**Пятый — другой случай.** Событие у него было правильное, и боевой код отработал верно. Устарело само ожидание: оно требовало от Backspace удалять составной знак целиком и было написано до того, как политика зафиксировалась в `TEXTSEG.md`. Теперь ожидание соответствует политике, а название теста прямо говорит, какая его половина проверяет перемещение курсора, а какая — удаление.

**Боевой код не тронут.** Изменены только три файла тестов, тринадцать добавленных строк.

Отдельно скажу, почему не пошёл простым путём. Первая попытка решить эту задачу заключалась в том, чтобы объявить правильным удаление целым знаком, переписать под это тесты и заодно `TEXTSEG.md`. Я её отклонил: политика «Backspace отщипывает кодовую точку» выбрана осознанно, обоснована поведением полей ввода Windows и браузеров, и UAX #29 разрешает оба варианта. Менять её задним числом в библиотеке, на которую в f4 приходится 4780 обращений, — не то, что можно сделать походя.