### PR TITLE
fix(x11): honor requested initial window geometry

### DIFF
--- a/x11_host.go
+++ b/x11_host.go
@@ -166,16 +166,11 @@ func NewX11Host(cols, rows, cellW, cellH int) (*X11Host, error) {
 			xproto.AtomAtom, 32, 1, data)
 	}
 
-	stateAtom, _ := xproto.InternAtom(conn, false, 13, "_NET_WM_STATE").Reply()
-	maxVertAtom, _ := xproto.InternAtom(conn, false, 28, "_NET_WM_STATE_MAXIMIZED_VERT").Reply()
-	maxHorzAtom, _ := xproto.InternAtom(conn, false, 28, "_NET_WM_STATE_MAXIMIZED_HORZ").Reply()
-	if stateAtom != nil && maxVertAtom != nil && maxHorzAtom != nil {
-		data := make([]byte, 8)
-		xgb.Put32(data, uint32(maxVertAtom.Atom))
-		xgb.Put32(data[4:], uint32(maxHorzAtom.Atom))
-		xproto.ChangeProperty(conn, xproto.PropModeReplace, host.wid, stateAtom.Atom, xproto.AtomAtom, 32, 2, data)
-	}
-
+	// Map the window at the geometry requested by the caller. In particular,
+	// do not seed _NET_WM_STATE with the maximized flags here: that state makes
+	// the window manager replace the requested dimensions before the first
+	// configure event. Native maximize/restore transitions are handled by the
+	// renderer when the window is resized.
 	xproto.MapWindow(conn, host.wid)
 	_, _ = xproto.GetInputFocus(conn).Reply()
 	host.dnd = newX11Dnd(host)


### PR DESCRIPTION
## Summary

- stop seeding the maximized EWMH state before the initial X11 map
- preserve the initial geometry requested by the caller; explicit resize and maximize transitions remain handled by the renderer

This fixes the common X11 backend behavior behind unxed/f4#651, where f4's saved GUI size was ignored and the window opened maximized.

## Validation

- GOTOOLCHAIN=auto go test ./... -count=1
- GOTOOLCHAIN=auto go vet ./...
- live Linux aarch64 / Fedora Asahi Remix 44 / KDE Plasma Wayland session using the X11 backend: saved 80x25 opened as 1120x850 and the EWMH state contained no maximize flags

— zoin-bot
