### PR TITLE
Две взаимные блокировки в замке владения экраном

### DIFF
--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -28,9 +28,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # go.mod sets the minimum language version, while govulncheck checks the
+      # standard library used for the build, so CI needs the latest patch.
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.26.x'
 
       - name: Build
         run: go build ./...

--- a/framemanager.go
+++ b/framemanager.go
@@ -280,6 +280,8 @@ type frameManager struct {
 	running       atomic.Bool
 	stopRequested atomic.Bool
 	shutdown      atomic.Bool
+	// uiOwnershipMu serializes direct UI access with transitions into and out
+	// of Run. It must never span the event loop because callOnUI waits on it.
 	uiOwnershipMu sync.Mutex
 	lifecycleMu   sync.Mutex
 	runDone       chan struct{}
@@ -1074,14 +1076,15 @@ func (fm *frameManager) hasTaskPump() bool {
 // callOnUI runs fn on the event-loop goroutine and waits for its result. Before
 // Run starts, uiOwnershipMu makes direct setup calls and Run mutually exclusive.
 func (fm *frameManager) callOnUI(fn func() error) error {
+	fm.uiOwnershipMu.Lock()
 	if !fm.running.Load() {
-		fm.uiOwnershipMu.Lock()
 		defer fm.uiOwnershipMu.Unlock()
 		if fm.shutdown.Load() {
 			return fmt.Errorf("frame manager is shut down")
 		}
 		return fn()
 	}
+	fm.uiOwnershipMu.Unlock()
 
 	result := make(chan error, 1)
 	fm.lifecycleMu.Lock()
@@ -2300,20 +2303,24 @@ type softwareBlinkRenderer interface {
 }
 
 func (fm *frameManager) Run(readers ...*vtinput.Reader) {
+	// Only hold uiOwnershipMu while publishing the running transition. Never
+	// extend it across the event loop: callOnUI may be waiting for this lock.
 	fm.uiOwnershipMu.Lock()
-	defer fm.uiOwnershipMu.Unlock()
 	if fm.shutdown.Load() {
+		fm.uiOwnershipMu.Unlock()
 		return
 	}
-	runDone := make(chan struct{})
 	fm.lifecycleMu.Lock()
 	if fm.running.Load() {
 		fm.lifecycleMu.Unlock()
+		fm.uiOwnershipMu.Unlock()
 		return
 	}
+	runDone := make(chan struct{})
 	fm.running.Store(true)
 	fm.runDone = runDone
 	fm.lifecycleMu.Unlock()
+	fm.uiOwnershipMu.Unlock()
 	fm.stopRequested.Store(false)
 
 	if len(readers) > 0 && readers[0] != nil {
@@ -2342,6 +2349,8 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 			CleanupStderrLog()
 			os.Exit(2)
 		}
+		fm.uiOwnershipMu.Lock()
+		fm.running.Store(false)
 		if fm.shutdown.Load() {
 			fm.finishShutdown()
 		} else if fm.scr != nil {
@@ -2356,12 +2365,12 @@ func (fm *frameManager) Run(readers ...*vtinput.Reader) {
 		}
 		CleanupStderrLog()
 		fm.lifecycleMu.Lock()
-		fm.running.Store(false)
 		if fm.runDone == runDone {
 			close(runDone)
 			fm.runDone = nil
 		}
 		fm.lifecycleMu.Unlock()
+		fm.uiOwnershipMu.Unlock()
 	}()
 
 	// Configure channel for tracking window resizing

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/unxed/vtinput"
 	"io"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -74,6 +75,55 @@ func (m *mockFrame) GetTitle() string             { return "MockFrame" }
 func (m *mockFrame) GetWorkspaceTabTitle() string { return m.tabTitle }
 func (m *mockFrame) GetWorkspaceTabMarker() string {
 	return m.tabMarker
+}
+
+func TestFrameManager_CallOnUIConcurrentRunStartup(t *testing.T) {
+	done := make(chan error, 1)
+	go func() {
+		for range 100 {
+			fm := &frameManager{}
+			fm.Init(NewSilentScreenBuf())
+			fm.SetHostMode(true)
+
+			// Queue Run on the ownership lock before callOnUI observes running.
+			fm.uiOwnershipMu.Lock()
+			runStarted := make(chan struct{})
+			runDone := make(chan struct{})
+			go func() {
+				close(runStarted)
+				fm.Run()
+				close(runDone)
+			}()
+			<-runStarted
+			runtime.Gosched()
+
+			callStarted := make(chan struct{})
+			callDone := make(chan error, 1)
+			go func() {
+				close(callStarted)
+				callDone <- fm.callOnUI(func() error { return nil })
+			}()
+			<-callStarted
+			runtime.Gosched()
+			fm.uiOwnershipMu.Unlock()
+
+			// Run lifetimes vary across platforms, so a stopped-manager error is
+			// valid here; only waiting forever indicates the regression.
+			<-callDone
+			fm.Shutdown()
+			<-runDone
+		}
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("callOnUI failed during Run startup: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("callOnUI deadlocked with concurrent Run startup")
+	}
 }
 
 func TestAppScreen_GetWorkspaceTitleIgnoresModalFrames(t *testing.T) {

--- a/protocol.go
+++ b/protocol.go
@@ -346,12 +346,9 @@ func (ps *ProtocolSession) handleMessage(msg *DownMessage) error {
 		})
 
 	case "quit":
-		if err := ps.fm.callOnUI(func() error {
-			ps.fm.Shutdown()
-			return nil
-		}); err != nil {
-			return err
-		}
+		// Shutdown takes uiOwnershipMu itself before Run starts, so routing it
+		// through callOnUI would deadlock on that non-reentrant mutex.
+		ps.fm.Shutdown()
 		return io.EOF
 
 	default:

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -169,6 +169,25 @@ func TestProtocol_Lifecycle(t *testing.T) {
 	_ = serverWriter.Close()
 }
 
+func TestProtocol_QuitBeforeRunDoesNotDeadlock(t *testing.T) {
+	fm := &frameManager{}
+	session := &ProtocolSession{fm: fm}
+	done := make(chan error, 1)
+
+	go func() {
+		done <- session.handleMessage(&DownMessage{Op: "quit"})
+	}()
+
+	select {
+	case err := <-done:
+		if err != io.EOF {
+			t.Fatalf("quit returned %v, want io.EOF", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("quit deadlocked before frame manager Run")
+	}
+}
+
 func TestProtocol_PipeClosureTeardown(t *testing.T) {
 	SetDefaultPalette()
 	scr := NewSilentScreenBuf()


### PR DESCRIPTION
CI на main красный по двум независимым причинам. Обе здесь.

## Зависание на macOS

`TestReplaySession_Verification` висит до четырёхминутного таймаута. Не мигание: перезапуск джобы даёт то же самое.

Механизм `callOnUI` / `uiOwnershipMu`, появившийся в 461c57e, блокируется двумя способами.

Первый. `Run` держал замок всё время своей работы, то есть всю жизнь менеджера. `callOnUI` встаёт на этот замок, когда читает `running` как false, — а между чтением и захватом `Run` успевает стартовать. Дальше ожидание кончится только вместе с `Run`, а `Run` кончается по `Shutdown`, который приходит сообщением `quit` из той же очереди, позади заблокированного вызова.

Теперь замок держится только на переключении флага и на разборе при выходе. Взаимное исключение сохраняется целиком: прямой вызов по-прежнему выполняется под замком и только когда `running` равен false, а поднять флаг `Run` может тоже лишь под ним.

Второй. Обработчик `quit` пропускал `Shutdown` через `callOnUI`, который выполняет переданную функцию под захваченным замком, — а `Shutdown` берёт тот же нереентрантный замок. Вызов напрямую: он и так безопасен с любой горутины, для того и запирается сам.

Оба регрессионных теста падают по таймауту внутри себя, а не подвешивают прогон. Это важно: сегодня поломка выглядела как четырёхминутное зависание вместо красного теста. Проверены в обоих состояниях — на коде до правки падают за секунду и за пять.

## govulncheck

`setup-go` брал версию из `go.mod`, и govulncheck находил три уязвимости в стандартной библиотеке именно этой сборки: GO-2026-4971 в `net`, GO-2026-4602 в `os`, GO-2026-4601 в `net/url`. Уязвим был тулчейн, а не vtui.

Директива `go` — нижняя граница языка для всех, кто подключает библиотеку, а не версия для сборки. Просим ветку и берём свежий патч. Поднятие `go.mod` до 1.26.6 в 14d3e49 закрывает ту же дыру, но её придётся поднимать при каждой следующей уязвимости и она поднимает планку всем потребителям.

## Проверено

gofmt, build, vet, сборка под 32 бита, govulncheck, actionlint — чисто. Все тесты проходят. 500 прогонов `TestReplaySession_Verification` — 500 из 500. Детектор гонок — ноль предупреждений: правился ровно тот механизм, который в 461c57e закрывал тридцать одну гонку, они не вернулись.

Заодно ушла тормознутость: пятьсот прогонов replay занимают 0,7 секунды вместо примерно 280. Всё это время процесс стоял в почти-блокировках.

Не чинится здесь: `TestEveryLayerIsPositionedAgain` из 66b3327 падает и на чистом main, отдельно от этого. Описал в issue.