### PR TITLE
ci: fix the stale planFit expectation and keep tag pushes out of the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: CI
 
 on:
+  # Branches only. A release tag points at a commit the branch push has
+  # already built, so an unfiltered `push` fans that one commit out into two
+  # independent runs of the whole matrix, and concurrency cannot fold them
+  # together because the group keys on the ref. '**' matches every branch,
+  # slashes included, and no tag at all.
   push:
+    branches: ['**']
   pull_request:
 
 # A push fans out into more than forty checks, and only the latest queued run

--- a/conhost_altscreen_windows_test.go
+++ b/conhost_altscreen_windows_test.go
@@ -2,7 +2,10 @@
 
 package vtui
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 func csbi(bufW, bufH, curX, curY, winW, winH int) consoleScreenBufferInfo {
 	return consoleScreenBufferInfo{
@@ -20,16 +23,29 @@ func ops(plan []fitStep) []fitOp {
 	return out
 }
 
-// The shrink is what kills Windows 10 conhost when the cursor or window is
-// still outside the smaller buffer (microsoft/terminal#2366, f4 #397). So on
-// any shrink the cursor must be pulled in and the window moved *before* the
-// buffer is sized down, and the buffer must be grown first so the window move
-// always lands inside it.
-func TestPlanFit_ShrinkMovesCursorAndWindowBeforeSizingDown(t *testing.T) {
-	// From a tall/wide buffer with the cursor deep inside it, down to 80x25.
-	plan := planFit(csbi(150, 300, 149, 299, 150, 50), 80, 25)
+var fitOpNames = [...]string{
+	fitGrowBuffer: "growBuffer",
+	fitMoveCursor: "moveCursor",
+	fitWindow:     "window",
+	fitSizeBuffer: "sizeBuffer",
+}
+
+// String is what makes a failed plan readable -- [growBuffer moveCursor]
+// rather than [0 1]. It lives in the test because nothing in the package
+// itself ever formats a fitOp. An op added without a name here prints as a
+// number rather than blanking or crashing the diagnostic.
+func (o fitOp) String() string {
+	if o < 0 || int(o) >= len(fitOpNames) || fitOpNames[o] == "" {
+		return "fitOp(" + strconv.Itoa(int(o)) + ")"
+	}
+	return fitOpNames[o]
+}
+
+// checkOps fails unless the plan is exactly want, in that order: for this
+// plan the order is the whole point, not just the set of calls.
+func checkOps(t *testing.T, plan []fitStep, want ...fitOp) {
+	t.Helper()
 	got := ops(plan)
-	want := []fitOp{fitGrowBuffer, fitMoveCursor, fitWindow, fitSizeBuffer}
 	if len(got) != len(want) {
 		t.Fatalf("plan = %v, want %v", got, want)
 	}
@@ -38,6 +54,18 @@ func TestPlanFit_ShrinkMovesCursorAndWindowBeforeSizingDown(t *testing.T) {
 			t.Fatalf("step %d = %v, want %v (full %v)", i, got[i], want[i], got)
 		}
 	}
+}
+
+// The shrink is what kills Windows 10 conhost when the cursor or window is
+// still outside the smaller buffer (microsoft/terminal#2366, f4 #397). So on
+// any shrink the cursor must be pulled in and the window moved *before* the
+// buffer is sized down. A buffer that already covers the target on both axes
+// has nothing to grow, so this plan opens with the cursor move; the
+// grow-first half of the invariant is pinned by the mixed-resize test below.
+func TestPlanFit_ShrinkMovesCursorAndWindowBeforeSizingDown(t *testing.T) {
+	// From a tall/wide buffer with the cursor deep inside it, down to 80x25.
+	plan := planFit(csbi(150, 300, 149, 299, 150, 50), 80, 25)
+	checkOps(t, plan, fitMoveCursor, fitWindow, fitSizeBuffer)
 	// The cursor must end up inside 80x25.
 	for _, s := range plan {
 		if s.op == fitMoveCursor {
@@ -49,11 +77,18 @@ func TestPlanFit_ShrinkMovesCursorAndWindowBeforeSizingDown(t *testing.T) {
 			t.Fatalf("final buffer %dx%d, want 80x25", s.coord.X, s.coord.Y)
 		}
 	}
-	// Cursor move precedes the size-down.
-	ci, si := -1, -1
+	// Both moves precede the size-down. The step-by-step check above already
+	// pins that, but these two orderings are the whole of #397 -- conhost
+	// faults on a buffer set smaller than where the cursor or the window
+	// still sit -- so they are spelled out as well, against a later and
+	// looser check of the steps.
+	ci, wi, si := -1, -1, -1
 	for i, s := range plan {
 		if s.op == fitMoveCursor {
 			ci = i
+		}
+		if s.op == fitWindow {
+			wi = i
 		}
 		if s.op == fitSizeBuffer {
 			si = i
@@ -62,9 +97,55 @@ func TestPlanFit_ShrinkMovesCursorAndWindowBeforeSizingDown(t *testing.T) {
 	if ci < 0 || ci > si {
 		t.Fatalf("cursor move (%d) must come before buffer size-down (%d)", ci, si)
 	}
+	if wi < 0 || wi > si {
+		t.Fatalf("window move (%d) must come before buffer size-down (%d)", wi, si)
+	}
 }
 
-// A cursor already inside the target needs no move.
+// A resize that cuts one axis while widening the other still moves the window
+// to the whole target before the buffer comes down, so the buffer has to cover
+// the old size and the target at once first: grown short of the target leaves
+// the window move hanging outside the buffer, and grown short of the old size
+// is itself the shrink the ordering exists to defer -- one
+// SetConsoleScreenBufferSize sets both axes.
+func TestPlanFit_MixedResizeGrowsTheBufferFirst(t *testing.T) {
+	for _, c := range []struct {
+		name       string
+		info       consoleScreenBufferInfo
+		w, h       int
+		wantGrow   Coord
+		wantWindow Coord // inclusive bottom-right
+	}{
+		{
+			// Narrow and very tall, widened to 80 columns and cut to 25 rows,
+			// with the cursor sitting on the last row.
+			name: "wider and shorter", info: csbi(60, 300, 59, 299, 60, 50), w: 80, h: 25,
+			wantGrow: Coord{X: 80, Y: 300}, wantWindow: Coord{X: 79, Y: 24},
+		},
+		{
+			// The same the other way up: wide and short, cut to 80 columns and
+			// grown to 50 rows, with the cursor out past column 80.
+			name: "narrower and taller", info: csbi(150, 25, 149, 24, 150, 25), w: 80, h: 50,
+			wantGrow: Coord{X: 150, Y: 50}, wantWindow: Coord{X: 79, Y: 49},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			plan := planFit(c.info, c.w, c.h)
+			checkOps(t, plan, fitGrowBuffer, fitMoveCursor, fitWindow, fitSizeBuffer)
+			if plan[0].coord != c.wantGrow {
+				t.Fatalf("grew the buffer to %dx%d, want %dx%d",
+					plan[0].coord.X, plan[0].coord.Y, c.wantGrow.X, c.wantGrow.Y)
+			}
+			if plan[2].coord != c.wantWindow {
+				t.Fatalf("window moved to %dx%d inclusive, want %dx%d",
+					plan[2].coord.X, plan[2].coord.Y, c.wantWindow.X, c.wantWindow.Y)
+			}
+		})
+	}
+}
+
+// A cursor already inside the target needs no move, and a buffer already
+// covering it needs no grow: window, then size-down, and nothing else.
 func TestPlanFit_NoCursorMoveWhenInside(t *testing.T) {
 	plan := planFit(csbi(150, 50, 3, 3, 150, 50), 80, 25)
 	for _, s := range plan {
@@ -72,20 +153,110 @@ func TestPlanFit_NoCursorMoveWhenInside(t *testing.T) {
 			t.Fatalf("cursor moved needlessly: it was at 3x3, inside 80x25")
 		}
 	}
+	checkOps(t, plan, fitWindow, fitSizeBuffer)
 }
 
-// Growing needs no cursor move and no shrink guard, just grow then window.
+// The cursor is pulled in per axis: the coordinate hanging outside the target
+// is clamped to the last cell, the one already inside is left where the user
+// put it.
+func TestPlanFit_ClampsOnlyTheAxisOutsideTheTarget(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		info consoleScreenBufferInfo
+		want Coord
+	}{
+		{"column outside", csbi(150, 25, 149, 3, 150, 25), Coord{X: 79, Y: 3}},
+		{"row outside", csbi(80, 300, 3, 299, 80, 50), Coord{X: 3, Y: 24}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			moved := false
+			for _, s := range planFit(c.info, 80, 25) {
+				if s.op != fitMoveCursor {
+					continue
+				}
+				moved = true
+				if s.coord != c.want {
+					t.Fatalf("cursor moved to %dx%d, want %dx%d",
+						s.coord.X, s.coord.Y, c.want.X, c.want.Y)
+				}
+			}
+			if !moved {
+				t.Fatal("the cursor was outside 80x25 and was not moved")
+			}
+		})
+	}
+}
+
+// Growing needs no cursor move: grow, window, and the size-down, which on a
+// pure grow asks for the size the grow has already set.
 func TestPlanFit_Grow(t *testing.T) {
 	plan := planFit(csbi(80, 25, 1, 1, 80, 25), 150, 50)
-	want := []fitOp{fitGrowBuffer, fitWindow, fitSizeBuffer}
-	if got := ops(plan); len(got) != len(want) {
-		t.Fatalf("plan = %v, want %v", got, want)
+	checkOps(t, plan, fitGrowBuffer, fitWindow, fitSizeBuffer)
+	if plan[0].coord != (Coord{X: 150, Y: 50}) {
+		t.Fatalf("grew the buffer to %dx%d, want 150x50", plan[0].coord.X, plan[0].coord.Y)
 	}
 }
 
 // Already the right size and origin: nothing to do.
 func TestPlanFit_Noop(t *testing.T) {
-	if plan := planFit(csbi(80, 25, 5, 5, 80, 25), 80, 25); plan != nil {
+	if plan := planFit(csbi(80, 25, 5, 5, 80, 25), 80, 25); len(plan) != 0 {
 		t.Fatalf("expected no work, got %v", ops(plan))
 	}
+}
+
+// The shortcut out needs every part to match: the buffer, the viewport, and
+// the viewport origin. The origin is belt and braces -- a console window
+// cannot reach past its own buffer, so a viewport already the size of the
+// buffer is at 0,0 -- but planFit checks it, so both halves are pinned here
+// against a viewport nudged off the origin.
+func TestPlanFit_NotANoopWhenAnythingIsOff(t *testing.T) {
+	scrolledRight := csbi(80, 25, 0, 0, 80, 25)
+	scrolledRight.srWindow.Left, scrolledRight.srWindow.Right = 1, 80
+	scrolledDown := csbi(80, 25, 0, 0, 80, 25)
+	scrolledDown.srWindow.Top, scrolledDown.srWindow.Bottom = 1, 25
+	for _, c := range []struct {
+		name string
+		info consoleScreenBufferInfo
+	}{
+		{"buffer one column wider", csbi(81, 25, 0, 0, 80, 25)},
+		{"buffer one row taller", csbi(80, 26, 0, 0, 80, 25)},
+		{"viewport one column narrower", csbi(80, 25, 0, 0, 79, 25)},
+		{"viewport one row shorter", csbi(80, 25, 0, 0, 80, 24)},
+		{"viewport scrolled right of the origin", scrolledRight},
+		{"viewport scrolled below the origin", scrolledDown},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if plan := planFit(c.info, 80, 25); len(plan) == 0 {
+				t.Fatal("expected a plan, got none")
+			}
+		})
+	}
+}
+
+// A COORD is a pair of int16, so a size the console cannot express is not
+// worth a single call: planFit backs out and leaves the buffer alone. The
+// bound is exclusive at the top -- the largest size a COORD does hold is
+// planned like any other.
+func TestPlanFit_OnlyPlansSizesACoordCanHold(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		w, h int
+	}{
+		{"no columns", 0, 25},
+		{"no rows", 80, 0},
+		{"columns past int16", 0x8000, 25},
+		{"rows past int16", 80, 0x8000},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if plan := planFit(csbi(150, 300, 149, 299, 150, 50), c.w, c.h); len(plan) != 0 {
+				t.Fatalf("planned %v for %dx%d, want nothing", ops(plan), c.w, c.h)
+			}
+		})
+	}
+	// The bound is exclusive: the largest size a COORD can hold is planned.
+	t.Run("the largest size int16 holds", func(t *testing.T) {
+		if plan := planFit(csbi(80, 25, 0, 0, 80, 25), 0x7fff, 0x7fff); len(plan) == 0 {
+			t.Fatal("0x7fff by 0x7fff fits in a COORD and must be planned")
+		}
+	})
 }


### PR DESCRIPTION
Two independent CI problems, no production code touched.

## main has been red since 3a64d25

`TestPlanFit_ShrinkMovesCursorAndWindowBeforeSizingDown` fails on windows/amd64 and windows/arm64, and has done so on every run since the commit that introduced it -- the other 46 jobs are green.

The test is the one that is wrong. It feeds a 150x300 buffer and asks for 80x25, so `grown` is `max(150,80)` by `max(300,25)`, which is the buffer already in place; `planFit` correctly omits `fitGrowBuffer` because there is nothing to grow. The condition arrived with the file in 6898db9 and 3a64d25 only moved it from a direct syscall into a plan step, so this is a stale expectation and not a regression in the resize path.

Everything the test exists to document is unchanged: the cursor pulled inside 80x25, the final buffer exactly 80x25, and both moves ordered ahead of the size-down.

## The grow half of the invariant was never tested

Those inputs never reach the branch, so it gets a test of its own on both axes -- a 60x300 buffer fitted to 80x25 must grow to 80x300 first, and a 150x25 one fitted to 80x50 to 150x50 -- since one `SetConsoleScreenBufferSize` sets both axes and growing only as far as the target would itself be the shrink the ordering exists to defer.

The rest of `planFit` is covered alongside it: the size bound a `COORD` sets, from both sides; the shortcut out when buffer, viewport and origin already match; and the per-axis cursor clamp. Every block of the function now runs with a non-zero count. `TestPlanFit_Grow` compared plan lengths rather than steps, so it goes through the same check as the rest now, and `fitOp` gets a `String` in the test file so a failed plan reads as `[growBuffer moveCursor]` instead of `[0 1]`.

## Every release built twice

An unfiltered `push` builds tags as well as branches. Releases are tagged `v0.1.NNN` on a commit `main` has just built, so v0.1.311 through v0.1.316 each ran the whole 48-job matrix twice -- once on `refs/heads/main`, again on `refs/tags/v0.1.NNN` -- and concurrency could not fold them together because the group keys on the ref.

Nothing in this workflow is tag-shaped: no release job, no read of `refs/tags`, no uploaded artifact, no `permissions` block. `branches: ['**']` matches every branch, slashes included, and no tag.

## Checks

`go test ./...` green on Windows, `gofmt -l` empty, `golangci-lint run --new-from-rev=origin/main` reports 0 issues, `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)