### PR TITLE
Fix repeated F1 from nesting HelpView windows

### DIFF
--- a/help_view.go
+++ b/help_view.go
@@ -300,6 +300,10 @@ func (hv *HelpView) ProcessKey(e *vtinput.InputEvent) bool {
 
 	// 1. Handle Help-specific navigation BEFORE BaseWindow focus cycling
 	switch e.VirtualKeyCode {
+	case vtinput.VK_F1:
+		// Help is already active; do not let BaseWindow.ShowHelp nest another view.
+		return true
+
 	case vtinput.VK_TAB:
 		if len(hv.current.Links) == 0 {
 			return hv.BaseWindow.ProcessKey(e)

--- a/help_view_test.go
+++ b/help_view_test.go
@@ -8,6 +8,42 @@ import (
 	"github.com/unxed/vtinput"
 )
 
+func TestHelpView_F1DoesNotNestAnotherHelpView(t *testing.T) {
+	oldFM := FrameManager
+	oldEngine := GlobalHelpEngine
+	fm := NewFrameManager()
+	FrameManager = fm
+	t.Cleanup(func() {
+		fm.Shutdown()
+		FrameManager = oldFM
+		GlobalHelpEngine = oldEngine
+	})
+
+	scr := NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	fm.Init(scr)
+
+	engine := NewHelpEngine(&mockHelpVFS{})
+	engine.AddTopic(&HelpTopic{Name: "Root", Lines: []string{"Root help"}})
+	engine.AddTopic(&HelpTopic{Name: "Contents", Lines: []string{"Contents help"}})
+	GlobalHelpEngine = engine
+
+	hv := NewHelpView(engine, "Root")
+	fm.Push(hv)
+	fm.dispatchEvent(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_F1,
+	}, false)
+
+	if len(fm.frames) != 1 {
+		t.Fatalf("F1 on HelpView created %d frames, want 1", len(fm.frames))
+	}
+	if fm.GetTopFrame() != hv {
+		t.Fatal("F1 on HelpView replaced the active help frame")
+	}
+}
+
 func TestHelpView_Navigation(t *testing.T) {
 	tmpDir := t.TempDir()
 	helpPath := filepath.Join(tmpDir, "test.hlf")


### PR DESCRIPTION
## Summary\n- consume F1 while a HelpView is active so BaseWindow cannot open a second help window\n- add a regression test covering FrameManager dispatch and stack depth\n\nThis fixes unxed/f4#867.\n\nValidation: go test . -run 'TestHelpView_F1DoesNotNestAnotherHelpView|TestHelpView_' passes on Windows 11 x64. The full go test ./... run is otherwise blocked by the repository's Python bindings test because Python is not installed on this machine.\n\n— zoin-bot