### PR TITLE
fix: keep focused modal controls visible after resize

### DIFF
--- a/dialog_test.go
+++ b/dialog_test.go
@@ -53,6 +53,28 @@ func TestCenteredDialogScrollsWithMouseWheelInAShortViewport(t *testing.T) {
 	}
 }
 
+func TestCenteredDialogKeepsFocusedControlVisibleAfterResize(t *testing.T) {
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(40, 8)
+	FrameManager.Init(scr)
+
+	dialog := NewCenteredDialog(30, 14, "Panel settings")
+	first := NewButton(dialog.X1+2, dialog.Y1+2, "First")
+	last := NewButton(dialog.X1+2, dialog.Y1+11, "Last")
+	last.IsDefault = true
+	dialog.AddItem(first)
+	dialog.AddItem(last)
+	dialog.Show(scr)
+
+	dialog.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_NEXT})
+	dialog.ResizeConsole(40, 6)
+
+	_, y1, _, y2 := last.GetPosition()
+	if y1 < dialog.Y1+1 || y2 > dialog.Y2-1 {
+		t.Fatalf("focused control is outside resized viewport: (%d,%d), viewport (%d,%d)", y1, y2, dialog.Y1+1, dialog.Y2-1)
+	}
+}
+
 func TestDialog_HotkeyCaseInsensitivity(t *testing.T) {
 	d := NewDialog(0, 0, 40, 10, "Case Test")
 	btn := NewButton(1, 1, "&File")

--- a/window.go
+++ b/window.go
@@ -79,6 +79,7 @@ func (w *Window) resizeModalViewport(screenW, screenH int) {
 	w.MoveRelative((screenW-viewW)/2-w.X1, (screenH-viewH)/2-w.Y1)
 	w.setViewportSize(viewW, viewH)
 	w.updateScrollBounds()
+	w.ensureFocusedItemVisible()
 }
 
 func (w *Window) updateScrollBounds() {


### PR DESCRIPTION
Follow-up for unxed/f4#561.

When a modal dialog is scrolled to a focused bottom control and the terminal is resized smaller, the viewport bounds are recalculated but the existing scroll offset is retained. The focused control can therefore move below the visible viewport. Re-run the existing focus-visibility invariant after resizing so every modal remains keyboard-accessible.

Added a regression test covering PageDown followed by a smaller resize.

Tests: `go test ./...` (pass). Live-tested f4 on Linux aarch64/Fedora Asahi Remix 44/KDE Plasma Wayland with the X11 backend through repeated 1000x300, 1000x360, 1000x420, and 1200x500 resizes, mouse dropdown interaction, and Escape redraw.