### PR TITLE
textseg: fold decomposed clusters to NFC before layout

### DIFF
--- a/textseg.go
+++ b/textseg.go
@@ -7,6 +7,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/mattn/go-runewidth"
 	"github.com/rivo/uniseg"
 )
@@ -68,8 +70,7 @@ func RegisterCluster(cluster string) uint64 {
 	if cluster == "" {
 		return 0
 	}
-	r, size := utf8.DecodeRuneInString(cluster)
-	if size == len(cluster) {
+	if r, size := utf8.DecodeRuneInString(cluster); size == len(cluster) {
 		return uint64(r)
 	}
 
@@ -80,18 +81,39 @@ func RegisterCluster(cluster string) uint64 {
 		return id
 	}
 
+	// Cache miss. Fold a decomposed sequence to its precomposed form first
+	// (SanitizeCluster already does this for text that went through the
+	// layout walk, so this only pays off for direct callers), then cache the
+	// result under the raw spelling too: repeat frames stay allocation-free
+	// whichever spelling arrives.
+	raw := cluster
+	if nfc := norm.NFC.String(cluster); nfc != cluster {
+		cluster = nfc
+	}
+
 	clusters.mu.Lock()
 	defer clusters.mu.Unlock()
-	if id, ok := clusters.byStr[cluster]; ok {
+	if id, ok := clusters.byStr[raw]; ok {
 		return id
 	}
-	next := CompCharFlag | uint64(len(clusters.byID)+1)
-	if next > MaxCompChar {
-		return uint64(r)
+	if r, size := utf8.DecodeRuneInString(cluster); size == len(cluster) {
+		id = uint64(r)
+	} else if existing, ok := clusters.byStr[cluster]; ok {
+		id = existing
+	} else {
+		next := CompCharFlag | uint64(len(clusters.byID)+1)
+		if next > MaxCompChar {
+			r, _ := utf8.DecodeRuneInString(cluster)
+			return uint64(r) // lossy fallback; deliberately not cached
+		}
+		clusters.byID = append(clusters.byID, cluster)
+		clusters.byStr[cluster] = next
+		id = next
 	}
-	clusters.byID = append(clusters.byID, cluster)
-	clusters.byStr[cluster] = next
-	return next
+	if raw != cluster {
+		clusters.byStr[raw] = id
+	}
+	return id
 }
 
 // CellString returns the text a cell carries. Fillers and empty cells render
@@ -292,6 +314,13 @@ func SanitizeCluster(cluster string) (string, int) {
 		return string(runeControlVisible), 1
 	case size == len(cluster) && unicode.Is(unicode.Cf, r):
 		return string(runeControlVisible), 1
+	}
+	// Fold a decomposed sequence to its precomposed form before the width
+	// is taken, so width, stored cluster and cursor advance all agree, and
+	// so a letter with an NFC equivalent ("и"+U+0306) reaches every backend
+	// as the plain rune ("й") terminals render as one ordinary cell.
+	if size != len(cluster) && !norm.NFC.IsNormalString(cluster) {
+		cluster = norm.NFC.String(cluster)
 	}
 	if clusterColumns(cluster) == 0 {
 		cluster = string(runeMarkBase) + cluster

--- a/textseg.go
+++ b/textseg.go
@@ -97,14 +97,14 @@ func RegisterCluster(cluster string) uint64 {
 		return id
 	}
 	if r, size := utf8.DecodeRuneInString(cluster); size == len(cluster) {
-		id = uint64(r)
+		id = uint64(r) //nolint:gosec // DecodeRuneInString never returns a negative rune
 	} else if existing, ok := clusters.byStr[cluster]; ok {
 		id = existing
 	} else {
 		next := CompCharFlag | uint64(len(clusters.byID)+1)
 		if next > MaxCompChar {
 			r, _ := utf8.DecodeRuneInString(cluster)
-			return uint64(r) // lossy fallback; deliberately not cached
+			return uint64(r) //nolint:gosec // never negative; lossy fallback, deliberately not cached
 		}
 		clusters.byID = append(clusters.byID, cluster)
 		clusters.byStr[cluster] = next

--- a/textseg_test.go
+++ b/textseg_test.go
@@ -187,13 +187,14 @@ func TestCellString_SpecialCells(t *testing.T) {
 	}
 }
 
+// A decomposed letter is kept in one cell, stored in its precomposed (NFC) form.
 func TestStringToCharInfo_KeepsMarksWithBase(t *testing.T) {
 	ci := StringToCharInfo("e\u0301X", 7)
 	if len(ci) != 2 {
 		t.Fatalf("expected 2 cells, got %d", len(ci))
 	}
-	if CellString(ci[0].Char) != "e\u0301" {
-		t.Errorf("cell 0: got %q, want %q", CellString(ci[0].Char), "e\u0301")
+	if CellString(ci[0].Char) != "é" {
+		t.Errorf("cell 0: got %q, want %q", CellString(ci[0].Char), "é")
 	}
 	if ci[1].Char != 'X' {
 		t.Errorf("cell 1: got %X, want 'X'", ci[1].Char)
@@ -350,7 +351,10 @@ func TestTruncateString_NeverSplitsACluster(t *testing.T) {
 	if got := TruncateString("A世B", 3, ""); got != "A世" {
 		t.Errorf("got %q, want %q", got, "A世")
 	}
-	if got := TruncateString("e\u0301XY", 2, ""); got != "e\u0301X" {
+	if got := TruncateString("e\u0301XY", 2, ""); got != "\u00e9X" {
+		// The truncating path rebuilds from sanitized clusters, which fold
+		// decomposed sequences to NFC; the mark still travels with its
+		// base, stored precomposed.
 		t.Errorf("combining mark must travel with its base: got %q", got)
 	}
 	if got := TruncateString("abcdef", 4, "…"); got != "abc…" {
@@ -409,5 +413,38 @@ func TestEmojiPresentationWideSetting(t *testing.T) {
 	EmojiPresentationWide = true
 	if got := ClusterWidth("❤\uFE0F"); got != 2 {
 		t.Errorf("with the setting on emoji presentation is wide: got %d, want 2", got)
+	}
+}
+
+// TestRegisterCluster_NFC: a decomposed letter is stored as its precomposed
+// rune so every backend renders it as one ordinary cell.
+func TestRegisterCluster_NFC(t *testing.T) {
+	if got := RegisterCluster("и\u0306"); got != uint64('й') {
+		t.Fatalf("RegisterCluster(NFD й) = %#x, want %#x", got, uint64('й'))
+	}
+	if got := RegisterCluster("e\u0301"); got != uint64('é') {
+		t.Fatalf("RegisterCluster(NFD é) = %#x, want %#x", got, uint64('é'))
+	}
+	if got := RegisterCluster("a\u0305"); !IsCompChar(got) {
+		t.Fatalf("RegisterCluster(a+overline) = %#x, want composite", got)
+	}
+}
+
+// TestStringToCharInfo_NFDHangul: decomposed Hangul (what macOS filesystems
+// return) is folded to the composed syllable, one wide cell plus filler.
+func TestStringToCharInfo_NFDHangul(t *testing.T) {
+	const nfd = "\u1112\u1161\u11ab" // NFD 한
+	ci := StringToCharInfo(nfd, 0)
+	if len(ci) != 2 {
+		t.Fatalf("expected 2 cells for NFD 한, got %d", len(ci))
+	}
+	if CellString(ci[0].Char) != "한" {
+		t.Errorf("cell 0: got %q, want %q", CellString(ci[0].Char), "한")
+	}
+	if ci[1].Char != WideCharFiller {
+		t.Errorf("cell 1: got %#x, want WideCharFiller", ci[1].Char)
+	}
+	if got := StringWidth(nfd); got != 2 {
+		t.Errorf("StringWidth = %d, want 2", got)
 	}
 }

--- a/x11_host_test.go
+++ b/x11_host_test.go
@@ -165,8 +165,11 @@ func TestX11Host_SendEvent_ClosedChannelSafety(t *testing.T) {
 }
 
 func TestX11Renderer_GlyphCacheUniqueness(t *testing.T) {
-	ch1 := RegisterCluster("e\u0301")
-	ch2 := RegisterCluster("e\u0308")
+	// Clusters with no precomposed form, so they stay composite: NFC folds
+	// "e\u0301"-style sequences to plain runes and they would never hit the
+	// glyph-key path this test guards.
+	ch1 := RegisterCluster("a\u0305")
+	ch2 := RegisterCluster("e\u0305")
 
 	key1 := glyphKey{ch1, 0, 0, 1}
 	key2 := glyphKey{ch2, 0, 0, 1}


### PR DESCRIPTION
## Problem

Filenames spelled in decomposed Unicode (NFD) — `и`+U+0306 for `й`, or the three-jamo Hangul that macOS filesystems return — reach the screen as multi-rune composite clusters. On terminals that do not cluster graphemes (ConPTY, older emulators) the cursor advances once per code point for such a cell. The renderer's resync (6d9351d, "resync the cursor after cells the terminal may measure differently") keeps the row straight, but the re-anchor overwrites the stray mark cell, so the letter loses its accent: `Майно` renders as `Маино`. The Win32 console backend (`charInfoToWin32`) drops the mark outright, since a CHAR_INFO cell holds a single UTF-16 unit.

Seen in practice in f4 file panels listing NFD-named files (the same family of symptoms as unxed/f4#546).

## Fix

Fold decomposed sequences to their precomposed (NFC) form with `golang.org/x/text/unicode/norm` (already an indirect dependency):

- **`SanitizeCluster`** normalizes a multi-rune cluster before its width is taken, so width, stored cluster and cursor advance all agree, and a letter with an NFC equivalent reaches every backend as a plain rune that every terminal renders as one ordinary cell. `norm.NFC.IsNormalString` gates the fold — already-NFC clusters (the common case) pay one scan, no allocation.
- **`RegisterCluster`** applies the same fold for direct callers — only on a registry miss, and the result is cached under the raw spelling too, so repeat frames stay allocation-free whichever spelling arrives.

Clusters with no precomposed form (e.g. `a`+U+0305) still go through the composite path and are covered by the existing resync.

## Tests

- `TestRegisterCluster_NFC`: NFD `й`/`é` become plain runes; `a`+U+0305 stays composite.
- `TestStringToCharInfo_NFDHangul`: NFD `한` becomes one wide cell plus filler, `StringWidth == 2`.
- `TestStringToCharInfo_KeepsMarksWithBase` updated: the mark still travels with its base, stored precomposed.
- `TestX11Renderer_GlyphCacheUniqueness` switched to non-composable clusters, which are the only ones that still reach the glyph-key path it guards.

Full suite passes on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrA7zP1nKDotzPP7q5fYMN
