### PR TITLE
fix: dispatch native window close on UI thread

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -2290,6 +2290,21 @@ func (fm *frameManager) Stop() {
 	}
 }
 
+// postQuitCommand schedules a native-window close on the UI event-loop
+// goroutine. Native window callbacks run on a backend-owned goroutine or
+// thread, while EmitCommand walks and mutates the frame stack. Keeping that
+// traversal on the same goroutine as keyboard and terminal input prevents a
+// close request from racing session/settings updates.
+func postQuitCommand() {
+	fm := FrameManager
+	if fm == nil || fm.IsShutdown() {
+		return
+	}
+	fm.PostTask(func() {
+		fm.EmitCommand(CmQuit, nil)
+	})
+}
+
 // Run starts the main application event loop.
 // softwareBlinkRenderer is implemented by renderers that draw their own
 // cursor in pixels (rather than relying on a native console/terminal

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -616,6 +616,40 @@ func TestFrameManager_PostTask(t *testing.T) {
 		t.Error("Posted task was not executed")
 	}
 }
+
+func TestPostQuitCommandPostsToUIQueue(t *testing.T) {
+	fm := &frameManager{}
+	fm.Init(NewSilentScreenBuf())
+	defer fm.Shutdown()
+
+	oldFm := FrameManager
+	FrameManager = fm
+	defer func() { FrameManager = oldFm }()
+
+	handled := false
+	frame := newMockFrame(0, 0, 10, 10, false)
+	frame.onHandleCommand = func(cmd int, args any) bool {
+		if cmd == CmQuit {
+			handled = true
+			return true
+		}
+		return false
+	}
+	fm.Push(frame)
+
+	postQuitCommand()
+	select {
+	case task := <-fm.TaskChan:
+		task()
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("native close did not post a UI task")
+	}
+
+	if !handled {
+		t.Fatal("posted native close did not dispatch CmQuit")
+	}
+}
+
 func TestFrameManager_FocusOnRemove(t *testing.T) {
 	fm := &frameManager{}
 	fm.Init(NewSilentScreenBuf())

--- a/win32_gui_windows.go
+++ b/win32_gui_windows.go
@@ -840,7 +840,7 @@ func (h *Win32GuiHost) handleMessage(hwnd syscall.Handle, msg uint32, wParam, lP
 			procDestroyWindow.Call(uintptr(hwnd))
 			return 0
 		}
-		FrameManager.EmitCommand(CmQuit, nil)
+		postQuitCommand()
 		return 0
 
 	case wmDestroy:

--- a/x11_host.go
+++ b/x11_host.go
@@ -326,7 +326,7 @@ func (h *X11Host) RunEventLoop() {
 				continue
 			}
 			if e.Data.Data32[0] == uint32(h.atomDelete) {
-				FrameManager.EmitCommand(CmQuit, nil)
+				postQuitCommand()
 			}
 
 		case xproto.SelectionNotifyEvent:


### PR DESCRIPTION
Native X11 and Win32 close callbacks invoked FrameManager.EmitCommand directly from backend-owned threads while the UI loop was mutating the same frame stack. That race could bypass or corrupt shutdown-time session/settings persistence.

Route both callbacks through a shared PostTask helper so CmQuit is processed on the FrameManager UI goroutine. This preserves ConfirmExit handling and the existing F10 path. Added a regression test for the queued close command.

Validated on Linux aarch64 with an ARM64 f4 build: three real X11/Xwayland WM_DELETE_WINDOW closes and one ANSI F10 exit all persisted session/settings state.

— zoin-bot