### PR TITLE
fix: clear GUI modifier state after focus loss

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -2914,7 +2914,14 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 	}
 
 	// Track Ctrl state for Switcher logic
-	if ev.Type == vtinput.KeyEventType {
+	if ev.Type == vtinput.FocusEventType && !ev.SetFocus {
+		// A GUI backend may lose the modifier key release together with
+		// keyboard focus. Clear the manager-side state as well as the backend
+		// tracker, otherwise the transient workspace UI can remain visible
+		// until an unrelated key event arrives.
+		fm.ctrlPressed = false
+		fm.workspaceTabPreview = false
+	} else if ev.Type == vtinput.KeyEventType {
 		wasCtrlPressed := fm.ctrlPressed
 		ctrl := (ev.ControlKeyState & (vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed)) != 0
 		if ev.VirtualKeyCode == vtinput.VK_CONTROL || ev.VirtualKeyCode == vtinput.VK_LCONTROL || ev.VirtualKeyCode == vtinput.VK_RCONTROL {

--- a/framemanager_test.go
+++ b/framemanager_test.go
@@ -3233,6 +3233,8 @@ func TestFrameManager_FocusLossResetsModifiers(t *testing.T) {
 	if !fm.KeyBar.shiftState || !fm.KeyBar.ctrlState {
 		t.Fatal("Modifiers were not set by Key event")
 	}
+	fm.ctrlPressed = true
+	fm.workspaceTabPreview = true
 
 	// 2. Dispatch FocusOut event
 	fm.dispatchEvent(&vtinput.InputEvent{
@@ -3242,6 +3244,9 @@ func TestFrameManager_FocusLossResetsModifiers(t *testing.T) {
 
 	if fm.KeyBar.shiftState || fm.KeyBar.ctrlState || fm.KeyBar.altState {
 		t.Error("FocusOut event did not reset KeyBar modifiers")
+	}
+	if fm.ctrlPressed || fm.workspaceTabPreview {
+		t.Error("FocusOut event did not reset FrameManager Ctrl state")
 	}
 }
 func TestFrameManager_ModifierKeyPressState(t *testing.T) {

--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -393,7 +393,7 @@ func (h *GogpuHost) handleFocus(focused bool) {
 	defer func() {
 		// App shutdown can close the reader while the backend is dispatching
 		// its final focus notification.
-		recover()
+		_ = recover()
 	}()
 	h.sendEvent(&vtinput.InputEvent{Type: vtinput.FocusEventType, SetFocus: focused})
 }

--- a/gogpu_host.go
+++ b/gogpu_host.go
@@ -248,7 +248,8 @@ func isSpecialOrModifiedKey(vk uint16, mods vtinput.ControlKeyState) bool {
 }
 
 func (h *GogpuHost) syncMods(key gpucontext.Key, mods gpucontext.Modifiers, isDown bool) vtinput.ControlKeyState {
-	switch gogpuKeyToVK(key, 0) {
+	vk := gogpuKeyToVK(key, 0)
+	switch vk {
 	case vtinput.VK_LCONTROL:
 		h.lCtrl = isDown
 	case vtinput.VK_RCONTROL:
@@ -264,6 +265,7 @@ func (h *GogpuHost) syncMods(key gpucontext.Key, mods gpucontext.Modifiers, isDo
 	}
 
 	h.superDown = mods.HasSuper()
+	h.syncModifierStateLocked(vk, mods, isDown)
 
 	var sysMods vtinput.ControlKeyState
 	if mods.HasShift() {
@@ -307,6 +309,93 @@ func (h *GogpuHost) syncMods(key gpucontext.Key, mods gpucontext.Modifiers, isDo
 
 	h.currentMods = sysMods
 	return sysMods
+}
+
+func isGogpuModifierVK(vk uint16) bool {
+	switch vk {
+	case vtinput.VK_SHIFT, vtinput.VK_LSHIFT, vtinput.VK_RSHIFT,
+		vtinput.VK_CONTROL, vtinput.VK_LCONTROL, vtinput.VK_RCONTROL,
+		vtinput.VK_MENU, vtinput.VK_LMENU, vtinput.VK_RMENU,
+		vtinput.VK_LWIN, vtinput.VK_RWIN, vtinput.VK_APPS,
+		vtinput.VK_CAPITAL, vtinput.VK_NUMLOCK, vtinput.VK_SCROLL:
+		return true
+	default:
+		return false
+	}
+}
+
+// syncModifierStateLocked repairs the side-tracking flags from gogpu's
+// aggregate modifier mask. A modifier release can be lost during a focus
+// transition, while an ordinary key event still gives us a reliable snapshot
+// of which modifier groups are active. Modifier key presses remain
+// authoritative when the platform reports its mask one event late.
+func (h *GogpuHost) syncModifierStateLocked(vk uint16, mods gpucontext.Modifiers, isDown bool) {
+	assumeActive := !isGogpuModifierVK(vk)
+	keepShift := isDown && (vk == vtinput.VK_SHIFT || vk == vtinput.VK_LSHIFT || vk == vtinput.VK_RSHIFT)
+	keepAlt := isDown && (vk == vtinput.VK_MENU || vk == vtinput.VK_LMENU || vk == vtinput.VK_RMENU)
+
+	if !mods.HasShift() && !keepShift {
+		h.lShift, h.rShift = false, false
+	} else if mods.HasShift() && assumeActive && !h.lShift && !h.rShift {
+		h.lShift = true
+	}
+	if !mods.HasAlt() && !keepAlt {
+		h.lAlt, h.rAlt = false, false
+	} else if mods.HasAlt() && assumeActive && !h.lAlt && !h.rAlt {
+		h.lAlt = true
+	}
+
+	keepCtrl := isDown && (vk == vtinput.VK_CONTROL || vk == vtinput.VK_LCONTROL || vk == vtinput.VK_RCONTROL)
+	if gogpuCmdIsCtrl {
+		// macOS has two Ctrl channels: Command is left Ctrl and physical Ctrl
+		// is right Ctrl. Keep their tracking independent when the aggregate
+		// platform flags change one channel at a time.
+		keepCommand := isDown && (vk == vtinput.VK_LCONTROL || vk == vtinput.VK_CONTROL)
+		keepPhysical := isDown && (vk == vtinput.VK_RCONTROL || vk == vtinput.VK_CONTROL)
+		if !mods.HasSuper() && !keepCommand {
+			h.lCtrl = false
+		} else if mods.HasSuper() && assumeActive && !h.lCtrl {
+			h.lCtrl = true
+		}
+		if !mods.HasControl() && !keepPhysical {
+			h.rCtrl = false
+		} else if mods.HasControl() && assumeActive && !h.rCtrl {
+			h.rCtrl = true
+		}
+	} else if !mods.HasControl() && !keepCtrl {
+		h.lCtrl, h.rCtrl = false, false
+	} else if mods.HasControl() && assumeActive && !h.lCtrl && !h.rCtrl {
+		h.lCtrl = true
+	}
+}
+
+func (h *GogpuHost) resetKeyboardStateLocked() {
+	if h.pendingKeyTimer != nil {
+		h.pendingKeyTimer.Stop()
+		h.pendingKeyTimer = nil
+	}
+	h.pendingKeyEvent = nil
+	h.lastVK = 0
+	h.suppressTextInput = false
+	h.currentMods = 0
+	h.lCtrl, h.rCtrl = false, false
+	h.lAlt, h.rAlt = false, false
+	h.lShift, h.rShift = false, false
+	h.superDown = false
+}
+
+func (h *GogpuHost) handleFocus(focused bool) {
+	h.mu.Lock()
+	if !focused {
+		h.resetKeyboardStateLocked()
+	}
+	h.mu.Unlock()
+	defer func() {
+		// App shutdown can close the reader while the backend is dispatching
+		// its final focus notification.
+		recover()
+	}()
+	h.sendEvent(&vtinput.InputEvent{Type: vtinput.FocusEventType, SetFocus: focused})
 }
 
 func RunGogpuHost(cols, rows int, fontName string, fontSize float64, setupApp func()) error {
@@ -371,6 +460,7 @@ func RunGogpuHost(cols, rows int, fontName string, fontSize float64, setupApp fu
 	app.OnClose(func() {
 		DebugLog("GOGPU_HOST: app is shutting down, renderer teardown follows")
 	})
+	app.EventSource().OnFocus(host.handleFocus)
 	// Files dropped on the window by other applications arrive here; the
 	// drag and drop core takes them from the backend to whatever the
 	// application registered as its target.

--- a/gogpu_host_test.go
+++ b/gogpu_host_test.go
@@ -68,6 +68,80 @@ func TestGogpuHost_SendEvent_NonBlocking(t *testing.T) {
 		t.Fatal("sendEvent blocked on full queue during MouseMoved event")
 	}
 }
+
+func TestGogpuModifierStateHealing(t *testing.T) {
+	oldCmdIsCtrl := gogpuCmdIsCtrl
+	defer func() { gogpuCmdIsCtrl = oldCmdIsCtrl }()
+	gogpuCmdIsCtrl = false
+
+	host := &GogpuHost{}
+	mods := host.syncMods(gpucontext.KeyA, gpucontext.ModShift|gpucontext.ModControl|gpucontext.ModAlt, true)
+	want := vtinput.ShiftPressed | vtinput.LeftCtrlPressed | vtinput.LeftAltPressed
+	if mods != want || !host.lShift || !host.lCtrl || !host.lAlt {
+		t.Fatalf("active aggregate modifiers = mods:%d sides shift:%v ctrl:%v alt:%v, want %d and healed sides",
+			mods, host.lShift, host.lCtrl, host.lAlt, want)
+	}
+
+	host.lCtrl, host.rCtrl = true, true
+	host.lAlt, host.rAlt = true, true
+	host.lShift, host.rShift = true, true
+	mods = host.syncMods(gpucontext.KeyA, 0, true)
+	if mods != 0 || host.lCtrl || host.rCtrl || host.lAlt || host.rAlt || host.lShift || host.rShift {
+		t.Fatalf("inactive aggregate modifiers = mods:%d sides ctrl:%v/%v alt:%v/%v shift:%v/%v, want cleared state",
+			mods, host.lCtrl, host.rCtrl, host.lAlt, host.rAlt, host.lShift, host.rShift)
+	}
+
+	// A modifier release can carry the pre-release aggregate mask. The
+	// already-applied key transition must not be recreated by the healer.
+	host.syncMods(gpucontext.KeyLeftControl, gpucontext.ModControl, false)
+	if host.lCtrl || host.rCtrl {
+		t.Fatalf("modifier release recreated a Ctrl side: %v/%v", host.lCtrl, host.rCtrl)
+	}
+}
+
+func TestGogpuFocusLossClearsKeyboardState(t *testing.T) {
+	pr, pw := io.Pipe()
+	reader := vtinput.NewReader(pr, true)
+	t.Cleanup(func() {
+		reader.Close()
+		_ = pw.Close()
+	})
+
+	host := &GogpuHost{
+		reader:            reader,
+		pendingKeyEvent:   &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true},
+		pendingKeyTimer:   time.NewTimer(time.Hour),
+		lastVK:            vtinput.VK_A,
+		suppressTextInput: true,
+		currentMods:       vtinput.LeftCtrlPressed | vtinput.RightAltPressed | vtinput.ShiftPressed,
+		lCtrl:             true,
+		rCtrl:             true,
+		lAlt:              true,
+		rAlt:              true,
+		lShift:            true,
+		rShift:            true,
+		superDown:         true,
+	}
+
+	host.handleFocus(false)
+	host.mu.Lock()
+	if host.pendingKeyEvent != nil || host.pendingKeyTimer != nil || host.lastVK != 0 || host.suppressTextInput || host.currentMods != 0 ||
+		host.lCtrl || host.rCtrl || host.lAlt || host.rAlt || host.lShift || host.rShift || host.superDown {
+		host.mu.Unlock()
+		t.Fatal("focus loss did not clear GoGPU keyboard state")
+	}
+	host.mu.Unlock()
+
+	select {
+	case event := <-reader.EventChan:
+		if event.Type != vtinput.FocusEventType || event.SetFocus {
+			t.Fatalf("focus loss event = %+v, want FocusEvent(false)", event)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for GoGPU focus loss event")
+	}
+}
+
 func TestGogpuHost_GetTerminalSize(t *testing.T) {
 	host := &GogpuHost{
 		cellW: 8,

--- a/wayland_host.go
+++ b/wayland_host.go
@@ -432,7 +432,7 @@ func (h *WaylandHost) Motion(w *window.Widget, input *window.Input, time uint32,
 			MouseY:          int16(mouseY),
 			MouseEventFlags: vtinput.MouseMoved,
 			ButtonState:     mouseBtn,
-			ControlKeyState: h.getMods(input),
+			ControlKeyState: h.modsForPointer(input),
 		}
 	}
 	return window.CursorLeftPtr
@@ -471,7 +471,7 @@ func (h *WaylandHost) Button(w *window.Widget, input *window.Input, time uint32,
 			MouseX:          int16(mouseX),
 			MouseY:          int16(mouseY),
 			ButtonState:     bs,
-			ControlKeyState: h.getMods(input),
+			ControlKeyState: h.modsForPointer(input),
 		}
 	}
 }
@@ -567,6 +567,7 @@ func (h *WaylandHost) Key(win *window.Window, input *window.Input, timeMs uint32
 	} else {
 		mods &^= vtinput.NumLockOn
 	}
+	h.syncModifierStateLocked(mods, vk, isDown)
 	h.currentMods = mods
 	h.mu.Unlock()
 
@@ -650,8 +651,78 @@ func (h *WaylandHost) getMods(input *window.Input) vtinput.ControlKeyState {
 	return mods
 }
 
+func isWaylandModifierVK(vk uint16) bool {
+	switch vk {
+	case vtinput.VK_SHIFT, vtinput.VK_LSHIFT, vtinput.VK_RSHIFT,
+		vtinput.VK_CONTROL, vtinput.VK_LCONTROL, vtinput.VK_RCONTROL,
+		vtinput.VK_MENU, vtinput.VK_LMENU, vtinput.VK_RMENU,
+		vtinput.VK_LWIN, vtinput.VK_RWIN, vtinput.VK_APPS,
+		vtinput.VK_CAPITAL, vtinput.VK_NUMLOCK, vtinput.VK_SCROLL:
+		return true
+	default:
+		return false
+	}
+}
+
+// syncModifierStateLocked repairs the side-tracking flags from Wayland's
+// aggregate modifier mask. The window package can lose a modifier key release
+// when keyboard focus changes, and it can also report the aggregate mask
+// before the corresponding key event updates it. Keep the modifier key's own
+// transition authoritative, while using ordinary events to recover a missing
+// side and inactive masks to clear stale sides.
+func (h *WaylandHost) syncModifierStateLocked(mods vtinput.ControlKeyState, vk uint16, isDown bool) {
+	assumeActive := !isWaylandModifierVK(vk)
+	keepShift := isDown && (vk == vtinput.VK_SHIFT || vk == vtinput.VK_LSHIFT || vk == vtinput.VK_RSHIFT)
+	keepCtrl := isDown && (vk == vtinput.VK_CONTROL || vk == vtinput.VK_LCONTROL || vk == vtinput.VK_RCONTROL)
+	keepAlt := isDown && (vk == vtinput.VK_MENU || vk == vtinput.VK_LMENU || vk == vtinput.VK_RMENU)
+
+	if mods&vtinput.ShiftPressed == 0 && !keepShift {
+		h.lShift, h.rShift = false, false
+	} else if mods&vtinput.ShiftPressed != 0 && assumeActive && !h.lShift && !h.rShift {
+		h.lShift = true
+	}
+	if mods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) == 0 && !keepCtrl {
+		h.lCtrl, h.rCtrl = false, false
+	} else if mods&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0 && assumeActive && !h.lCtrl && !h.rCtrl {
+		h.lCtrl = true
+	}
+	if mods&(vtinput.LeftAltPressed|vtinput.RightAltPressed) == 0 && !keepAlt {
+		h.lAlt, h.rAlt = false, false
+	} else if mods&(vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0 && assumeActive && !h.lAlt && !h.rAlt {
+		h.lAlt = true
+	}
+}
+
+func (h *WaylandHost) modsForPointer(input *window.Input) vtinput.ControlKeyState {
+	mods := h.getMods(input)
+	if input == nil {
+		// A nil callback input carries no modifier snapshot; do not treat it as
+		// an assertion that all currently tracked modifiers are released.
+		return mods
+	}
+	h.mu.Lock()
+	h.syncModifierStateLocked(mods, 0, false)
+	h.mu.Unlock()
+	return mods
+}
+
+func (h *WaylandHost) sendFocusEvent(focused bool) {
+	h.mu.Lock()
+	reader := h.reader
+	h.mu.Unlock()
+	if reader == nil || reader.EventChan == nil {
+		return
+	}
+	defer func() {
+		// The reader may close concurrently with the display loop during exit.
+		recover()
+	}()
+	reader.EventChan <- &vtinput.InputEvent{Type: vtinput.FocusEventType, SetFocus: focused}
+}
+
 func (h *WaylandHost) Focus(w *window.Window, device *window.Input) {
 	if device != nil {
+		h.sendFocusEvent(true)
 		return
 	}
 
@@ -667,6 +738,7 @@ func (h *WaylandHost) Focus(w *window.Window, device *window.Input) {
 	h.lAlt, h.rAlt = false, false
 	h.lShift, h.rShift = false, false
 	h.mu.Unlock()
+	h.sendFocusEvent(false)
 }
 
 // waylandNumLockFromKeysym recovers the XKB NumLock state from a keypad
@@ -761,7 +833,7 @@ func (h *WaylandHost) PointerFrame(w *window.Widget, input *window.Input) {
 		direction = 1
 		steps = -steps
 	}
-	mods := h.getMods(input)
+	mods := h.modsForPointer(input)
 	for range steps {
 		reader.EventChan <- &vtinput.InputEvent{
 			Type:            vtinput.MouseEventType,

--- a/wayland_host.go
+++ b/wayland_host.go
@@ -715,7 +715,7 @@ func (h *WaylandHost) sendFocusEvent(focused bool) {
 	}
 	defer func() {
 		// The reader may close concurrently with the display loop during exit.
-		recover()
+		_ = recover()
 	}()
 	reader.EventChan <- &vtinput.InputEvent{Type: vtinput.FocusEventType, SetFocus: focused}
 }

--- a/wayland_host_test.go
+++ b/wayland_host_test.go
@@ -65,7 +65,15 @@ func TestWaylandNumLockFromKeysym(t *testing.T) {
 }
 
 func TestWaylandFocusLossClearsKeyboardState(t *testing.T) {
+	pr, pw := io.Pipe()
+	reader := vtinput.NewReader(pr, true)
+	t.Cleanup(func() {
+		reader.Close()
+		_ = pw.Close()
+	})
+
 	host := &WaylandHost{
+		reader:       reader,
 		isRepeating:  true,
 		repeatVK:     vtinput.VK_LMENU,
 		repeatChar:   'x',
@@ -88,6 +96,14 @@ func TestWaylandFocusLossClearsKeyboardState(t *testing.T) {
 	if !host.isRepeating || !host.lAlt {
 		t.Fatal("focus gain unexpectedly cleared keyboard state")
 	}
+	select {
+	case event := <-reader.EventChan:
+		if event.Type != vtinput.FocusEventType || !event.SetFocus {
+			t.Fatalf("focus gain event = %+v, want FocusEvent(true)", event)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for Wayland focus gain event")
+	}
 
 	host.Focus(nil, nil)
 
@@ -100,6 +116,37 @@ func TestWaylandFocusLossClearsKeyboardState(t *testing.T) {
 	if host.currentMods != 0 || host.numLockOn || host.numLockKnown || host.lCtrl || host.rCtrl || host.lAlt || host.rAlt || host.lShift || host.rShift {
 		t.Fatalf("modifier state not cleared: mods=%d numlock=%v/%v ctrl=%v/%v alt=%v/%v shift=%v/%v",
 			host.currentMods, host.numLockOn, host.numLockKnown, host.lCtrl, host.rCtrl, host.lAlt, host.rAlt, host.lShift, host.rShift)
+	}
+
+	select {
+	case event := <-reader.EventChan:
+		if event.Type != vtinput.FocusEventType || event.SetFocus {
+			t.Fatalf("focus loss event = %+v, want FocusEvent(false)", event)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for Wayland focus loss event")
+	}
+}
+
+func TestWaylandModifierStateHealing(t *testing.T) {
+	host := &WaylandHost{}
+
+	host.syncModifierStateLocked(vtinput.LeftCtrlPressed, vtinput.VK_A, true)
+	if !host.lCtrl || host.rCtrl {
+		t.Fatalf("active aggregate Ctrl sides = %v/%v, want left Ctrl", host.lCtrl, host.rCtrl)
+	}
+
+	host.lCtrl, host.rCtrl = true, true
+	host.syncModifierStateLocked(0, vtinput.VK_A, true)
+	if host.lCtrl || host.rCtrl {
+		t.Fatalf("inactive aggregate Ctrl sides = %v/%v, want cleared state", host.lCtrl, host.rCtrl)
+	}
+
+	// The key transition is applied before the aggregate mask is read. A
+	// release must not recreate the side from a still-active pre-release mask.
+	host.syncModifierStateLocked(vtinput.LeftCtrlPressed, vtinput.VK_LCONTROL, false)
+	if host.lCtrl || host.rCtrl {
+		t.Fatalf("modifier release recreated a Ctrl side: %v/%v", host.lCtrl, host.rCtrl)
 	}
 }
 

--- a/x11_host.go
+++ b/x11_host.go
@@ -122,7 +122,7 @@ func NewX11Host(cols, rows, cellW, cellH int) (*X11Host, error) {
 		uint32(xproto.EventMaskKeyPress | xproto.EventMaskKeyRelease |
 			xproto.EventMaskButtonPress | xproto.EventMaskButtonRelease |
 			xproto.EventMaskPointerMotion | xproto.EventMaskExposure |
-			xproto.EventMaskStructureNotify),
+			xproto.EventMaskStructureNotify | xproto.EventMaskFocusChange),
 		uint32(cmap),
 	}
 
@@ -271,6 +271,11 @@ func (h *X11Host) RunEventLoop() {
 				h.sendEvent(&vtinput.InputEvent{Type: vtinput.ResizeEventType})
 			}
 
+		case xproto.FocusInEvent:
+			h.handleFocusEvent(true)
+		case xproto.FocusOutEvent:
+			h.handleFocusEvent(false)
+
 		case xproto.MappingNotifyEvent:
 			h.mu.Lock()
 			if h.translator != nil {
@@ -341,6 +346,83 @@ func (h *X11Host) RunEventLoop() {
 	}
 }
 
+func (h *X11Host) handleFocusEvent(focused bool) {
+	if !focused {
+		h.mu.Lock()
+		h.resetKeyboardStateLocked()
+		h.mu.Unlock()
+	}
+	h.sendEvent(&vtinput.InputEvent{Type: vtinput.FocusEventType, SetFocus: focused})
+}
+
+func (h *X11Host) resetKeyboardStateLocked() {
+	h.currentMods = 0
+	h.lCtrl, h.rCtrl = false, false
+	h.lAlt, h.rAlt = false, false
+	h.lShift, h.rShift = false, false
+}
+
+func isX11ModifierVK(vk uint16) bool {
+	switch vk {
+	case vtinput.VK_SHIFT, vtinput.VK_LSHIFT, vtinput.VK_RSHIFT,
+		vtinput.VK_CONTROL, vtinput.VK_LCONTROL, vtinput.VK_RCONTROL,
+		vtinput.VK_MENU, vtinput.VK_LMENU, vtinput.VK_RMENU:
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *X11Host) syncModifierStateLocked(state uint16, vk uint16, isDown bool) vtinput.ControlKeyState {
+	assumeActive := !isX11ModifierVK(vk)
+	keepShift := isDown && (vk == vtinput.VK_SHIFT || vk == vtinput.VK_LSHIFT || vk == vtinput.VK_RSHIFT)
+	keepCtrl := isDown && (vk == vtinput.VK_CONTROL || vk == vtinput.VK_LCONTROL || vk == vtinput.VK_RCONTROL)
+	keepAlt := isDown && (vk == vtinput.VK_MENU || vk == vtinput.VK_LMENU || vk == vtinput.VK_RMENU)
+
+	if state&xproto.ModMaskShift == 0 && !keepShift {
+		h.lShift, h.rShift = false, false
+	} else if state&xproto.ModMaskShift != 0 && assumeActive && !h.lShift && !h.rShift {
+		h.lShift = true
+	}
+	if state&xproto.ModMaskControl == 0 && !keepCtrl {
+		h.lCtrl, h.rCtrl = false, false
+	} else if state&xproto.ModMaskControl != 0 && assumeActive && !h.lCtrl && !h.rCtrl {
+		h.lCtrl = true
+	}
+	if state&xproto.ModMask1 == 0 && !keepAlt {
+		h.lAlt, h.rAlt = false, false
+	} else if state&xproto.ModMask1 != 0 && assumeActive && !h.lAlt && !h.rAlt {
+		h.lAlt = true
+	}
+
+	var mods vtinput.ControlKeyState
+	if state&xproto.ModMaskShift != 0 {
+		mods |= vtinput.ShiftPressed
+	}
+	if state&xproto.ModMaskControl != 0 {
+		if h.rCtrl {
+			mods |= vtinput.RightCtrlPressed
+		} else {
+			mods |= vtinput.LeftCtrlPressed
+		}
+	}
+	if state&xproto.ModMask1 != 0 {
+		if h.rAlt {
+			mods |= vtinput.RightAltPressed
+		} else {
+			mods |= vtinput.LeftAltPressed
+		}
+	}
+	if state&xproto.ModMaskLock != 0 {
+		mods |= vtinput.CapsLockOn
+	}
+	if state&xproto.ModMask2 != 0 {
+		mods |= vtinput.NumLockOn
+	}
+	h.currentMods = mods
+	return mods
+}
+
 func (h *X11Host) handleKeyEvent(detail xproto.Keycode, state uint16, isDown bool) {
 	h.mu.Lock()
 	tr := h.translator
@@ -390,31 +472,7 @@ func (h *X11Host) handleKeyEvent(detail xproto.Keycode, state uint16, isDown boo
 			}
 		}
 
-		var sysMods vtinput.ControlKeyState
-		if state&1 != 0 {
-			sysMods |= vtinput.ShiftPressed
-		}
-		if state&4 != 0 {
-			if h.rCtrl {
-				sysMods |= vtinput.RightCtrlPressed
-			} else {
-				sysMods |= vtinput.LeftCtrlPressed
-			}
-		}
-		if state&8 != 0 {
-			if h.rAlt {
-				sysMods |= vtinput.RightAltPressed
-			} else {
-				sysMods |= vtinput.LeftAltPressed
-			}
-		}
-		if state&2 != 0 {
-			sysMods |= vtinput.CapsLockOn
-		}
-		if state&16 != 0 {
-			sysMods |= vtinput.NumLockOn
-		}
-		h.currentMods = sysMods
+		sysMods := h.syncModifierStateLocked(state, vk, isDown)
 		h.mu.Unlock()
 
 		event := &vtinput.InputEvent{
@@ -475,37 +533,9 @@ func (h *X11Host) handleButtonEvent(x, y int16, detail xproto.Button, state uint
 }
 
 func (h *X11Host) translateModifiers(state uint16) vtinput.ControlKeyState {
-	var mods vtinput.ControlKeyState
-	if state&1 != 0 {
-		mods |= vtinput.ShiftPressed
-	}
-	if state&4 != 0 {
-		h.mu.Lock()
-		rCtrl := h.rCtrl
-		h.mu.Unlock()
-		if rCtrl {
-			mods |= vtinput.RightCtrlPressed
-		} else {
-			mods |= vtinput.LeftCtrlPressed
-		}
-	}
-	if state&8 != 0 {
-		h.mu.Lock()
-		rAlt := h.rAlt
-		h.mu.Unlock()
-		if rAlt {
-			mods |= vtinput.RightAltPressed
-		} else {
-			mods |= vtinput.LeftAltPressed
-		}
-	}
-	if state&2 != 0 {
-		mods |= vtinput.CapsLockOn
-	}
-	if state&16 != 0 {
-		mods |= vtinput.NumLockOn
-	}
-	return mods
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.syncModifierStateLocked(state, 0, false)
 }
 
 func (h *X11Host) flushImage() int {

--- a/x11_host_test.go
+++ b/x11_host_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jezek/xgb/xproto"
 	"github.com/unxed/vtinput"
 )
 
@@ -162,6 +163,80 @@ func TestX11Host_SendEvent_ClosedChannelSafety(t *testing.T) {
 	// Тест отправки при закрытии канала завершения хоста
 	close(h.closeChan)
 	h.sendEvent(&vtinput.InputEvent{Type: vtinput.ResizeEventType})
+}
+
+func TestX11HostFocusLossClearsKeyboardState(t *testing.T) {
+	pr, pw := io.Pipe()
+	reader := vtinput.NewReader(pr, true)
+	t.Cleanup(func() {
+		reader.Close()
+		_ = pw.Close()
+	})
+
+	h := &X11Host{
+		reader:      reader,
+		closeChan:   make(chan struct{}),
+		currentMods: vtinput.LeftCtrlPressed | vtinput.RightAltPressed | vtinput.ShiftPressed,
+		lCtrl:       true,
+		rCtrl:       true,
+		lAlt:        true,
+		rAlt:        true,
+		lShift:      true,
+		rShift:      true,
+	}
+
+	h.handleFocusEvent(false)
+	h.mu.Lock()
+	if h.currentMods != 0 || h.lCtrl || h.rCtrl || h.lAlt || h.rAlt || h.lShift || h.rShift {
+		h.mu.Unlock()
+		t.Fatal("focus loss did not clear X11 keyboard state")
+	}
+	h.mu.Unlock()
+
+	select {
+	case event := <-reader.EventChan:
+		if event.Type != vtinput.FocusEventType || event.SetFocus {
+			t.Fatalf("focus loss event = %+v, want FocusEvent(false)", event)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for X11 focus loss event")
+	}
+
+	h.handleFocusEvent(true)
+	select {
+	case event := <-reader.EventChan:
+		if event.Type != vtinput.FocusEventType || !event.SetFocus {
+			t.Fatalf("focus gain event = %+v, want FocusEvent(true)", event)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for X11 focus gain event")
+	}
+}
+
+func TestX11ModifierStateHealing(t *testing.T) {
+	h := &X11Host{}
+
+	mods := h.syncModifierStateLocked(xproto.ModMaskControl, vtinput.VK_A, true)
+	if mods != vtinput.LeftCtrlPressed || !h.lCtrl || h.rCtrl {
+		t.Fatalf("active aggregate Ctrl = mods:%d sides:%v/%v, want left Ctrl", mods, h.lCtrl, h.rCtrl)
+	}
+
+	h.lCtrl, h.rCtrl = true, true
+	mods = h.syncModifierStateLocked(0, vtinput.VK_A, true)
+	if mods != 0 || h.lCtrl || h.rCtrl {
+		t.Fatalf("inactive aggregate Ctrl = mods:%d sides:%v/%v, want cleared state", mods, h.lCtrl, h.rCtrl)
+	}
+
+	// X11 reports a modifier key release with the state from before the
+	// release. The already-applied key transition must not be healed back in.
+	h.lCtrl = false
+	mods = h.syncModifierStateLocked(xproto.ModMaskControl, vtinput.VK_LCONTROL, false)
+	if h.lCtrl {
+		t.Fatal("modifier release recreated left Ctrl side")
+	}
+	if mods != vtinput.LeftCtrlPressed {
+		t.Fatalf("modifier release result = %d, want aggregate Ctrl", mods)
+	}
 }
 
 func TestX11Renderer_GlyphCacheUniqueness(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix f4 issue https://github.com/unxed/f4/issues/255 by making GUI modifier state recoverable after focus transitions.

- subscribe the X11 host to FocusIn/FocusOut and forward focus events;
- heal stale Shift/Ctrl/Alt side tracking from aggregate masks in X11, Wayland, and GoGPU;
- preserve modifier-key transition ordering when a platform reports a pre-transition mask;
- clear Wayland/GoGPU keyboard, repeat, pending-key, and manager-side Ctrl state on focus loss;
- cover the behavior with focused host and FrameManager tests.

## Validation

- `GOTOOLCHAIN=auto go test ./...`
- `GOTOOLCHAIN=auto go test -race ./...`
- built f4 on Linux aarch64 and reproduced the lost Ctrl release on baseline X11;
- repeated the focus-switch sequence with fixed X11 and GoGPU/XWayland builds, confirming FocusOut/FocusIn delivery and no stuck Ctrl state;
- native GoGPU startup also succeeded on the ARM64 KDE Plasma Wayland session.

The f4 full suite has unrelated pre-existing `internal/ttyx` X11 `BadMatch`/geometry failures in this XWayland environment; all other f4 packages passed. Native f4 `--gui=wayland` still hits its existing startup nil-pointer before host interaction.
