### PR TITLE
Снимать захват мыши по отпусканию, а не по пустому ButtonState

### DIFF
--- a/framemanager.go
+++ b/framemanager.go
@@ -3055,7 +3055,14 @@ func (fm *frameManager) dispatchEvent(ev *vtinput.InputEvent, is_injected bool) 
 		// 3.1. Active Mouse Capture (Dragging/Resizing)
 		if fm.capturedFrame != nil {
 			handled = fm.capturedFrame.ProcessMouse(ev)
-			if ev.ButtonState == 0 {
+			// A release is !KeyDown, not an empty ButtonState. The SGR mouse
+			// report names the button that was let go, so vtinput hands the
+			// release on with that button still in ButtonState; reading the
+			// release out of ButtonState alone therefore never sees one, and
+			// the capture is held forever. That is fatal where a tap is the
+			// only input there is: the first tap captures, and nothing but a
+			// wheel event -- which carries no button at all -- lets go again.
+			if ev.ButtonState == 0 || !ev.KeyDown {
 				fm.capturedFrame = nil // Release capture
 			}
 		} else {


### PR DESCRIPTION
Захват мыши снимается только при `ButtonState == 0` (`framemanager.go`):

```go
if fm.capturedFrame != nil {
    handled = fm.capturedFrame.ProcessMouse(ev)
    if ev.ButtonState == 0 {
        fm.capturedFrame = nil // Release capture
    }
}
```

Но SGR-отчёт при отпускании называет кнопку, которую отпустили, и vtinput передаёт событие именно так — с кнопкой в `ButtonState` и `KeyDown == false`. Это его осознанная семантика, закреплённая тестом `parser_test.go` (отпускание правой кнопки ожидается как `ButtonState == RightmostButtonPressed && !KeyDown`).

Получается, что одна сторона пишет отпускание в `KeyDown`, а другая читает его из `ButtonState`. В результате отпускание не наступает никогда, и `capturedFrame` держится до конца сессии.

## Как проявляется

На Termux (Android), где касание — единственный способ ввода, интерфейс блокируется после первого же тапа: меню срабатывает один раз, дальше не реагирует, а прокрутка списка файлов внезапно «расколдовывает» его. Объясняется тем, что событие колеса идёт другой веткой парсера и `ButtonState` не выставляет вовсе — только оно и снимает захват.

Лог подтверждает: нажатие и отпускание приходят в FrameManager неразличимыми по состоянию.

```
FM_DISPATCH: Received event: Mouse{Pos:36,28 Btn:Left DOWN Mods:None Src:sgr_mouse}
FM: Mouse Event at (36,28) State:1 Wheel:0
FM_DISPATCH: Received event: Mouse{Pos:36,28 Btn:Left UP   Mods:None Src:sgr_mouse}
FM: Mouse Event at (36,28) State:1 Wheel:0
```

## Правка

Проверяем `KeyDown` дополнительно к прежнему условию. Семантика vtinput не меняется, путь Windows-консоли, где при отпускании `ButtonState` действительно обнуляется, продолжает работать по прежней ветке.

Проверено на Termux (Android 15, arm64): до правки меню залипает после первого тапа, после — работает штатно. Тесты пакета проходят.

См. https://github.com/unxed/f4/issues/882