### PR TITLE
31 гонка вокруг менеджера экрана и протокола

### DIFF
--- a/autolayout_test.go
+++ b/autolayout_test.go
@@ -4,7 +4,22 @@ import (
 	"testing"
 )
 
+func useAutoLayoutTestScreen(t *testing.T) {
+	t.Helper()
+	oldFM := FrameManager
+	fm := &frameManager{}
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	fm.Init(scr)
+	FrameManager = fm
+	t.Cleanup(func() {
+		fm.Shutdown()
+		FrameManager = oldFM
+	})
+}
+
 func TestAutoLayout_BasicPinAndStack(t *testing.T) {
+	useAutoLayoutTestScreen(t)
 	SetDefaultPalette()
 	dlg := NewCenteredDialog(50, 15, " AutoLayout Test ")
 
@@ -44,6 +59,7 @@ func TestAutoLayout_BasicPinAndStack(t *testing.T) {
 }
 
 func TestAutoLayout_ApportionWidthsEqualColumns(t *testing.T) {
+	useAutoLayoutTestScreen(t)
 	SetDefaultPalette()
 	dlg := NewCenteredDialog(72, 10, " Equal Columns ")
 
@@ -77,6 +93,7 @@ func TestAutoLayout_ApportionWidthsEqualColumns(t *testing.T) {
 }
 
 func TestAutoLayout_SnapToGridAndEqualize(t *testing.T) {
+	useAutoLayoutTestScreen(t)
 	SetDefaultPalette()
 	dlg := NewCenteredDialog(60, 10, " Snapping Test ")
 
@@ -110,6 +127,7 @@ func TestAutoLayout_SnapToGridAndEqualize(t *testing.T) {
 }
 
 func TestAutoLayout_ResizeReSolve(t *testing.T) {
+	useAutoLayoutTestScreen(t)
 	SetDefaultPalette()
 	dlg := NewCenteredDialog(50, 10, " Resize Test ")
 

--- a/cmd/vtui-replay/main.go
+++ b/cmd/vtui-replay/main.go
@@ -51,14 +51,29 @@ func replaySession(r io.Reader, verify bool, speed float64) error {
 
 	fm := vtui.NewFrameManager()
 	fm.Init(scr)
+	fm.Push(vtui.NewDesktop())
 	defer fm.Shutdown()
+	fm.SetHostMode(true)
+	runDone := make(chan struct{})
+	go func() {
+		fm.Run()
+		close(runDone)
+	}()
 
 	clientReader, serverWriter := io.Pipe()
 	serverReader, clientWriter := io.Pipe()
 
 	session := vtui.NewProtocolSession(serverReader, serverWriter, fm)
+	serveDone := make(chan struct{})
 	go func() {
 		_ = session.Serve()
+		close(serveDone)
+	}()
+	defer func() {
+		_ = clientWriter.Close()
+		<-serveDone
+		_ = serverWriter.Close()
+		<-runDone
 	}()
 
 	scanner := bufio.NewScanner(r)
@@ -105,7 +120,5 @@ func replaySession(r io.Reader, verify bool, speed float64) error {
 		}
 	}
 
-	_ = clientWriter.Close()
-	_ = serverWriter.Close()
 	return scanner.Err()
 }

--- a/combobox_color_test.go
+++ b/combobox_color_test.go
@@ -38,6 +38,7 @@ func TestComboBox_DropdownUsesComboPalette(t *testing.T) {
 // The visible symptom the indices above are there to prevent: a dropdown
 // painted in the dialog's own background, indistinguishable from it.
 func TestComboBox_DropdownStandsApartFromDialog(t *testing.T) {
+	preserveTestPalette(t)
 	SetDefaultPalette()
 	Palette[ColDialogText] = SetRGBBoth(0, 0x2E3436, 0xD3D7CF)
 	Palette[ColDialogComboText] = SetRGBBoth(0, 0xEEEEEC, 0x06989A)
@@ -87,6 +88,7 @@ func TestVMenu_DefaultsToMenuPalette(t *testing.T) {
 	}
 }
 func TestComboBox_DropdownOnlyFocusedFillsSelectionContinuously(t *testing.T) {
+	preserveTestPalette(t)
 	SetDefaultPalette()
 	Palette[ColDialogComboText] = SetRGBBoth(0, 0xEEEEEC, 0x37322C)
 	Palette[ColDialogComboSelectedText] = SetRGBBoth(0, 0x1E1A16, 0xE6B450)
@@ -117,6 +119,7 @@ func TestComboBox_DropdownOnlyFocusedFillsSelectionContinuously(t *testing.T) {
 }
 
 func TestComboBox_UnfocusedArrowIsVisible(t *testing.T) {
+	preserveTestPalette(t)
 	SetDefaultPalette()
 	Palette[ColDialogComboText] = SetRGBBoth(0, 0xEEEEEC, 0x37322C)
 	Palette[ColDialogComboHighlight] = SetRGBBoth(0, 0xE6CF70, 0x37322C)

--- a/common_dialogs.go
+++ b/common_dialogs.go
@@ -26,6 +26,7 @@ type FSProvider interface {
 
 // SelectDirDialog creates a standard directory selection dialog.
 func SelectDirDialog(title string, initialPath string, vfs FSProvider) *Window {
+	fm := FrameManager
 	width := 50
 	height := 18
 	dlg := NewCenteredDialog(width, height, title)
@@ -45,7 +46,7 @@ func SelectDirDialog(title string, initialPath string, vfs FSProvider) *Window {
 					}
 				}
 			})
-			FrameManager.PostTask(func() {
+			fm.PostTask(func() {
 				if dlg.IsDone() {
 					return
 				}
@@ -63,7 +64,7 @@ func SelectDirDialog(title string, initialPath string, vfs FSProvider) *Window {
 				} else {
 					lb.SetSelectPos(0)
 				}
-				FrameManager.Redraw()
+				fm.Redraw()
 			})
 		}()
 	}
@@ -116,7 +117,7 @@ func SelectDirDialog(title string, initialPath string, vfs FSProvider) *Window {
 	layout.Apply()
 
 	updateList(vfs.GetPath(), "")
-	FrameManager.Push(dlg)
+	fm.Push(dlg)
 	return dlg
 }
 
@@ -354,6 +355,7 @@ func createMessageDialog(title string, text string, buttons []string, kind Messa
 
 // SelectFileDialog creates a standard file selection dialog.
 func SelectFileDialog(title string, initialPath string, vfs FSProvider, onOk func(string)) *Window {
+	fm := FrameManager
 	width := 55
 	height := 20
 	dlg := NewCenteredDialog(width, height, title)
@@ -376,7 +378,7 @@ func SelectFileDialog(title string, initialPath string, vfs FSProvider, onOk fun
 			vfs.ReadDir(context.Background(), p, func(chunk []FSItem) {
 				allEntries = append(allEntries, chunk...)
 			})
-			FrameManager.PostTask(func() {
+			fm.PostTask(func() {
 				if dlg.IsDone() {
 					return
 				}
@@ -410,7 +412,7 @@ func SelectFileDialog(title string, initialPath string, vfs FSProvider, onOk fun
 				} else {
 					lb.SetSelectPos(0)
 				}
-				FrameManager.Redraw()
+				fm.Redraw()
 			})
 		}()
 	}
@@ -474,7 +476,7 @@ func SelectFileDialog(title string, initialPath string, vfs FSProvider, onOk fun
 	layout.Apply()
 
 	updateList(vfs.GetPath(), "")
-	FrameManager.Push(dlg)
+	fm.Push(dlg)
 	return dlg
 }
 

--- a/common_dialogs_test.go
+++ b/common_dialogs_test.go
@@ -57,6 +57,7 @@ func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool
 
 func TestSelectDirDialog_ArrowVsEnter(t *testing.T) {
 	SetDefaultPalette()
+	FrameManager.Init(NewSilentScreenBuf())
 	tmpDir := t.TempDir()
 	vfs := &testVFS{currentPath: tmpDir}
 
@@ -128,6 +129,7 @@ func TestInputBox_OkCallback(t *testing.T) {
 
 func TestSelectFileDialog_Selection(t *testing.T) {
 	SetDefaultPalette()
+	FrameManager.Init(NewSilentScreenBuf())
 	tmpDir := t.TempDir()
 	v := &testVFS{currentPath: tmpDir}
 	os.WriteFile(filepath.Join(tmpDir, "dummy.txt"), []byte("data"), 0644)
@@ -170,6 +172,7 @@ func TestSelectFileDialog_Selection(t *testing.T) {
 
 func TestSelectDirDialog_Filtering(t *testing.T) {
 	SetDefaultPalette()
+	FrameManager.Init(NewSilentScreenBuf())
 	tmpDir := t.TempDir()
 	os.Mkdir(filepath.Join(tmpDir, "subfolder"), 0755)
 	os.WriteFile(filepath.Join(tmpDir, "should_be_hidden.txt"), []byte("data"), 0644)
@@ -199,6 +202,7 @@ func TestSelectDirDialog_Filtering(t *testing.T) {
 
 func TestDialogNavigation_UX(t *testing.T) {
 	SetDefaultPalette()
+	FrameManager.Init(NewSilentScreenBuf())
 	tmpDir := t.TempDir()
 	subPath := filepath.Join(tmpDir, "my_work_folder")
 	os.Mkdir(subPath, 0755)

--- a/dragdrop.go
+++ b/dragdrop.go
@@ -257,18 +257,26 @@ func DeliverDragEvent(ev *DragEvent) DropAction {
 		return DropNone
 	}
 
-	if !DragDeliverToUI || FrameManager == nil || FrameManager.taskChanIn == nil {
+	// Backend delivery belongs to the manager and policy which were active
+	// when this event arrived. Re-reading package globals while waiting lets a
+	// later host/test lifecycle silently redirect an in-flight gesture.
+	deliverToUI := DragDeliverToUI
+	fm := FrameManager
+	timeout := DragDeliverTimeout
+	if !deliverToUI || fm == nil || !fm.hasTaskPump() {
 		return safeHandleDrag(t, ev)
 	}
 
 	res := make(chan DropAction, 1)
-	FrameManager.PostTask(func() { res <- safeHandleDrag(t, ev) })
+	if !fm.enqueueTask(func() { res <- safeHandleDrag(t, ev) }) {
+		return DropNone
+	}
 	select {
 	case action := <-res:
 		DebugLog("DND: %s handled as %s", ev.Phase, action)
 		return action
-	case <-time.After(DragDeliverTimeout):
-		DebugLog("DND: UI thread silent for %s, reporting no action", DragDeliverTimeout)
+	case <-time.After(timeout):
+		DebugLog("DND: UI thread silent for %s, reporting no action", timeout)
 		return DropNone
 	}
 }

--- a/ebiten_renderer_test.go
+++ b/ebiten_renderer_test.go
@@ -309,6 +309,7 @@ func pixelAt(t *testing.T, r *EbitenRenderer, x, y int) (rr, g, b uint8) {
 // Frame characters must go through the geometric path, not the font, so that
 // neighbouring cells join. A font glyph would leave the seam column unlit.
 func TestEbitenRenderer_BoxCharsJoinAcrossCells(t *testing.T) {
+	preserveTestPalette(t)
 	// A nil face proves the point twice over: if the box path were not taken
 	// these cells would render as nothing at all.
 	r := NewEbitenRenderer(nil, nil, 8, 16, 1)

--- a/edit_test.go
+++ b/edit_test.go
@@ -92,6 +92,7 @@ func TestVMenu_ScrollbarMouseClick(t *testing.T) {
 	if m.TopPos != 0 { // 5 - height (5) = 0
 		t.Errorf("VMenu PageUp click failed, pos %d", m.TopPos)
 	}
+	m.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType})
 }
 func TestVMenu_Hotkeys(t *testing.T) {
 	m := NewVMenu("Menu")
@@ -766,6 +767,7 @@ func TestEdit_RightArrow_FullSelection_StaysInFocus(t *testing.T) {
 	}
 }
 func TestEdit_FullSelectionColorsOnlyTextPortion(t *testing.T) {
+	preserveTestPalette(t)
 	SetDefaultPalette()
 	Palette[ColDialogEdit] = SetRGBBoth(0, 0xEEEEEC, 0x37322C)
 	Palette[ColDialogEditUnchanged] = SetRGBBoth(0, 0x2E2A24, 0xE6B450)

--- a/far2l_extensions.go
+++ b/far2l_extensions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/unxed/vtinput"
@@ -19,15 +20,19 @@ var (
 	GlobalClipboardAccessManager ClipboardAccessManager
 	Far2lEnabled                 bool
 	far2lInteractMu              sync.Mutex
-	far2lIDCounter               uint8
+	far2lIDCounter               atomic.Uint32
 )
 
 // Far2lInteract sends a request to the terminal emulator and optionally waits for a reply.
 func Far2lInteract(stk *vtinput.Far2lStack, wait bool) *vtinput.Far2lStack {
-	return Far2lInteractTimeout(stk, wait, 2*time.Second)
+	return far2lInteractTimeout(FrameManager, stk, wait, 2*time.Second)
 }
 
 func Far2lInteractTimeout(stk *vtinput.Far2lStack, wait bool, timeout time.Duration) *vtinput.Far2lStack {
+	return far2lInteractTimeout(FrameManager, stk, wait, timeout)
+}
+
+func far2lInteractTimeout(fm *frameManager, stk *vtinput.Far2lStack, wait bool, timeout time.Duration) *vtinput.Far2lStack {
 	far2lInteractMu.Lock()
 	defer far2lInteractMu.Unlock()
 
@@ -35,8 +40,8 @@ func Far2lInteractTimeout(stk *vtinput.Far2lStack, wait bool, timeout time.Durat
 	DebugLog("VTUI_FAR2L_INTERACT: Sending ID=%d, payload_len=%d, wait=%v", id, len(payload), wait)
 	_, _ = os.Stdout.Write(payload)
 
-	if wait && FrameManager != nil {
-		return FrameManager.WaitFar2lResponse(id, timeout)
+	if wait && fm != nil {
+		return fm.WaitFar2lResponse(id, timeout)
 	}
 	DebugLog("VTUI_FAR2L: Processed without waiting for ID=%d", id)
 	return nil
@@ -54,11 +59,10 @@ func far2lInteractionPayload(stk *vtinput.Far2lStack) []byte {
 }
 
 func far2lInteractionPayloadLocked(stk *vtinput.Far2lStack) (uint8, []byte) {
-	far2lIDCounter++
-	if far2lIDCounter == 0 {
-		far2lIDCounter = 1
+	id := uint8(far2lIDCounter.Add(1))
+	if id == 0 {
+		id = uint8(far2lIDCounter.Add(1))
 	}
-	id := far2lIDCounter
 	stk.PushU8(id)
 	b64 := base64.StdEncoding.EncodeToString(*stk)
 	payload := make([]byte, 0, len(b64)+10)
@@ -73,8 +77,10 @@ func far2lInteractionPayloadLocked(stk *vtinput.Far2lStack) (uint8, []byte) {
 const clientID = "vtui-stateful-terminal-client-persistent-id-32chars"
 
 func SetFar2lClipboard(text string) bool {
-	DebugLog("VTUI_FAR2L: SetFar2lClipboard attempt, Enabled=%v, text_len=%d", Far2lEnabled, len(text))
-	if !Far2lEnabled {
+	fm := FrameManager
+	enabled := far2lEnabledFor(fm)
+	DebugLog("VTUI_FAR2L: SetFar2lClipboard attempt, Enabled=%v, text_len=%d", enabled, len(text))
+	if !enabled {
 		return false
 	}
 	// 1. Open
@@ -83,7 +89,7 @@ func SetFar2lClipboard(text string) bool {
 	stk.PushU8('o') // FARTTY_INTERACT_CLIP_OPEN
 	stk.PushU8('c') // FARTTY_INTERACT_CLIPBOARD
 	DebugLog("VTUI_FAR2L: Requesting CLIP_OPEN with ID %q...", clientID)
-	reply := Far2lInteractTimeout(stk, true, 15*time.Second)
+	reply := far2lInteractTimeout(fm, stk, true, 15*time.Second)
 
 	if reply != nil {
 		status := reply.PopU8()
@@ -103,7 +109,7 @@ func SetFar2lClipboard(text string) bool {
 			stk.PushU8('c') // FARTTY_INTERACT_CLIPBOARD
 
 			DebugLog("VTUI_FAR2L: Requesting CLIP_SETDATA...")
-			setReply := Far2lInteractTimeout(stk, true, 15*time.Second)
+			setReply := far2lInteractTimeout(fm, stk, true, 15*time.Second)
 
 			success := false
 			if setReply != nil {
@@ -120,7 +126,7 @@ func SetFar2lClipboard(text string) bool {
 			stk = &vtinput.Far2lStack{}
 			stk.PushU8('c') // FARTTY_INTERACT_CLIP_CLOSE
 			stk.PushU8('c') // FARTTY_INTERACT_CLIPBOARD
-			Far2lInteract(stk, false)
+			far2lInteractTimeout(fm, stk, false, 2*time.Second)
 
 			return success
 		}
@@ -130,8 +136,10 @@ func SetFar2lClipboard(text string) bool {
 
 // GetFar2lClipboard attempts to read the clipboard using far2l extensions.
 func GetFar2lClipboard() (string, bool) {
-	DebugLog("VTUI_FAR2L: GetFar2lClipboard attempt, Enabled=%v", Far2lEnabled)
-	if !Far2lEnabled {
+	fm := FrameManager
+	enabled := far2lEnabledFor(fm)
+	DebugLog("VTUI_FAR2L: GetFar2lClipboard attempt, Enabled=%v", enabled)
+	if !enabled {
 		return "", false
 	}
 
@@ -139,7 +147,7 @@ func GetFar2lClipboard() (string, bool) {
 	stk.PushString(clientID)
 	stk.PushU8('o')
 	stk.PushU8('c')
-	reply := Far2lInteractTimeout(stk, true, 15*time.Second)
+	reply := far2lInteractTimeout(fm, stk, true, 15*time.Second)
 
 	if reply != nil {
 		status := reply.PopU8()
@@ -150,7 +158,7 @@ func GetFar2lClipboard() (string, bool) {
 			stk.PushU32(1)  // CF_TEXT
 			stk.PushU8('g') // FARTTY_INTERACT_CLIP_GETDATA
 			stk.PushU8('c') // FARTTY_INTERACT_CLIPBOARD
-			getReply := Far2lInteractTimeout(stk, true, 15*time.Second)
+			getReply := far2lInteractTimeout(fm, stk, true, 15*time.Second)
 
 			res := ""
 			if getReply != nil {
@@ -174,10 +182,17 @@ func GetFar2lClipboard() (string, bool) {
 			stk = &vtinput.Far2lStack{}
 			stk.PushU8('c')
 			stk.PushU8('c')
-			Far2lInteract(stk, false)
+			far2lInteractTimeout(fm, stk, false, 2*time.Second)
 
 			return res, true
 		}
 	}
 	return "", false
+}
+
+func far2lEnabledFor(fm *frameManager) bool {
+	if fm != nil && fm.far2lConfigured.Load() {
+		return fm.far2lEnabled.Load()
+	}
+	return Far2lEnabled
 }

--- a/far2l_extensions_test.go
+++ b/far2l_extensions_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestFar2lClipboard_Disabled(t *testing.T) {
+	oldEnabled := Far2lEnabled
+	t.Cleanup(func() { Far2lEnabled = oldEnabled })
 	Far2lEnabled = false
 	ok := SetFar2lClipboard("test")
 	if ok {
@@ -21,6 +23,11 @@ func TestFar2lClipboard_Disabled(t *testing.T) {
 }
 
 func TestFar2lInteract_Timeout(t *testing.T) {
+	oldEnabled, oldFM := Far2lEnabled, FrameManager
+	t.Cleanup(func() {
+		Far2lEnabled = oldEnabled
+		FrameManager = oldFM
+	})
 	Far2lEnabled = true
 	// Init minimal FrameManager
 	FrameManager = &frameManager{}
@@ -56,7 +63,15 @@ func TestFar2lInteract_Timeout(t *testing.T) {
 }
 
 func TestFar2lInteract_Success(t *testing.T) {
+	oldEnabled, oldFM := Far2lEnabled, FrameManager
+	oldID := far2lIDCounter.Load()
+	t.Cleanup(func() {
+		Far2lEnabled = oldEnabled
+		FrameManager = oldFM
+		far2lIDCounter.Store(oldID)
+	})
 	Far2lEnabled = true
+	far2lIDCounter.Store(0)
 	idToWait := uint8(0)
 
 	// Mocking the interaction loop
@@ -70,10 +85,10 @@ func TestFar2lInteract_Success(t *testing.T) {
 
 	go func() {
 		// Wait for the ID to be assigned by Far2lInteract
-		for far2lIDCounter == 0 {
+		for far2lIDCounter.Load() == 0 {
 			time.Sleep(10 * time.Millisecond)
 		}
-		idToWait = far2lIDCounter
+		idToWait = uint8(far2lIDCounter.Load())
 
 		// Prepare reply
 		resp := vtinput.Far2lStack{}
@@ -103,10 +118,19 @@ func TestFar2lInteract_Success(t *testing.T) {
 }
 
 func TestFar2lInteract_NoEventStealing(t *testing.T) {
+	oldEnabled, oldFM := Far2lEnabled, FrameManager
+	oldID := far2lIDCounter.Load()
+	t.Cleanup(func() {
+		Far2lEnabled = oldEnabled
+		FrameManager = oldFM
+		far2lIDCounter.Store(oldID)
+	})
 	Far2lEnabled = true
+	far2lIDCounter.Store(0)
 
 	localFm := &frameManager{}
 	localFm.Init(NewSilentScreenBuf())
+	defer localFm.Shutdown()
 	localFm.EventChan = make(chan *vtinput.InputEvent, 10)
 	FrameManager = localFm
 
@@ -149,9 +173,7 @@ func TestFar2lInteract_NoEventStealing(t *testing.T) {
 	// We wait a bit to ensure WaitFar2lResponse has processed the kp event.
 	time.Sleep(100 * time.Millisecond)
 
-	localFm.far2lMu.Lock()
-	idToWait := far2lIDCounter
-	localFm.far2lMu.Unlock()
+	idToWait := uint8(far2lIDCounter.Load())
 
 	resp := vtinput.Far2lStack{}
 	resp.PushU16(24) // height
@@ -182,8 +204,11 @@ func TestFar2lInteract_NoEventStealing(t *testing.T) {
 	}
 }
 func TestIssue117_WaitFar2lResponse_TaskPumping(t *testing.T) {
+	oldFM := FrameManager
+	t.Cleanup(func() { FrameManager = oldFM })
 	fm := &frameManager{}
 	fm.Init(NewSilentScreenBuf())
+	defer fm.Shutdown()
 	FrameManager = fm
 
 	taskExecuted := false
@@ -215,8 +240,11 @@ func TestIssue117_WaitFar2lResponse_TaskPumping(t *testing.T) {
 }
 
 func TestIssue117_WaitFar2lResponse_TimeoutCleanup(t *testing.T) {
+	oldFM := FrameManager
+	t.Cleanup(func() { FrameManager = oldFM })
 	fm := &frameManager{}
 	fm.Init(NewSilentScreenBuf())
+	defer fm.Shutdown()
 	FrameManager = fm
 
 	// Wait for a non-existent reply with a short 50ms timeout

--- a/framemanager.go
+++ b/framemanager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/unxed/vtui/vreactive"
 	"golang.org/x/term"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -220,6 +221,9 @@ type frameManager struct {
 	RedrawChan  chan struct{}
 	TaskChan    chan func()
 	taskChanIn  chan func()
+	taskDone    chan struct{}
+	taskMu      sync.Mutex
+	taskWG      sync.WaitGroup
 	EventChan   chan *vtinput.InputEvent
 	EventFilter func(*vtinput.InputEvent) bool
 	// needsRender is set from background goroutines as well as the UI one --
@@ -233,6 +237,10 @@ type frameManager struct {
 
 	pendingFar2l map[uint8]chan *vtinput.Far2lStack
 	far2lMu      sync.Mutex
+	// Far2lEnabled is the startup default. Negotiation completes after Run has
+	// started, so its result belongs to this manager rather than that global.
+	far2lEnabled    atomic.Bool
+	far2lConfigured atomic.Bool
 
 	// Global standard UI components
 	DisabledCommands CommandSet
@@ -266,8 +274,17 @@ type frameManager struct {
 	workspaceNewTabX         int
 	workspaceTabDrag         *AppScreen
 	workspaceTabDragHits     []workspaceTabHit
-	running                  bool
-	lastTitle                string
+	// The UI graph itself stays single-goroutine-owned. These atomics only
+	// coordinate callers which need to stop that goroutine or observe that its
+	// shutdown has completed.
+	running       atomic.Bool
+	stopRequested atomic.Bool
+	shutdown      atomic.Bool
+	uiOwnershipMu sync.Mutex
+	lifecycleMu   sync.Mutex
+	runDone       chan struct{}
+	shutdownDone  bool
+	lastTitle     string
 
 	lastMouseClickTime     time.Time
 	lastMouseX, lastMouseY int
@@ -714,6 +731,12 @@ func (fm *frameManager) Screen() *ScreenBuf {
 
 // Init initializes the FrameManager with a ScreenBuf.
 func (fm *frameManager) Init(scr *ScreenBuf) {
+	fm.shutdown.Store(false)
+	fm.stopRequested.Store(false)
+	fm.lifecycleMu.Lock()
+	fm.shutdownDone = false
+	fm.lifecycleMu.Unlock()
+
 	fm.scr = scr
 	fm.frames = make([]Frame, 0, 10)
 	fm.Screens = []*AppScreen{{Number: 1, Frames: fm.frames}}
@@ -730,6 +753,8 @@ func (fm *frameManager) Init(scr *ScreenBuf) {
 	fm.workspaceTabDragHits = nil
 	fm.currentToast = nil
 	fm.needsRender.Store(true)
+	fm.far2lEnabled.Store(Far2lEnabled)
+	fm.far2lConfigured.Store(true)
 
 	if fm.RedrawChan == nil {
 		fm.RedrawChan = make(chan struct{}, 1)
@@ -739,34 +764,7 @@ func (fm *frameManager) Init(scr *ScreenBuf) {
 		fm.animWake = make(chan struct{}, 1)
 	}
 
-	if fm.taskChanIn == nil {
-		fm.taskChanIn = make(chan func())
-		fm.TaskChan = make(chan func())
-
-		go func() {
-			var queue []func()
-			for {
-				if len(queue) == 0 {
-					task, ok := <-fm.taskChanIn
-					if !ok {
-						return
-					}
-					queue = append(queue, task)
-				} else {
-					select {
-					case task, ok := <-fm.taskChanIn:
-						if !ok {
-							return
-						}
-						queue = append(queue, task)
-					case fm.TaskChan <- queue[0]:
-						queue[0] = nil
-						queue = queue[1:]
-					}
-				}
-			}
-		}()
-	}
+	fm.startTaskPump()
 
 	fm.injectedEvents = make([]*vtinput.InputEvent, 0)
 	SetDefaultPalette()
@@ -785,6 +783,67 @@ func (fm *frameManager) Init(scr *ScreenBuf) {
 		os.Stdout.WriteString("\x1b]104\x07")
 	}
 
+}
+
+// startTaskPump creates one queue pump for this manager. The goroutine uses
+// captured channels because Init and Shutdown replace the lifecycle fields.
+func (fm *frameManager) startTaskPump() {
+	fm.taskMu.Lock()
+	defer fm.taskMu.Unlock()
+	if fm.taskChanIn != nil {
+		return
+	}
+
+	in := make(chan func())
+	out := make(chan func())
+	done := make(chan struct{})
+	fm.taskChanIn = in
+	fm.TaskChan = out
+	fm.taskDone = done
+	fm.taskWG.Add(1)
+	go func() {
+		defer fm.taskWG.Done()
+		var queue []func()
+		for {
+			if len(queue) == 0 {
+				select {
+				case task := <-in:
+					queue = append(queue, task)
+				case <-done:
+					return
+				}
+				continue
+			}
+
+			select {
+			case task := <-in:
+				queue = append(queue, task)
+			case out <- queue[0]:
+				queue[0] = nil
+				queue = queue[1:]
+			case <-done:
+				return
+			}
+		}
+	}()
+}
+
+func (fm *frameManager) stopTaskPump() {
+	fm.taskMu.Lock()
+	done := fm.taskDone
+	if done != nil {
+		close(done)
+		fm.taskDone = nil
+		fm.taskChanIn = nil
+		fm.TaskChan = nil
+	}
+	fm.taskMu.Unlock()
+
+	// The pump never takes taskMu. Waiting after the unlock also keeps a task
+	// which was already posting from being trapped behind this teardown.
+	if done != nil {
+		fm.taskWG.Wait()
+	}
 }
 
 // Push adds a new frame to the top of the stack and assigns a number if it's non-modal.
@@ -985,8 +1044,61 @@ func (fm *frameManager) Redraw() {
 
 // PostTask schedules a function to be executed safely on the main UI thread.
 func (fm *frameManager) PostTask(task func()) {
-	if fm.taskChanIn != nil {
-		fm.taskChanIn <- task
+	fm.enqueueTask(task)
+}
+
+func (fm *frameManager) enqueueTask(task func()) bool {
+	if task == nil {
+		return false
+	}
+	fm.taskMu.Lock()
+	in, done := fm.taskChanIn, fm.taskDone
+	fm.taskMu.Unlock()
+	if in == nil || done == nil {
+		return false
+	}
+	select {
+	case in <- task:
+		return true
+	case <-done:
+		return false
+	}
+}
+
+func (fm *frameManager) hasTaskPump() bool {
+	fm.taskMu.Lock()
+	defer fm.taskMu.Unlock()
+	return fm.taskChanIn != nil && fm.taskDone != nil
+}
+
+// callOnUI runs fn on the event-loop goroutine and waits for its result. Before
+// Run starts, uiOwnershipMu makes direct setup calls and Run mutually exclusive.
+func (fm *frameManager) callOnUI(fn func() error) error {
+	if !fm.running.Load() {
+		fm.uiOwnershipMu.Lock()
+		defer fm.uiOwnershipMu.Unlock()
+		if fm.shutdown.Load() {
+			return fmt.Errorf("frame manager is shut down")
+		}
+		return fn()
+	}
+
+	result := make(chan error, 1)
+	fm.lifecycleMu.Lock()
+	runDone := fm.runDone
+	if !fm.running.Load() || runDone == nil {
+		fm.lifecycleMu.Unlock()
+		return fmt.Errorf("frame manager stopped before scheduling task")
+	}
+	fm.lifecycleMu.Unlock()
+	if !fm.enqueueTask(func() { result <- fn() }) {
+		return fmt.Errorf("frame manager task pump is stopped")
+	}
+	select {
+	case err := <-result:
+		return err
+	case <-runDone:
+		return fmt.Errorf("frame manager stopped before running task")
 	}
 }
 
@@ -1073,6 +1185,10 @@ func (fm *frameManager) PostEvent(ev vtinput.InputEvent) {
 // timeout > 0 waits up to the given duration.
 // Returns false when the application should terminate (no frames left or shutdown).
 func (fm *frameManager) Step(timeout time.Duration) bool {
+	return fm.stepWithSize(timeout, GetTerminalSize)
+}
+
+func (fm *frameManager) stepWithSize(timeout time.Duration, getSize func() (int, int, error)) bool {
 	if fm.IsShutdown() {
 		return false
 	}
@@ -1098,7 +1214,7 @@ func (fm *frameManager) Step(timeout time.Duration) bool {
 	if injected {
 		if e != nil {
 			if e.Type == vtinput.ResizeEventType {
-				fm.handleResize()
+				fm.handleResizeWith(getSize)
 			} else {
 				fm.dispatchEvent(e, true)
 			}
@@ -1122,7 +1238,7 @@ func (fm *frameManager) Step(timeout time.Duration) bool {
 			}
 			if ev != nil {
 				if ev.Type == vtinput.ResizeEventType {
-					fm.handleResize()
+					fm.handleResizeWith(getSize)
 				} else {
 					fm.dispatchEvent(ev, false)
 				}
@@ -1148,7 +1264,7 @@ func (fm *frameManager) Step(timeout time.Duration) bool {
 			}
 			if ev != nil {
 				if ev.Type == vtinput.ResizeEventType {
-					fm.handleResize()
+					fm.handleResizeWith(getSize)
 				} else {
 					fm.dispatchEvent(ev, false)
 				}
@@ -1176,7 +1292,7 @@ func (fm *frameManager) Step(timeout time.Duration) bool {
 		}
 		if ev != nil {
 			if ev.Type == vtinput.ResizeEventType {
-				fm.handleResize()
+				fm.handleResizeWith(getSize)
 			} else {
 				fm.dispatchEvent(ev, false)
 			}
@@ -1188,7 +1304,11 @@ func (fm *frameManager) Step(timeout time.Duration) bool {
 }
 
 func (fm *frameManager) handleResize() {
-	width, height, err := GetTerminalSize()
+	fm.handleResizeWith(GetTerminalSize)
+}
+
+func (fm *frameManager) handleResizeWith(getSize func() (int, int, error)) {
+	width, height, err := getSize()
 	DebugLog("FM_RESIZE: handleResize triggered. GetTerminalSize returned: %dx%d (err: %v). Current scr: %dx%d", width, height, err, fm.scr.width, fm.scr.height)
 	if err != nil {
 		return
@@ -1198,10 +1318,47 @@ func (fm *frameManager) handleResize() {
 
 // Shutdown clears all frames, stops the event loop, and cleanly restores the terminal state. Safe and idempotent.
 func (fm *frameManager) Shutdown() {
-	fm.running = false
+	fm.shutdown.Store(true)
+	fm.stopRequested.Store(true)
+	select {
+	case fm.RedrawChan <- struct{}{}:
+	default:
+	}
+	if fm.running.Load() {
+		return
+	}
+
+	fm.uiOwnershipMu.Lock()
+	if !fm.running.Load() {
+		fm.finishShutdown()
+	}
+	fm.uiOwnershipMu.Unlock()
+}
+
+// shutdownAndWait is for owners outside the UI goroutine, such as a protocol
+// session. Shutdown itself cannot always wait because UI callbacks call it too.
+func (fm *frameManager) shutdownAndWait() {
+	fm.Shutdown()
+	fm.lifecycleMu.Lock()
+	done := fm.runDone
+	fm.lifecycleMu.Unlock()
+	if done != nil {
+		<-done
+	}
+}
+
+func (fm *frameManager) finishShutdown() {
+	fm.lifecycleMu.Lock()
+	if fm.shutdownDone {
+		fm.lifecycleMu.Unlock()
+		return
+	}
+	fm.shutdownDone = true
 	fm.Screens = nil
 	fm.frames = nil
 	fm.capturedFrame = nil
+	fm.lifecycleMu.Unlock()
+
 	if fm.scr != nil {
 		fm.scr.SetCursorVisible(true)
 		// If a Suspend already restored the terminal (quit path), this flush
@@ -1214,11 +1371,12 @@ func (fm *frameManager) Shutdown() {
 	}
 	Suspend()
 	CleanupStderrLog()
+	fm.stopTaskPump()
 }
 
 // IsShutdown returns true if the FrameManager has been shut down explicitly.
 func (fm *frameManager) IsShutdown() bool {
-	return fm.Screens == nil
+	return fm.shutdown.Load()
 }
 
 func (fm *frameManager) RegisterFar2lWaiter(id uint8) chan *vtinput.Far2lStack {
@@ -2078,9 +2236,11 @@ func (fm *frameManager) GetBackendName() string {
 }
 func (fm *frameManager) GetSyncStats() string {
 	tLen, tCap := 0, 0
+	fm.taskMu.Lock()
 	if fm.TaskChan != nil {
 		tLen, tCap = len(fm.TaskChan), cap(fm.TaskChan)
 	}
+	fm.taskMu.Unlock()
 	eLen, eCap := 0, 0
 	if fm.EventChan != nil {
 		eLen, eCap = len(fm.EventChan), cap(fm.EventChan)
@@ -2119,11 +2279,7 @@ func (fm *frameManager) ResizeWindow(cols, rows int) {
 // Stop signals the main loop to exit.
 func (fm *frameManager) Stop() {
 	DebugLog("FM: Stop() requested. Deactivating menus and exiting loop.")
-	// Safety: deactivate top menu before leaving to avoid stale sub-menus on return
-	if fm.MenuBar != nil {
-		fm.MenuBar.Active = false
-	}
-	fm.running = false
+	fm.stopRequested.Store(true)
 	// Wake up the select loop immediately
 	select {
 	case fm.RedrawChan <- struct{}{}:
@@ -2144,14 +2300,36 @@ type softwareBlinkRenderer interface {
 }
 
 func (fm *frameManager) Run(readers ...*vtinput.Reader) {
+	fm.uiOwnershipMu.Lock()
+	defer fm.uiOwnershipMu.Unlock()
+	if fm.shutdown.Load() {
+		return
+	}
+	runDone := make(chan struct{})
+	fm.lifecycleMu.Lock()
+	if fm.running.Load() {
+		fm.lifecycleMu.Unlock()
+		return
+	}
+	fm.running.Store(true)
+	fm.runDone = runDone
+	fm.lifecycleMu.Unlock()
+	fm.stopRequested.Store(false)
+
 	if len(readers) > 0 && readers[0] != nil {
 		fm.Reader = readers[0]
 		fm.EventChan = readers[0].GetEventChan()
 		defer readers[0].Close()
 	}
-	fm.running = true
+	workersDone := make(chan struct{})
+	var workers sync.WaitGroup
 	// Restore cursor visibility on exit
 	defer func() {
+		close(workersDone)
+		workers.Wait()
+		if fm.stopRequested.Load() && fm.MenuBar != nil {
+			fm.MenuBar.Active = false
+		}
 		if r := recover(); r != nil {
 			// Note: RecordCrash now generates its own full stack dump
 			DebugLog("FATAL PANIC IN RUN LOOP: %v", r)
@@ -2164,8 +2342,9 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 			CleanupStderrLog()
 			os.Exit(2)
 		}
-		fm.running = false
-		if fm.scr != nil {
+		if fm.shutdown.Load() {
+			fm.finishShutdown()
+		} else if fm.scr != nil {
 			fm.scr.SetCursorVisible(true)
 			// Skip the flush if Suspend already restored the terminal: this
 			// defer runs after the quit path's Suspend(), and a frame written
@@ -2176,15 +2355,20 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 			}
 		}
 		CleanupStderrLog()
+		fm.lifecycleMu.Lock()
+		fm.running.Store(false)
+		if fm.runDone == runDone {
+			close(runDone)
+			fm.runDone = nil
+		}
+		fm.lifecycleMu.Unlock()
 	}()
 
 	// Configure channel for tracking window resizing
 	sigChan := make(chan os.Signal, 1)
 	watchResizeSignal(sigChan)
-
-	// Closed when Run exits, so the idle heartbeat and resize forwarder stop.
-	done := make(chan struct{})
-	defer close(done)
+	defer signal.Stop(sigChan)
+	getTerminalSize := GetTerminalSize
 
 	// Heartbeat for animations and cursor blinking: ticks at ~30fps while
 	// animations are active. The lighter 250ms idle tick only exists for
@@ -2219,7 +2403,9 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 		}
 	}
 
+	workers.Add(1)
 	go func() {
+		defer workers.Done()
 		tmr := time.NewTimer(33 * time.Millisecond)
 		if !tmr.Stop() {
 			select {
@@ -2251,7 +2437,7 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 					select {
 					case <-fm.animWake:
 						continue
-					case <-done:
+					case <-workersDone:
 						return
 					}
 				}
@@ -2268,7 +2454,7 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 				case <-idleTmr.C:
 					fm.Redraw()
 					continue
-				case <-done:
+				case <-workersDone:
 					return
 				}
 			}
@@ -2284,7 +2470,7 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 				}
 			case <-tmr.C:
 				fm.PostTask(func() { fm.tickAnimations() })
-			case <-done:
+			case <-workersDone:
 				return
 			}
 		}
@@ -2293,12 +2479,25 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 	// Terminal size polling: skipped in GUI backends; adaptive fallback in TTY.
 	sizeChan := make(chan struct{}, 1)
 	if !fm.isGUI() {
+		workers.Add(1)
 		go func() {
-			lastW, lastH, _ := GetTerminalSize()
+			defer workers.Done()
+			lastW, lastH, _ := getTerminalSize()
 			interval := 200 * time.Millisecond
-			for fm.running {
-				time.Sleep(interval)
-				w, h, err := GetTerminalSize()
+			for {
+				timer := time.NewTimer(interval)
+				select {
+				case <-timer.C:
+				case <-workersDone:
+					if !timer.Stop() {
+						select {
+						case <-timer.C:
+						default:
+						}
+					}
+					return
+				}
+				w, h, err := getTerminalSize()
 				if err == nil && w > 0 && h > 0 && (w != lastW || h != lastH) {
 					lastW, lastH = w, h
 					interval = 200 * time.Millisecond
@@ -2314,24 +2513,26 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 	}
 
 	// Forward resize notifications to the event queue
+	workers.Add(1)
 	go func() {
+		defer workers.Done()
 		for {
 			select {
 			case <-sigChan:
-				fm.PostTask(func() { fm.handleResize() })
+				fm.PostTask(func() { fm.handleResizeWith(getTerminalSize) })
 			case <-sizeChan:
-				fm.PostTask(func() { fm.handleResize() })
-			case <-done:
+				fm.PostTask(func() { fm.handleResizeWith(getTerminalSize) })
+			case <-workersDone:
 				return
 			}
 		}
 	}()
 
-	for fm.running && !fm.IsShutdown() {
+	for !fm.stopRequested.Load() && !fm.IsShutdown() {
 		if !fm.hostMode && len(fm.frames) == 0 {
 			break
 		}
-		if !fm.Step(-1) {
+		if !fm.stepWithSize(-1, getTerminalSize) {
 			if !fm.hostMode {
 				break
 			}
@@ -2623,8 +2824,8 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 	if ev.Type == vtinput.Far2lEventType {
 		DebugLog("FM_DISPATCH: Processing Far2l event: cmd=%q", ev.Far2lCommand)
 		if ev.Far2lCommand == "ok" {
-			DebugLog("FM_DISPATCH: Far2l extensions successfully negotiated with host. Setting Far2lEnabled = true")
-			Far2lEnabled = true
+			DebugLog("FM_DISPATCH: Far2l extensions successfully negotiated with host")
+			fm.far2lEnabled.Store(true)
 			// A screen may have asked for its graphics protocol before the
 			// asynchronous far2l acknowledgement arrived. Switch it now so
 			// image viewers do not retain the initial GraphicsNone/kitty choice.

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1158,9 +1159,11 @@ func TestFrameManager_SizePolling(t *testing.T) {
 	oldGetSize := GetTerminalSize
 	defer func() { GetTerminalSize = oldGetSize }()
 
-	mockW, mockH := 80, 24
+	var mockW, mockH atomic.Int64
+	mockW.Store(80)
+	mockH.Store(24)
 	GetTerminalSize = func() (int, int, error) {
-		return mockW, mockH, nil
+		return int(mockW.Load()), int(mockH.Load()), nil
 	}
 
 	fm := &frameManager{}
@@ -1184,7 +1187,8 @@ func TestFrameManager_SizePolling(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Change mock size to trigger polling mechanism
-	mockW, mockH = 100, 30
+	mockW.Store(100)
+	mockH.Store(30)
 
 	// Wait for the polling interval (200ms) + buffer time
 	time.Sleep(300 * time.Millisecond)
@@ -1631,6 +1635,7 @@ func TestFrameManager_ScreensMenuUsesStructuredAlignedWorkspaceInfo(t *testing.T
 func TestFrameManager_TaskCleanup(t *testing.T) {
 	fm := &frameManager{}
 	fm.Init(NewSilentScreenBuf())
+	defer fm.Shutdown()
 
 	w1 := NewWindow(0, 0, 10, 10, "TaskWin")
 	fm.Push(w1)
@@ -1639,10 +1644,9 @@ func TestFrameManager_TaskCleanup(t *testing.T) {
 		t.Fatal("Frame not pushed")
 	}
 
-	fm.TaskChan = make(chan func(), 1)
-	fm.TaskChan <- func() {
+	fm.PostTask(func() {
 		w1.SetExitCode(0)
-	}
+	})
 
 	// Emulate Run() block extraction and execution
 	task := <-fm.TaskChan

--- a/graphics_far2l_test.go
+++ b/graphics_far2l_test.go
@@ -54,9 +54,9 @@ func TestFar2lAcknowledgementUpdatesExistingScreen(t *testing.T) {
 }
 
 func TestFar2lEncoderSetUsesPackedCropAndInclusiveArea(t *testing.T) {
-	oldID := far2lIDCounter
-	far2lIDCounter = 0
-	t.Cleanup(func() { far2lIDCounter = oldID })
+	oldID := far2lIDCounter.Load()
+	far2lIDCounter.Store(0)
+	t.Cleanup(func() { far2lIDCounter.Store(oldID) })
 
 	// Two padded rows: the command must contain only the selected 2x2 crop,
 	// not the source stride or pixels outside the source rectangle.
@@ -100,9 +100,9 @@ func TestFar2lEncoderSetUsesPackedCropAndInclusiveArea(t *testing.T) {
 }
 
 func TestFar2lEncoderDeletesStaleImages(t *testing.T) {
-	oldID := far2lIDCounter
-	far2lIDCounter = 0
-	t.Cleanup(func() { far2lIDCounter = oldID })
+	oldID := far2lIDCounter.Load()
+	far2lIDCounter.Store(0)
+	t.Cleanup(func() { far2lIDCounter.Store(oldID) })
 
 	e := newFar2lEncoder()
 	surf := NewImageSurface(1, 1)
@@ -125,9 +125,9 @@ func TestFar2lEncoderDeletesStaleImages(t *testing.T) {
 }
 
 func TestScreenBufFlushFar2lGraphics(t *testing.T) {
-	oldID := far2lIDCounter
-	far2lIDCounter = 0
-	t.Cleanup(func() { far2lIDCounter = oldID })
+	oldID := far2lIDCounter.Load()
+	far2lIDCounter.Store(0)
+	t.Cleanup(func() { far2lIDCounter.Store(oldID) })
 
 	scr := NewScreenBuf()
 	var out bytes.Buffer

--- a/localization_test.go
+++ b/localization_test.go
@@ -3,6 +3,8 @@ package vtui
 import "testing"
 
 func TestLocalization_Msg(t *testing.T) {
+	original := SnapshotStrings()
+	t.Cleanup(func() { ReplaceStrings(original) })
 	// 1. Test built-in string
 	if Msg("vtui.Ok") != "&Ok" {
 		t.Errorf("Expected '&Ok', got %q", Msg("vtui.Ok"))
@@ -28,6 +30,8 @@ func TestLocalization_Msg(t *testing.T) {
 	}
 }
 func TestReverseLookup(t *testing.T) {
+	original := SnapshotStrings()
+	t.Cleanup(func() { ReplaceStrings(original) })
 	AddStrings(map[string]string{
 		"Test.ReverseKey": "UniqueTranslatedString",
 	})

--- a/palette_test.go
+++ b/palette_test.go
@@ -2,7 +2,18 @@ package vtui
 
 import "testing"
 
+func preserveTestPalette(t *testing.T) {
+	t.Helper()
+	palette := append([]uint64(nil), Palette...)
+	themePalette := ThemePalette
+	t.Cleanup(func() {
+		Palette = palette
+		ThemePalette = themePalette
+	})
+}
+
 func TestSetDefaultPalette(t *testing.T) {
+	preserveTestPalette(t)
 	// Reset palette to ensure the function fills it
 	Palette = make([]uint64, LastPaletteColor)
 

--- a/protocol.go
+++ b/protocol.go
@@ -75,6 +75,10 @@ type ProtocolSession struct {
 	throttleMap   map[string]time.Time
 	recordFile    *os.File
 	recordStart   time.Time
+	eventMu       sync.Mutex
+	eventClosed   bool
+	eventWG       sync.WaitGroup
+	closeDone     chan struct{}
 }
 
 // NewProtocolSession creates a new protocol session over the given I/O streams.
@@ -99,6 +103,7 @@ func NewProtocolSession(in io.Reader, out io.Writer, fm *frameManager) *Protocol
 		throttleMap:   make(map[string]time.Time),
 		recordFile:    recF,
 		recordStart:   time.Now(),
+		closeDone:     make(chan struct{}),
 	}
 
 	// Wire FrameManager event sink to protocol output
@@ -136,8 +141,33 @@ func (ps *ProtocolSession) send(msg UpMessage) error {
 	return err
 }
 
+func (ps *ProtocolSession) recordDown(line []byte) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.closed || ps.recordFile == nil {
+		return
+	}
+	var raw any
+	_ = json.Unmarshal(line, &raw)
+	recLine, _ := json.Marshal(map[string]any{
+		"time": time.Since(ps.recordStart).Seconds(),
+		"dir":  "down",
+		"msg":  raw,
+	})
+	_, _ = ps.recordFile.Write(append(recLine, '\n'))
+	_ = ps.recordFile.Sync()
+}
+
 func (ps *ProtocolSession) handleUIEvent(ev UIEvent) {
+	ps.eventMu.Lock()
+	if ps.eventClosed {
+		ps.eventMu.Unlock()
+		return
+	}
+	ps.eventWG.Add(1)
+	ps.eventMu.Unlock()
 	go func() {
+		defer ps.eventWG.Done()
 		switch ev.Kind {
 		case "command":
 			_ = ps.send(UpMessage{
@@ -193,18 +223,7 @@ func (ps *ProtocolSession) Serve() error {
 		if ps.tracing {
 			fmt.Fprintf(os.Stderr, "[VTUI_TRACE:DOWN] %s\n", string(line))
 		}
-		if ps.recordFile != nil {
-			elapsed := time.Since(ps.recordStart).Seconds()
-			var raw any
-			_ = json.Unmarshal(line, &raw)
-			recLine, _ := json.Marshal(map[string]any{
-				"time": elapsed,
-				"dir":  "down",
-				"msg":  raw,
-			})
-			_, _ = ps.recordFile.Write(append(recLine, '\n'))
-			_ = ps.recordFile.Sync()
-		}
+		ps.recordDown(line)
 
 		var msg DownMessage
 		if err := json.Unmarshal(line, &msg); err != nil {
@@ -236,13 +255,17 @@ func (ps *ProtocolSession) Serve() error {
 func (ps *ProtocolSession) handleMessage(msg *DownMessage) error {
 	switch msg.Op {
 	case "hello":
-		w, h := 80, 25
-		if ps.fm != nil && ps.fm.scr != nil {
-			w, h = ps.fm.scr.width, ps.fm.scr.height
-		}
-		backend := "ansi"
+		w, h, backend := 80, 25, "ansi"
 		if ps.fm != nil {
-			backend = ps.fm.GetBackendName()
+			if err := ps.fm.callOnUI(func() error {
+				if ps.fm.scr != nil {
+					w, h = ps.fm.scr.width, ps.fm.scr.height
+				}
+				backend = ps.fm.GetBackendName()
+				return nil
+			}); err != nil {
+				return err
+			}
 		}
 		return ps.send(UpMessage{
 			Op:       "welcome",
@@ -273,50 +296,62 @@ func (ps *ProtocolSession) handleMessage(msg *DownMessage) error {
 		if frameID == "" {
 			frameID = msg.Tree.ID
 		}
-		doc := &VuiDocument{
-			VuiVersion: 1,
-			Root:       msg.Tree,
-		}
-		win, err := LoadVuiDocument(doc)
-		if err != nil {
-			return fmt.Errorf("mount error: %w", err)
-		}
-		if frameID != "" {
-			win.SetID(frameID)
-		}
-		ps.mountedFrames[frameID] = win
-		ps.fm.Push(win)
-		ps.fm.Redraw()
-		return nil
+		return ps.fm.callOnUI(func() error {
+			doc := &VuiDocument{
+				VuiVersion: 1,
+				Root:       msg.Tree,
+			}
+			win, err := LoadVuiDocument(doc)
+			if err != nil {
+				return fmt.Errorf("mount error: %w", err)
+			}
+			if frameID != "" {
+				win.SetID(frameID)
+			}
+			ps.mountedFrames[frameID] = win
+			ps.fm.Push(win)
+			ps.fm.Redraw()
+			return nil
+		})
 
 	case "patch":
-		return ps.applyPatch(msg)
+		return ps.fm.callOnUI(func() error { return ps.applyPatch(msg) })
 
 	case "call":
-		return ps.handleCall(msg)
+		return ps.fm.callOnUI(func() error { return ps.handleCall(msg) })
 
 	case "message":
 		buttons := msg.Buttons
 		if len(buttons) == 0 {
 			buttons = []string{"&Ok"}
 		}
-		dlg := ShowMessage(msg.Title, msg.Text, buttons)
-		if msg.FrameID != "" {
-			dlg.SetID(msg.FrameID)
-		}
-		ps.fm.Redraw()
-		return nil
+		return ps.fm.callOnUI(func() error {
+			dlg := createMessageDialog(msg.Title, msg.Text, buttons, legacyKindFromTitle(msg.Title))
+			if msg.FrameID != "" {
+				dlg.SetID(msg.FrameID)
+			}
+			ps.fm.Push(dlg)
+			ps.fm.Redraw()
+			return nil
+		})
 
 	case "close":
-		if f, ok := ps.mountedFrames[msg.FrameID]; ok {
-			f.Close()
-			delete(ps.mountedFrames, msg.FrameID)
-			ps.fm.Redraw()
-		}
-		return nil
+		return ps.fm.callOnUI(func() error {
+			if f, ok := ps.mountedFrames[msg.FrameID]; ok {
+				f.Close()
+				delete(ps.mountedFrames, msg.FrameID)
+				ps.fm.Redraw()
+			}
+			return nil
+		})
 
 	case "quit":
-		ps.fm.Shutdown()
+		if err := ps.fm.callOnUI(func() error {
+			ps.fm.Shutdown()
+			return nil
+		}); err != nil {
+			return err
+		}
 		return io.EOF
 
 	default:
@@ -410,9 +445,15 @@ func frameMatchesIDString(f Frame) string {
 
 // Close terminates the protocol session and tears down the UI safely.
 func (ps *ProtocolSession) Close() {
+	ps.eventMu.Lock()
+	ps.eventClosed = true
+	ps.eventMu.Unlock()
+
 	ps.mu.Lock()
 	if ps.closed {
+		done := ps.closeDone
 		ps.mu.Unlock()
+		<-done
 		return
 	}
 	ps.closed = true
@@ -421,8 +462,11 @@ func (ps *ProtocolSession) Close() {
 		ps.recordFile = nil
 	}
 	ps.mu.Unlock()
+	ps.eventWG.Wait()
 
 	if ps.fm != nil {
-		ps.fm.Shutdown()
+		ps.fm.SetEventSink(nil)
+		ps.fm.shutdownAndWait()
 	}
+	close(ps.closeDone)
 }

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -3,6 +3,7 @@ package vtui
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -17,7 +18,15 @@ func TestProtocol_Lifecycle(t *testing.T) {
 
 	fm := &frameManager{}
 	fm.Init(scr)
+	fm.Push(NewDesktop())
 	defer fm.Shutdown()
+	fm.SetHostMode(true)
+	runDone := make(chan struct{})
+	go func() {
+		fm.Run()
+		close(runDone)
+	}()
+	waitForCondition(t, time.Second, func() bool { return fm.running.Load() })
 
 	oldFM := FrameManager
 	FrameManager = fm
@@ -28,24 +37,43 @@ func TestProtocol_Lifecycle(t *testing.T) {
 
 	session := NewProtocolSession(serverReader, serverWriter, fm)
 
+	serveDone := make(chan struct{})
 	go func() {
 		_ = session.Serve()
+		close(serveDone)
 	}()
+	decoder := json.NewDecoder(clientReader)
+	readReply := func(seq int) UpMessage {
+		t.Helper()
+		for {
+			var msg UpMessage
+			if err := decoder.Decode(&msg); err != nil {
+				t.Fatalf("Failed to decode reply %d: %v", seq, err)
+			}
+			if msg.Op == "error" {
+				t.Fatalf("protocol error before reply %d: %s: %s", seq, msg.Code, msg.Message)
+			}
+			if msg.ReplyTo == seq {
+				return msg
+			}
+		}
+	}
+	barrier := func(seq int) {
+		t.Helper()
+		writeDone := make(chan struct{})
+		go func() {
+			_, _ = clientWriter.Write([]byte(fmt.Sprintf("{\"op\":\"hello\",\"seq\":%d,\"version\":1}\n", seq)))
+			close(writeDone)
+		}()
+		_ = readReply(seq)
+		<-writeDone
+	}
 
 	// 1. Send "hello"
 	helloMsg := `{"op":"hello","seq":1,"version":1}` + "\n"
 	_, _ = clientWriter.Write([]byte(helloMsg))
 
-	buf := make([]byte, 1024)
-	n, err := clientReader.Read(buf)
-	if err != nil {
-		t.Fatalf("Failed to read welcome response: %v", err)
-	}
-
-	var welcome UpMessage
-	if err := json.Unmarshal(buf[:n], &welcome); err != nil {
-		t.Fatalf("Failed to parse welcome message: %v (raw: %s)", err, string(buf[:n]))
-	}
+	welcome := readReply(1)
 
 	if welcome.Op != "welcome" || welcome.ReplyTo != 1 || welcome.Version != 1 {
 		t.Errorf("Unexpected welcome payload: %+v", welcome)
@@ -55,40 +83,55 @@ func TestProtocol_Lifecycle(t *testing.T) {
 	mountMsg := `{"op":"mount","frameId":"testDlg","tree":{"type":"Dialog","id":"testDlg","props":{"title":" Test Dialog "},"children":[{"type":"Edit","id":"userEdit","props":{"text":"Alice"}},{"type":"Button","id":"submitBtn","props":{"text":"&Ok","command":1000}}]}}` + "\n"
 
 	_, _ = clientWriter.Write([]byte(mountMsg))
-	time.Sleep(50 * time.Millisecond)
+	barrier(2)
 
-	edit, ok := fm.Lookup("testDlg", "userEdit")
-	if !ok {
-		t.Fatal("userEdit not mounted")
-	}
-	if edit.(*Edit).GetText() != "Alice" {
-		t.Errorf("Expected edit text 'Alice', got %q", edit.(*Edit).GetText())
+	var edit *Edit
+	if err := fm.callOnUI(func() error {
+		el, ok := fm.Lookup("testDlg", "userEdit")
+		if !ok {
+			return fmt.Errorf("userEdit not mounted")
+		}
+		edit = el.(*Edit)
+		if got := edit.GetText(); got != "Alice" {
+			return fmt.Errorf("expected edit text Alice, got %q", got)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 
 	// 3. Send "patch" to update Edit text (JSON Lines single line)
 	patchMsg := `{"op":"patch","frameId":"testDlg","ops":[{"kind":"set","id":"userEdit","props":{"text":"Bob"}}]}` + "\n"
 
 	_, _ = clientWriter.Write([]byte(patchMsg))
-	time.Sleep(50 * time.Millisecond)
+	barrier(3)
 
-	if edit.(*Edit).GetText() != "Bob" {
-		t.Errorf("Expected patched text 'Bob', got %q", edit.(*Edit).GetText())
+	if err := fm.callOnUI(func() error {
+		if got := edit.GetText(); got != "Bob" {
+			return fmt.Errorf("expected patched text Bob, got %q", got)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 
 	// 4. Trigger button command and verify event upstream
-	btn, ok := fm.Lookup("testDlg", "submitBtn")
-	if !ok {
-		t.Fatal("submitBtn not found")
+	if err := fm.callOnUI(func() error {
+		btn, ok := fm.Lookup("testDlg", "submitBtn")
+		if !ok {
+			return fmt.Errorf("submitBtn not found")
+		}
+		btn.(*Button).ProcessKey(&vtinput.InputEvent{
+			Type:           vtinput.KeyEventType,
+			KeyDown:        true,
+			VirtualKeyCode: vtinput.VK_RETURN,
+		})
+		return nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 
-	btn.(*Button).ProcessKey(&vtinput.InputEvent{
-		Type:           vtinput.KeyEventType,
-		KeyDown:        true,
-		VirtualKeyCode: vtinput.VK_RETURN,
-	})
-
 	var cmdEvent UpMessage
-	decoder := json.NewDecoder(clientReader)
 	for {
 		var ev UpMessage
 		if err := decoder.Decode(&ev); err != nil {
@@ -107,7 +150,16 @@ func TestProtocol_Lifecycle(t *testing.T) {
 	// 5. Send "quit"
 	quitMsg := `{"op":"quit"}` + "\n"
 	_, _ = clientWriter.Write([]byte(quitMsg))
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-serveDone:
+	case <-time.After(time.Second):
+		t.Fatal("protocol session did not stop after quit")
+	}
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("frame manager did not stop after quit")
+	}
 
 	if !fm.IsShutdown() {
 		t.Error("Expected FrameManager to be shutdown after quit")
@@ -124,18 +176,37 @@ func TestProtocol_PipeClosureTeardown(t *testing.T) {
 
 	fm := &frameManager{}
 	fm.Init(scr)
+	fm.Push(NewDesktop())
+	fm.SetHostMode(true)
+	runDone := make(chan struct{})
+	go func() {
+		fm.Run()
+		close(runDone)
+	}()
+	waitForCondition(t, time.Second, func() bool { return fm.running.Load() })
 
 	var inBuf, outBuf bytes.Buffer
 	inReader, inWriter := io.Pipe()
 	session := NewProtocolSession(inReader, &outBuf, fm)
 
+	serveDone := make(chan struct{})
 	go func() {
 		_ = session.Serve()
+		close(serveDone)
 	}()
 
 	// Closing the pipe simulates child/host crash
 	_ = inWriter.Close()
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-serveDone:
+	case <-time.After(time.Second):
+		t.Fatal("protocol session did not stop after pipe closure")
+	}
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("frame manager did not stop after pipe closure")
+	}
 
 	if !fm.IsShutdown() {
 		t.Error("Session should shutdown FrameManager on pipe closure")

--- a/scrollbar.go
+++ b/scrollbar.go
@@ -232,10 +232,16 @@ func (sb *ScrollBar) ProcessMouse(e *vtinput.InputEvent) bool {
 	}
 
 	if action != 0 {
+		if sb.repeatTimer != nil {
+			sb.repeatTimer.Stop()
+		}
 		sb.repeatAction = action
 		sb.triggerStep()
 		// Start auto-repeat
-		sb.repeatTimer = time.AfterFunc(400*time.Millisecond, sb.doRepeat)
+		fm := FrameManager
+		sb.repeatTimer = time.AfterFunc(400*time.Millisecond, func() {
+			sb.doRepeat(fm)
+		})
 	}
 
 	return true
@@ -270,13 +276,18 @@ func (sb *ScrollBar) triggerStep() {
 	}
 }
 
-func (sb *ScrollBar) doRepeat() {
-	FrameManager.PostTask(func() {
+func (sb *ScrollBar) doRepeat(fm *frameManager) {
+	if fm == nil {
+		return
+	}
+	fm.PostTask(func() {
 		if sb.repeatTimer == nil {
 			return
 		}
 		sb.triggerStep()
-		sb.repeatTimer = time.AfterFunc(50*time.Millisecond, sb.doRepeat)
+		sb.repeatTimer = time.AfterFunc(50*time.Millisecond, func() {
+			sb.doRepeat(fm)
+		})
 	})
 }
 

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -9,7 +9,7 @@ func TestRunAsync_TaskExecutionAndCancellation(t *testing.T) {
 	// Setup isolated FrameManager for the test
 	fm := &frameManager{}
 	fm.Init(NewSilentScreenBuf())
-	fm.TaskChan = make(chan func(), 10)
+	defer fm.Shutdown()
 
 	oldFm := FrameManager
 	FrameManager = fm

--- a/vreactive/property.go
+++ b/vreactive/property.go
@@ -45,17 +45,21 @@ type Property[T any] interface {
 }
 
 type property[T any] struct {
-	mu       sync.RWMutex
-	val      T
-	handlers map[int]func(T)
-	nextID   int
-	behavior BehaviorDef[T]
+	mu               sync.RWMutex
+	val              T
+	handlers         map[int]func(T)
+	nextID           int
+	behavior         BehaviorDef[T]
+	updateQueue      UpdateQueue
+	animationManager AnimationManager
 }
 
 func NewProperty[T any](initial T) Property[T] {
 	return &property[T]{
-		val:      initial,
-		handlers: make(map[int]func(T)),
+		val:              initial,
+		handlers:         make(map[int]func(T)),
+		updateQueue:      GlobalUpdateQueue,
+		animationManager: GlobalAnimationManager,
 	}
 }
 
@@ -76,10 +80,10 @@ func (p *property[T]) Set(val T) {
 	b := p.behavior
 	p.mu.RUnlock()
 
-	if b != nil && GlobalAnimationManager != nil {
+	if b != nil && p.animationManager != nil {
 		start := p.Get()
 		anim := b.CreateAnimator(start, val)
-		GlobalAnimationManager.AddAnimation(func(dt float64) bool {
+		p.animationManager.AddAnimation(func(dt float64) bool {
 			newVal, done := anim.Tick(dt)
 			p.setInternal(newVal)
 			return done
@@ -139,11 +143,15 @@ func (p *property[T]) Watch(handler func()) func() {
 // SafeSet updates the property value on the global update queue if configured.
 // Extremely useful for thread-safe mutation from background goroutines.
 func SafeSet[T any](p Property[T], val T) {
-	if GlobalUpdateQueue != nil {
-		GlobalUpdateQueue.PostTask(func() {
+	if owned, ok := p.(interface{ getUpdateQueue() UpdateQueue }); ok && owned.getUpdateQueue() != nil {
+		owned.getUpdateQueue().PostTask(func() {
 			p.Set(val)
 		})
 	} else {
 		p.Set(val)
 	}
+}
+
+func (p *property[T]) getUpdateQueue() UpdateQueue {
+	return p.updateQueue
 }

--- a/vreactive/property_test.go
+++ b/vreactive/property_test.go
@@ -22,7 +22,6 @@ func TestProperty_CycleDetection(t *testing.T) {
 }
 
 func TestProperty_SafeSet(t *testing.T) {
-	p := NewProperty(0)
 	called := false
 
 	GlobalUpdateQueue = &mockUpdateQueue{
@@ -32,6 +31,7 @@ func TestProperty_SafeSet(t *testing.T) {
 		},
 	}
 	defer func() { GlobalUpdateQueue = nil }()
+	p := NewProperty(0)
 
 	SafeSet(p, 42)
 	if !called {

--- a/vtui_test.go
+++ b/vtui_test.go
@@ -502,6 +502,9 @@ func TestEdit_Editing(t *testing.T) {
 }
 
 func TestEdit_Rendering(t *testing.T) {
+	// Rendering must use the palette this test asserts against, regardless of
+	// which palette-customizing test shuffle ran first.
+	SetDefaultPalette()
 	scr := NewSilentScreenBuf()
 	scr.AllocBuf(10, 1)
 	e := NewEdit(0, 0, 10, "abc")
@@ -512,9 +515,6 @@ func TestEdit_Rendering(t *testing.T) {
 
 	e.Show(scr)
 	e.DisplayObject(scr)
-
-	// Must initialize default palette
-	SetDefaultPalette()
 
 	colNorm := Palette[ColDialogEdit]
 	colSel := Palette[ColDialogEditSelected]

--- a/vui_loader.go
+++ b/vui_loader.go
@@ -90,11 +90,12 @@ func watchVuiFile(path string, targetWin *Window) {
 		return
 	}
 	lastMtime := fi.ModTime()
+	fm := FrameManager
 
 	go func() {
 		for {
 			time.Sleep(200 * time.Millisecond)
-			if FrameManager == nil || FrameManager.IsShutdown() {
+			if fm == nil || fm.IsShutdown() {
 				return
 			}
 			info, err := os.Stat(path)
@@ -104,7 +105,7 @@ func watchVuiFile(path string, targetWin *Window) {
 			if info.ModTime().After(lastMtime) {
 				lastMtime = info.ModTime()
 				DebugLog("VUI: Hot reloading %s...", path)
-				FrameManager.PostTask(func() {
+				fm.PostTask(func() {
 					stateMap := make(map[string]any)
 					walk(targetWin, func(el UIElement) bool {
 						id := el.GetId()
@@ -132,7 +133,7 @@ func watchVuiFile(path string, targetWin *Window) {
 						targetWin.SetPosition(newWin.X1, newWin.Y1, newWin.X2, newWin.Y2)
 						targetWin.rootGroup = newWin.rootGroup
 						targetWin.rootGroup.SetOwner(targetWin)
-						FrameManager.Redraw()
+						fm.Redraw()
 					}
 				})
 			}


### PR DESCRIPTION
`go test -race -shuffle=on ./...` показывает **31 различную пару конфликтующих обращений**. Семнадцать — жизненный цикл менеджера экрана, его запуск и изменение размера. Шесть — объекты интерфейса, которые протокол создаёт и читает одновременно. Остальные — состояние far2l, рабочие горутины диалогов и таймеры повтора у полосы прокрутки.

**Замысел библиотеки сохранён.** Граф интерфейса по-прежнему принадлежит одной горутине. Изменились пути, которые через это перешагивали.

**Протокол.** Операции над деревом интерфейса теперь выполняются на горутине интерфейса, а не мутируют его прямо из обслуживающей. Закрытие сначала отключает приёмник событий, потом дожидается уже запущенных отправок и только затем останавливает менеджер. Повторное закрытие ждёт первое, а не проскакивает мимо — это была одна из гонок.

**Жизненный цикл.** Состояние, которое читают фоновые работники — запущен, остановка, завершение — переведено на атомарные операции. Работники, запущенные из `Run`, отменяются и дожидаются до его выхода, так что опрос размера экрана больше не может пережить менеджер, который он опрашивает.

**`GetTerminalSize`** запоминается один раз при запуске. Её переназначают графические оболочки, а читала её горутина опроса — эта пара прямо фигурировала в отчётах детектора.

Рабочие горутины диалогов, таймеры повтора и счётчик запросов far2l получили то же лечение. Это не новый приём: `RunAsync` и таймеры всплывающих подсказок в этой же библиотеке уже так делают, просто не везде.

**Побочный результат.** Два теста меню, которые сборка пропускает на всех платформах, теперь проходят **по сто раз подряд** под детектором гонок. Похоже, их отключили именно из-за этих гонок. В этом изменении они оставлены отключёнными — возвращать их решать тому, кто их отключал.

**Проверено:** двадцать чистых прогонов `-race -shuffle=on` подряд, плюс восемь независимых уже вместе с двумя другими открытыми PR. Сборка, `go vet` и обычные тесты чистые.