### PR TITLE
Детектор гонок и снятие устаревшего пропуска двух тестов

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,21 +46,24 @@ jobs:
         with:
           go-version: '1.26.x'
 
-      # The race detector is not part of this workflow yet; a separate job
-      # will be added later. The screen-manager, protocol teardown and Far2l
-      # races that originally kept it out have been fixed.
-      #
-      # The two skipped tests drive fm.Run with a reader on os.Stdin and rely
-      # on Run returning when stdin hits EOF. That holds on Windows, but on
-      # the macOS runner the event channel never closes and the whole suite
-      # hangs until the go test timeout. They stay skipped everywhere for now
-      # so the skip set does not vary by platform; unskip once fm.Run's exit
-      # no longer depends on platform stdin semantics.
       - name: Test
-        run: >
-          go test -count=1 -timeout 4m
-          -skip 'TestFrameManager_MenuBarNavigabilityWithSubMenu|TestFrameManager_ModalDialogBlocksF9'
-          ./...
+        run: go test -count=1 -timeout 4m ./...
+
+  race:
+    name: Race
+    runs-on: ubuntu-latest
+    env:
+      # The rest of this workflow intentionally keeps cgo disabled. Enabling
+      # it here does not reverse that decision: the race detector requires it.
+      CGO_ENABLED: 1
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+
+      - run: go test -race -count=1 -timeout 15m ./...
 
   vulnerabilities:
     name: Vulnerabilities


### PR DESCRIPTION
## Детектор гонок

После того как в #94 и #95 закрыли гонки вокруг менеджера экрана, протокола и Far2l, за ними не следит никто. Тридцать одна закрытая пара конкурентных обращений может вернуться незамеченной.

Одна джоба, весь пакет, один прогон — около минуты. Исключений по пакетам не нужно, всё проходит начисто, ноль предупреждений.

Это единственная джоба в файле с включённым cgo. Не потому, что правило «vtui собирается без cgo» тут гнётся, а потому, что детектору cgo необходим. В комментарии это оговорено.

## Пропуск двух тестов устарел десять дней назад

`44a3b21` (11 августа) добавил пропуск `TestFrameManager_MenuBarNavigabilityWithSubMenu` и `TestFrameManager_ModalDialogBlocksF9`, потому что оба делали так:

```go
fm.Run(vtinput.NewReader(os.Stdin, false))
```

и ждали, что `Run` вернётся, когда закончится стандартный ввод. На раннере macOS он не заканчивался, и весь прогон висел до таймаута.

`5132c57` (16 августа) заменил блокирующий цикл на `InjectEvents` и `Step`. Сегодня в этих тестах нет ни `Run`, ни `os.Stdin` — только вброс события и один шаг. То есть условие, которое комментарий к пропуску сам называл поводом его снять, «когда выход из `Run` перестанет зависеть от поведения стандартного ввода», выполнено.

Проверено: весь пакет без единого пропуска зелёный, оба теста проходят 20 раз подряд обычным прогоном и 50 раз подряд под детектором.

К гонкам этот пропуск отношения не имел: на коммите до их починки оба теста проходят так же.