### PR TITLE
fix: discover monochrome emoji fallback fonts

### DIFF
--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -789,7 +789,7 @@ func loadGogpuFont(fontName string, size float64) (text.Face, *fontFallbackChain
 	if noFallback {
 		DebugLog("GOGPU_DIAG_FONT: fallback chain disabled by VTUI_GOGPU_NO_FALLBACK")
 	} else {
-		for _, p := range fallbackFontPaths {
+		for _, p := range fallbackPathsForGUI() {
 			if _, err := os.Stat(p); err != nil {
 				continue
 			}

--- a/gui_font.go
+++ b/gui_font.go
@@ -45,8 +45,10 @@ var fallbackFontPaths = []string{
 	"/usr/share/fonts/truetype/arphic/uming.ttc",
 	"/usr/share/fonts/truetype/arphic/ukai.ttc",
 	// Linux — emoji and general symbol coverage
-	"/usr/share/fonts/noto/NotoColorEmoji.ttf",
-	"/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf",
+	"/usr/share/fonts/google-noto-emoji-fonts/NotoEmoji-Regular.ttf",
+	"/usr/share/fonts/noto/NotoEmoji-Regular.ttf",
+	"/usr/share/fonts/truetype/noto/NotoEmoji-Regular.ttf",
+	"/usr/share/fonts/gdouros-symbola/Symbola.ttf",
 	"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
 	"/usr/share/fonts/TTF/DejaVuSans.ttf",
 	"/usr/share/fonts/truetype/unifont/unifont.ttf",
@@ -83,6 +85,42 @@ var fallbackFontPaths = []string{
 var runFontconfigMonospace = func() (string, error) {
 	out, err := exec.Command("fc-match", "-f", "%{file}", "monospace").Output()
 	return strings.TrimSpace(string(out)), err
+}
+
+const maxFontconfigEmojiPaths = 4
+
+// runFontconfigEmoji asks fontconfig for the small set of fonts it would use
+// for an emoji code point. The static fallback list covers common locations,
+// but package layouts vary too much for it to find every distro's emoji font.
+// Keeping this a variable makes the lookup deterministic in tests without
+// making fontconfig a build-time dependency.
+var runFontconfigEmoji = func() ([]string, error) {
+	out, err := exec.Command("fc-match", "-s", "-f", "%{file}\n", "emoji:charset=1f600:color=false").Output()
+	if err != nil {
+		return nil, err
+	}
+	paths := parseFontconfigPaths(string(out))
+	if len(paths) > maxFontconfigEmojiPaths {
+		paths = paths[:maxFontconfigEmojiPaths]
+	}
+	return paths, nil
+}
+
+func parseFontconfigPaths(output string) []string {
+	var paths []string
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(output, "\n") {
+		path := strings.TrimSpace(line)
+		if path == "" || !filepath.IsAbs(path) {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	return paths
 }
 
 // runeCoverage is a bitmap of the runes a font has glyphs for, over all of
@@ -486,6 +524,34 @@ func fontconfigMonospacePath() string {
 	return path
 }
 
+// fallbackPathsForGUI adds fontconfig's runtime emoji matches to the portable
+// static list. The returned order keeps the curated paths first and only
+// appends paths that are not already present, so existing font priorities stay
+// stable while distro-specific fonts become discoverable.
+func fallbackPathsForGUI() []string {
+	paths := append([]string(nil), fallbackFontPaths...)
+	if runtime.GOOS != "linux" {
+		return paths
+	}
+
+	dynamic, err := runFontconfigEmoji()
+	if err != nil {
+		return paths
+	}
+	seen := make(map[string]struct{}, len(paths)+len(dynamic))
+	for _, path := range paths {
+		seen[path] = struct{}{}
+	}
+	for _, path := range dynamic {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
 // loadBestFont attempts to find a suitable monospace TTF font on the system.
 // If none is found, it falls back to a built-in bitmap font.
 func loadBestFont(fontName string, size float64, dpi float64) (font.Face, int, int) {
@@ -528,7 +594,7 @@ func loadBestFont(fontName string, size float64, dpi float64) (font.Face, int, i
 	// fallback font here, which held hundreds of megabytes for glyphs most
 	// sessions never draw.
 	var chain *fontFallbackChain
-	for _, path := range fallbackFontPaths {
+	for _, path := range fallbackPathsForGUI() {
 		if _, err := os.Stat(path); err != nil {
 			continue
 		}

--- a/gui_font_test.go
+++ b/gui_font_test.go
@@ -1,6 +1,7 @@
 package vtui
 
 import (
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -101,6 +102,43 @@ func TestFontconfigMonospacePath(t *testing.T) {
 
 	if got := fontconfigMonospacePath(); got != "/tmp/Mono.ttf" {
 		t.Errorf("fontconfigMonospacePath() = %q, want /tmp/Mono.ttf", got)
+	}
+}
+
+func TestParseFontconfigPaths(t *testing.T) {
+	got := parseFontconfigPaths("/fonts/Emoji.ttf\n/fonts/Emoji.ttf\nrelative.ttf\n /fonts/Symbola.ttf \n")
+	want := []string{"/fonts/Emoji.ttf", "/fonts/Symbola.ttf"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseFontconfigPaths() = %#v, want %#v", got, want)
+	}
+}
+
+func TestFallbackPathsForGUI_DeduplicatesFontconfigMatches(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("fontconfig fallback lookup is Linux-only")
+	}
+	previous := runFontconfigEmoji
+	runFontconfigEmoji = func() ([]string, error) {
+		return []string{fallbackFontPaths[0], "/tmp/Emoji.ttf", "/tmp/Emoji.ttf"}, nil
+	}
+	t.Cleanup(func() { runFontconfigEmoji = previous })
+
+	paths := fallbackPathsForGUI()
+	count := 0
+	for _, path := range paths {
+		if path == "/tmp/Emoji.ttf" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("dynamic emoji path count = %d, want 1 in %#v", count, paths)
+	}
+	for i, path := range paths {
+		for _, earlier := range paths[:i] {
+			if earlier == path {
+				t.Fatalf("duplicate fallback path %q in %#v", path, paths)
+			}
+		}
 	}
 }
 

--- a/gui_font_test.go
+++ b/gui_font_test.go
@@ -1,6 +1,7 @@
 package vtui
 
 import (
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
@@ -106,8 +107,14 @@ func TestFontconfigMonospacePath(t *testing.T) {
 }
 
 func TestParseFontconfigPaths(t *testing.T) {
-	got := parseFontconfigPaths("/fonts/Emoji.ttf\n/fonts/Emoji.ttf\nrelative.ttf\n /fonts/Symbola.ttf \n")
-	want := []string{"/fonts/Emoji.ttf", "/fonts/Symbola.ttf"}
+	base := "/fonts"
+	if runtime.GOOS == "windows" {
+		base = `C:\fonts`
+	}
+	emojiPath := filepath.Join(base, "Emoji.ttf")
+	symbolPath := filepath.Join(base, "Symbola.ttf")
+	got := parseFontconfigPaths(emojiPath + "\n" + emojiPath + "\nrelative.ttf\n " + symbolPath + " \n")
+	want := []string{emojiPath, symbolPath}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("parseFontconfigPaths() = %#v, want %#v", got, want)
 	}


### PR DESCRIPTION
## Summary

- discover distro-specific emoji fallback fonts through fontconfig on Linux
- keep color bitmap fonts out of the x/image fallback path and add common monochrome emoji locations
- use the same fallback path set for X11, Wayland, and GoGPU
- add coverage for fontconfig path parsing and deduplication

This fixes the missing emoji reported in unxed/f4#276. The current Fedora ARM64 host had `NotoEmoji-Regular.ttf` installed at `/usr/share/fonts/google-noto-emoji-fonts/NotoEmoji-Regular.ttf`, but the previous curated list did not include that path. `fc-match` also preferred a COLRv1 color font which the current rasterizer rendered as an empty mask, so the query explicitly requests `color=false`.

Tests: `GOTOOLCHAIN=auto go test ./...`
