### PR TITLE
scrollview: PgUp/PgDn page by a screenful, scrolls clamp at the ends

### DIFF
--- a/scrollview.go
+++ b/scrollview.go
@@ -63,32 +63,92 @@ func (sv *ScrollView) GetRowProvider() RowProvider {
 
 // ScrollBy shifts the view and the selection by the same amount, keeping the cursor vertically stable.
 // If the view hits a boundary, the remaining scroll delta is applied to the cursor.
+// The selection clamps at the list ends even when Wrap is on: wrapping is an
+// arrow-key affordance, and a wheel notch or page jump at the boundary should
+// stop there, not teleport across the list.
 func (sv *ScrollView) ScrollBy(delta int) {
-	if sv.ItemCount == 0 {
+	if sv.ItemCount == 0 || delta == 0 {
 		return
 	}
 
-	targetTop := sv.TopPos + delta
-	maxTop := sv.ItemCount - sv.ViewHeight
-	if maxTop < 0 {
-		maxTop = 0
+	if sv.ViewHeight > 0 {
+		targetTop := sv.TopPos + delta
+		maxTop := sv.ItemCount - sv.ViewHeight
+		if maxTop < 0 {
+			maxTop = 0
+		}
+		if targetTop < 0 {
+			targetTop = 0
+		}
+		if targetTop > maxTop {
+			targetTop = maxTop
+		}
+		sv.TopPos = targetTop
 	}
-	if targetTop < 0 {
-		targetTop = 0
+	// With ViewHeight 0 (not laid out yet) TopPos is left alone: any shift
+	// would be meaningless and EnsureVisible cannot repair it.
+
+	// SetSelectPos re-runs EnsureVisible, which reconciles TopPos when the
+	// clamped or nudged selection lands outside the shifted view.
+	sv.setSelectPosClamped(sv.SelectPos+delta, delta)
+}
+
+// setSelectPosClamped clamps target to the list bounds, steers it off
+// unselectable rows (first continuing in the direction of travel, then
+// backwards), and applies it. When no row is selectable at all the clamped
+// target is kept: virtualized consumers drive ItemCount without backing
+// items, and their rows all report unselectable.
+func (sv *ScrollView) setSelectPosClamped(target, dir int) {
+	if target < 0 {
+		target = 0
 	}
-	if targetTop > maxTop {
-		targetTop = maxTop
+	if target >= sv.ItemCount {
+		target = sv.ItemCount - 1
 	}
+	if sv.IsSelectable != nil && !sv.IsSelectable(target) {
+		step := 1
+		if dir < 0 {
+			step = -1
+		}
+		found := -1
+		for p := target + step; p >= 0 && p < sv.ItemCount; p += step {
+			if sv.IsSelectable(p) {
+				found = p
+				break
+			}
+		}
+		if found == -1 {
+			for p := target - step; p >= 0 && p < sv.ItemCount; p -= step {
+				if sv.IsSelectable(p) {
+					found = p
+					break
+				}
+			}
+		}
+		if found != -1 {
+			target = found
+		}
+	}
+	sv.SetSelectPos(target)
+}
 
-	// Move the cursor by the requested delta to keep it physically stable on the screen,
-	// or to push it towards the boundary if the view itself cannot scroll further.
-	sv.MoveSelection(delta)
-
-	// Force the view to the calculated target
-	sv.TopPos = targetTop
-
-	// Safety check in case MoveSelection jumped out of bounds due to unselectable items
-	sv.EnsureVisible()
+// PageBy moves the view and the selection one screenful up (dir < 0) or down
+// (dir > 0). Repeated presses walk the list a screen at a time, keep the
+// cursor on its row within the view, and stop at the ends without wrapping.
+// Before layout (ViewHeight 0) it degrades to a single-row move so the keys
+// still act.
+func (sv *ScrollView) PageBy(dir int) {
+	if dir == 0 {
+		return
+	}
+	page := sv.ViewHeight
+	if page < 1 {
+		page = 1
+	}
+	if dir < 0 {
+		page = -page
+	}
+	sv.ScrollBy(page)
 }
 
 func (sv *ScrollView) MoveRelative(dx, dy int) {
@@ -246,9 +306,9 @@ func (sv *ScrollView) HandleNavKey(vk uint16) bool {
 	case vtinput.VK_DOWN:
 		sv.MoveSelection(1)
 	case vtinput.VK_PRIOR:
-		sv.MoveSelection(-sv.ViewHeight)
+		sv.PageBy(-1)
 	case vtinput.VK_NEXT:
-		sv.MoveSelection(sv.ViewHeight)
+		sv.PageBy(1)
 	case vtinput.VK_HOME:
 		sv.SetSelectPos(0)
 	case vtinput.VK_END:

--- a/vmenu.go
+++ b/vmenu.go
@@ -139,30 +139,31 @@ func (m *VMenu) ProcessKey(e *vtinput.InputEvent) bool {
 			return false
 		}
 		return m.HandleKey(e)
-	case vtinput.VK_PRIOR: // PgUp
-		m.SetSelectPos(0)
-		return true
-	case vtinput.VK_NEXT: // PgDn
-		m.SetSelectPos(m.ItemCount - 1)
-		return true
+	// PgUp/PgDn fall through to HandleKey like Home/End do: HandleNavKey
+	// pages via PageBy, which clamps at the list ends even though Wrap is on.
 	case vtinput.VK_ESCAPE, vtinput.VK_F10:
 		m.SetExitCode(-1)
 		return FrameManager.GetTopFrame() == Frame(m)
 	case vtinput.VK_RETURN:
 		if m.SelectPos >= 0 && m.SelectPos < m.ItemCount {
-			item := m.Items[m.SelectPos]
-			if item.Separator {
-				return true
-			}
-			if FrameManager.DisabledCommands.IsDisabled(item.Command) {
-				return true
-			}
+			// Virtual consumers size the menu via ItemCount without backing
+			// Items; such rows carry no command to fire, but the selection is
+			// still confirmed through OnAction and the exit code.
+			if m.SelectPos < len(m.Items) {
+				item := m.Items[m.SelectPos]
+				if item.Separator {
+					return true
+				}
+				if FrameManager.DisabledCommands.IsDisabled(item.Command) {
+					return true
+				}
 
-			// 1. Fire the actual action (bubbles through owner)
-			oldCmd := m.Command
-			m.Command = item.Command
-			m.FireAction(item.OnClick, item.UserData)
-			m.Command = oldCmd
+				// 1. Fire the actual action (bubbles through owner)
+				oldCmd := m.Command
+				m.Command = item.Command
+				m.FireAction(item.OnClick, item.UserData)
+				m.Command = oldCmd
+			}
 
 			// 2. Notify listener (may close the menu)
 			if m.OnAction != nil {
@@ -268,7 +269,9 @@ func (m *VMenu) ProcessMouse(e *vtinput.InputEvent) bool {
 		if hoverIdx == -1 {
 			return false
 		}
-		if !m.Items[hoverIdx].Separator {
+		// Rows past len(Items) belong to virtual consumers that only set
+		// ItemCount; they are plain selectable rows, not separators.
+		if hoverIdx >= len(m.Items) || !m.Items[hoverIdx].Separator {
 			m.SetSelectPos(hoverIdx)
 		}
 		return true
@@ -276,18 +279,22 @@ func (m *VMenu) ProcessMouse(e *vtinput.InputEvent) bool {
 
 	if e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown {
 		clickIdx := m.GetClickIndex(int(e.MouseY))
-		if clickIdx != -1 && !m.Items[clickIdx].Separator {
+		if clickIdx != -1 && (clickIdx >= len(m.Items) || !m.Items[clickIdx].Separator) {
 			m.SetSelectPos(clickIdx)
-			item := m.Items[clickIdx]
-			if FrameManager.DisabledCommands.IsDisabled(item.Command) {
-				return true
-			}
+			// Virtual rows (ItemCount beyond len(Items)) have no command to
+			// fire; the click still selects and confirms them.
+			if clickIdx < len(m.Items) {
+				item := m.Items[clickIdx]
+				if FrameManager.DisabledCommands.IsDisabled(item.Command) {
+					return true
+				}
 
-			// Fire Action BEFORE calling OnAction/SetExitCode
-			oldCmd := m.Command
-			m.Command = item.Command
-			m.FireAction(item.OnClick, item.UserData)
-			m.Command = oldCmd
+				// Fire Action BEFORE calling OnAction/SetExitCode
+				oldCmd := m.Command
+				m.Command = item.Command
+				m.FireAction(item.OnClick, item.UserData)
+				m.Command = oldCmd
+			}
 
 			if m.OnAction != nil {
 				m.OnAction(clickIdx)

--- a/vmenu_test.go
+++ b/vmenu_test.go
@@ -27,16 +27,186 @@ func TestVMenu_BoundaryNavigation(t *testing.T) {
 		t.Error("Up at index 0 should return false when Wrap=false")
 	}
 
-	// 3. Test PgUp/PgDn jumps
+	// 3. PgDn on a menu shorter than a page still lands on the last item
+	m.SetPosition(0, 0, 20, 4) // ViewHeight 3 > 2 items
 	m.SetSelectPos(0)
 	m.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_NEXT})
 	if m.SelectPos != 1 {
-		t.Error("PgDn failed to jump to end")
+		t.Error("PgDn failed to reach the last item")
 	}
 
 	// 3. Left/Right in standalone menu should return false (boundary exit)
 	if m.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_LEFT}) {
 		t.Error("Left in standalone menu should return false")
+	}
+}
+
+func TestVMenu_PageNavigation(t *testing.T) {
+	key := func(vk uint16) *vtinput.InputEvent {
+		return &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vk}
+	}
+
+	m := NewVMenu("Page")
+	for i := 0; i < 12; i++ {
+		m.AddItem(MenuItem{Text: "Item"})
+	}
+	// 7 rows minus top/bottom margins -> ViewHeight = 5
+	m.SetPosition(0, 0, 20, 6)
+	if m.ViewHeight != 5 {
+		t.Fatalf("test setup: expected ViewHeight 5, got %d", m.ViewHeight)
+	}
+
+	m.SetSelectPos(2)
+
+	// PgDn advances selection and view by one page, keeping the cursor row
+	if !m.ProcessKey(key(vtinput.VK_NEXT)) {
+		t.Fatal("PgDn should be handled")
+	}
+	if m.SelectPos != 7 || m.TopPos != 5 {
+		t.Fatalf("after PgDn expected SelectPos=7 TopPos=5, got %d/%d", m.SelectPos, m.TopPos)
+	}
+
+	// Second PgDn clamps at the last item; TopPos clamps at ItemCount-ViewHeight
+	m.ProcessKey(key(vtinput.VK_NEXT))
+	if m.SelectPos != 11 || m.TopPos != 7 {
+		t.Fatalf("after 2nd PgDn expected SelectPos=11 TopPos=7, got %d/%d", m.SelectPos, m.TopPos)
+	}
+
+	// PgDn at the end must stay put, not wrap to the top (Wrap is on by default)
+	m.ProcessKey(key(vtinput.VK_NEXT))
+	if m.SelectPos != 11 || m.TopPos != 7 {
+		t.Fatalf("PgDn at end must clamp, got SelectPos=%d TopPos=%d", m.SelectPos, m.TopPos)
+	}
+
+	// PgUp mirrors the paging back...
+	m.ProcessKey(key(vtinput.VK_PRIOR))
+	if m.SelectPos != 6 || m.TopPos != 2 {
+		t.Fatalf("after PgUp expected SelectPos=6 TopPos=2, got %d/%d", m.SelectPos, m.TopPos)
+	}
+	m.ProcessKey(key(vtinput.VK_PRIOR))
+	if m.SelectPos != 1 || m.TopPos != 0 {
+		t.Fatalf("after 2nd PgUp expected SelectPos=1 TopPos=0, got %d/%d", m.SelectPos, m.TopPos)
+	}
+
+	// ...and clamps at item 0 without wrapping to the end
+	m.ProcessKey(key(vtinput.VK_PRIOR))
+	if m.SelectPos != 0 || m.TopPos != 0 {
+		t.Fatalf("PgUp at start must clamp, got SelectPos=%d TopPos=%d", m.SelectPos, m.TopPos)
+	}
+
+	// Virtual list: ItemCount set directly with no Items populated (f4-style
+	// Find All frame). Paging must not touch len(m.Items).
+	v := NewVMenu("Virtual")
+	v.ItemCount = 40
+	v.SetPosition(0, 0, 20, 6)
+	v.SetSelectPos(0)
+	v.ProcessKey(key(vtinput.VK_NEXT))
+	if v.SelectPos != 5 || v.TopPos != 5 {
+		t.Fatalf("virtual PgDn expected SelectPos=5 TopPos=5, got %d/%d", v.SelectPos, v.TopPos)
+	}
+	v.ProcessKey(key(vtinput.VK_PRIOR))
+	if v.SelectPos != 0 || v.TopPos != 0 {
+		t.Fatalf("virtual PgUp expected SelectPos=0 TopPos=0, got %d/%d", v.SelectPos, v.TopPos)
+	}
+}
+
+func TestVMenu_PageSkipsSeparator(t *testing.T) {
+	m := NewVMenu("Sep")
+	for i := 0; i < 5; i++ {
+		m.AddItem(MenuItem{Text: "Item"})
+	}
+	m.AddSeparator() // index 5
+	for i := 0; i < 6; i++ {
+		m.AddItem(MenuItem{Text: "Item"})
+	}
+	m.SetPosition(0, 0, 20, 6) // ViewHeight 5
+	m.SetSelectPos(0)
+
+	// PgDn lands on the separator at index 5 and must step past it
+	m.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_NEXT})
+	if m.SelectPos != 6 {
+		t.Fatalf("PgDn must skip the separator, expected SelectPos=6, got %d", m.SelectPos)
+	}
+
+	// PgUp from 6 lands on index 1; on the way back the separator is not hit,
+	// but paging up from 6+... exercise the reverse nudge too: from index 10,
+	// PgUp lands on 5 (separator) and must continue upward to 4.
+	m.SetSelectPos(10)
+	m.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_PRIOR})
+	if m.SelectPos != 4 {
+		t.Fatalf("PgUp must skip the separator, expected SelectPos=4, got %d", m.SelectPos)
+	}
+}
+
+func TestVMenu_WheelAtEdgeClampsInsteadOfWrapping(t *testing.T) {
+	m := NewVMenu("Wheel")
+	for i := 0; i < 12; i++ {
+		m.AddItem(MenuItem{Text: "Item"})
+	}
+	m.SetPosition(0, 0, 20, 6) // ViewHeight 5
+	m.SetSelectPos(11)         // bottom: TopPos 7
+
+	handled := m.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, WheelDirection: -1})
+	if !handled {
+		t.Fatal("wheel scroll should be handled")
+	}
+	if m.SelectPos != 11 || m.TopPos != 7 {
+		t.Fatalf("wheel down at bottom must clamp, not wrap to top: SelectPos=%d TopPos=%d", m.SelectPos, m.TopPos)
+	}
+
+	m.SetSelectPos(0)
+	m.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType, WheelDirection: 1})
+	if m.SelectPos != 0 || m.TopPos != 0 {
+		t.Fatalf("wheel up at top must clamp, not wrap to bottom: SelectPos=%d TopPos=%d", m.SelectPos, m.TopPos)
+	}
+}
+
+func TestVMenu_VirtualListEnterAndHoverDoNotPanic(t *testing.T) {
+	m := NewVMenu("Virtual")
+	m.ItemCount = 40 // no Items populated
+	m.SetPosition(0, 0, 20, 6)
+	m.SetSelectPos(3)
+
+	confirmed := -1
+	m.OnAction = func(i int) { confirmed = i }
+
+	// Enter on a virtual row: no item command to fire, but the selection is
+	// confirmed and the menu closes with it.
+	m.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN})
+	if confirmed != 3 {
+		t.Fatalf("Enter on a virtual row should confirm via OnAction, got %d", confirmed)
+	}
+	if !m.IsDone() || m.exitCode != 3 {
+		t.Fatalf("Enter on a virtual row should close with its index, done=%v exit=%d", m.IsDone(), m.exitCode)
+	}
+
+	// Hover over a virtual row selects it
+	m.ClearDone()
+	handled := m.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		MouseX:          5,
+		MouseY:          2, // row 1 of content -> index TopPos+1
+		MouseEventFlags: vtinput.MouseMoved,
+	})
+	if !handled {
+		t.Fatal("hover over a virtual row should be handled")
+	}
+	if m.SelectPos != m.TopPos+1 {
+		t.Fatalf("hover should select the virtual row, expected %d, got %d", m.TopPos+1, m.SelectPos)
+	}
+
+	// Click on a virtual row confirms it
+	confirmed = -1
+	clickIdx := m.TopPos + 2
+	m.ProcessMouse(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		MouseX:      5,
+		MouseY:      3,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		KeyDown:     true,
+	})
+	if confirmed != clickIdx {
+		t.Fatalf("click on a virtual row should confirm via OnAction, expected %d, got %d", clickIdx, confirmed)
 	}
 }
 


### PR DESCRIPTION
## Problem

`VMenu.ProcessKey` handled PgUp/PgDn by jumping to the first/last item (`SetSelectPos(0)` / `SetSelectPos(ItemCount-1)`), so paging a long menu was impossible. Reported against f4''s editor "Find All" occurrences list, but it affects every VMenu on every platform.

The obvious delegation to `MoveSelection(±ViewHeight)` would not work either: `NewVMenu` sets `Wrap = true`, and `MoveSelection` steps one item at a time with wrapping, so a page-sized move near the ends would wrap around the list instead of clamping. The same defect was already reachable through the mouse wheel — `ScrollBy` fed the selection through `MoveSelection`, so a wheel notch at the bottom of a menu teleported to the top.

## Fix

The fix lives in `ScrollView`, so paging and the wheel agree across every widget:

- `ScrollBy` now moves the selection with an explicit clamp instead of `MoveSelection`. Wrap stays an arrow-key affordance; page and wheel moves stop at the list ends. The landing row is nudged off unselectable rows (forward in the direction of travel first, then backward), and when nothing is selectable the clamped position is kept — that is the virtual-list case, where consumers (e.g. f4''s Find All frame) set `ItemCount` without populating `Items`.
- `TopPos` shifts by the same delta before the selection, so the cursor keeps its relative row within the view while paging, matching Far Manager''s feel. With `ViewHeight` 0 (keys before layout) the view no longer shifts at all, closing a ratchet that could push `TopPos` past the list.
- New `PageBy(dir)` wraps this as the shared page-move primitive. `HandleNavKey` uses it, and VMenu''s PgUp/PgDn now simply fall through to `HandleKey` like Home/End already did (Home/End behavior unchanged).
- VMenu''s Enter, hover, and click paths stop indexing `Items` for rows at or past `len(Items)`: virtual rows select and confirm through `OnAction`/exit code instead of panicking.

Behavior note: consumers that page (window switcher, Edit history popup) now move a screenful per press instead of jumping to the ends; menus shorter than a page still reach the first/last item in one press.

## Tests

- `TestVMenu_PageNavigation`: 12 items over a 5-row view — PgDn advances `SelectPos` and `TopPos` by a page keeping the cursor row, clamps at the last item without wrapping, PgUp mirrors back to item 0; plus a virtual-list (`ItemCount` only) round trip.
- `TestVMenu_PageSkipsSeparator`: nudge in both directions.
- `TestVMenu_WheelAtEdgeClampsInsteadOfWrapping`: fails against the old `ScrollBy`, passes now.
- `TestVMenu_VirtualListEnterAndHoverDoNotPanic`: Enter/hover/click on `ItemCount`-only menus.
- Existing paging tests for ListBox/Table/TreeView/HelpView/ScrollView pass unchanged — the new math produces the same values they assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtkhZvKNV1ssKUT9vPkjMW