### PR TITLE
Цвет курсора: задавать через OSC 12, а не оставлять теме терминала

### DIFF
--- a/screenbuf.go
+++ b/screenbuf.go
@@ -1063,7 +1063,22 @@ func (r *AnsiRenderer) Flush() {
 
 // PrepareFlush appends the cursor state and mode 2026 termination to the pending frame.
 func (r *AnsiRenderer) PrepareFlush() func() {
-	if !r.firstInit || r.termCursorInvalid || r.cursorX != r.lastSentCursorX || r.cursorY != r.lastSentCursorY || r.cursorVis != r.lastSentCursorVis || r.cursorShape != r.lastSentCursorShape {
+	// The cursor color is tracked package-wide, not per renderer: there is one
+	// terminal, and Suspend/Resume are what invalidate the value. It is only
+	// consumed once actually written, so flipping ManageCursorStyle back on at
+	// runtime still delivers the color.
+	colorPending := ManageCursorStyle && !cursorStyleViaConsoleAPI() && CursorColor != cursorColorSent
+	if !r.firstInit || r.termCursorInvalid || r.cursorX != r.lastSentCursorX || r.cursorY != r.lastSentCursorY || r.cursorVis != r.lastSentCursorVis || r.cursorShape != r.lastSentCursorShape || colorPending {
+		if colorPending {
+			if CursorColor >= 0 {
+				_, _ = fmt.Fprintf(&r.frameOut, seqCursorColor, CursorColor&0xFFFFFF)
+				DebugLog("CURSOR: OSC 12 #%06X", CursorColor&0xFFFFFF)
+			} else {
+				_, _ = r.frameOut.WriteString(seqResetCursorColor)
+				DebugLog("CURSOR: OSC 112, cursor color handed back to the terminal")
+			}
+			cursorColorSent = CursorColor
+		}
 		r.writeCursorPos(r.cursorY+1, r.cursorX+1)
 		if IsFreeBSDConsole {
 			if r.cursorVis {

--- a/screenbuf_cursor_color_test.go
+++ b/screenbuf_cursor_color_test.go
@@ -1,0 +1,141 @@
+package vtui
+
+import (
+	"strings"
+	"testing"
+)
+
+// cursorColorTestState isolates one test from the package-wide cursor color
+// state and puts it back afterwards: there is one terminal, so these globals
+// are shared with every other test in the package.
+func cursorColorTestState(t *testing.T) {
+	t.Helper()
+	oldColor, oldSent, oldManage := CursorColor, cursorColorSent, ManageCursorStyle
+	CursorColor = -1
+	cursorColorSent = -2
+	ManageCursorStyle = true
+	t.Cleanup(func() {
+		CursorColor, cursorColorSent, ManageCursorStyle = oldColor, oldSent, oldManage
+	})
+}
+
+// ansiRendererWithCapture wires a ScreenBuf whose frames land in a builder
+// instead of the terminal.
+func ansiRendererWithCapture(t *testing.T) (*AnsiRenderer, *strings.Builder) {
+	t.Helper()
+	scr := NewScreenBuf()
+	r, ok := scr.Renderer.(*AnsiRenderer)
+	if !ok {
+		t.Fatalf("default renderer is %T, want *AnsiRenderer", scr.Renderer)
+	}
+	var out strings.Builder
+	scr.Writer = &out
+	return r, &out
+}
+
+func TestCursorColor_SentOnceAndOnChange(t *testing.T) {
+	cursorColorTestState(t)
+	r, out := ansiRendererWithCapture(t)
+
+	CursorColor = 0xFFCC00
+	r.Flush()
+	if want := "\x1b]12;#FFCC00\x07"; !strings.Contains(out.String(), want) {
+		t.Fatalf("frame does not name the cursor color %q, got %q", want, out.String())
+	}
+
+	// The terminal already knows the color, so a second frame must not repeat it.
+	out.Reset()
+	r.Flush()
+	if strings.Contains(out.String(), "\x1b]12;") {
+		t.Errorf("cursor color re-sent for an unchanged value: %q", out.String())
+	}
+
+	// Handing the color back is the only thing a negative value does.
+	out.Reset()
+	CursorColor = -1
+	r.Flush()
+	if !strings.Contains(out.String(), seqResetCursorColor) {
+		t.Errorf("clearing CursorColor did not emit OSC 112, got %q", out.String())
+	}
+}
+
+func TestCursorColor_SuppressedWhenCursorNotManaged(t *testing.T) {
+	cursorColorTestState(t)
+	r, out := ansiRendererWithCapture(t)
+
+	ManageCursorStyle = false
+	CursorColor = 0x00FF00
+	r.Flush()
+	if strings.Contains(out.String(), "\x1b]12;") {
+		t.Fatalf("cursor color sent even though ManageCursorStyle is false: %q", out.String())
+	}
+
+	// The value was not consumed while suppressed, so switching management
+	// back on in a running session still delivers it.
+	out.Reset()
+	ManageCursorStyle = true
+	r.Flush()
+	if want := "\x1b]12;#00FF00\x07"; !strings.Contains(out.String(), want) {
+		t.Errorf("cursor color not sent after ManageCursorStyle was re-enabled, got %q", out.String())
+	}
+}
+
+func TestCursorColor_SuspendRestoresAndResumeResends(t *testing.T) {
+	cursorColorTestState(t)
+
+	mock := &mockTermOut{}
+	oldGetTermOut := getTermOut
+	getTermOut = func() interface {
+		WriteString(string) (int, error)
+		Sync() error
+	} {
+		return mock
+	}
+	defer func() { getTermOut = oldGetTermOut }()
+
+	CursorColor = 0xFF0000
+	cursorColorSent = CursorColor
+	isPrepared = true
+	inAltScreen = true
+	inputRestore = func() {}
+
+	Suspend()
+	if !strings.Contains(mock.builder.String(), seqResetCursorColor) {
+		t.Fatalf("Suspend did not hand the cursor color back: %q", mock.builder.String())
+	}
+	if cursorColorSent != -2 {
+		t.Fatalf("cursorColorSent = %d after Suspend, want -2 (unknown)", cursorColorSent)
+	}
+
+	// Whatever ran while vtui was suspended may have restyled the cursor, so
+	// the next frame has to name the color again.
+	mock.builder.Reset()
+	r, out := ansiRendererWithCapture(t)
+	r.Flush()
+	if want := "\x1b]12;#FF0000\x07"; !strings.Contains(out.String(), want) {
+		t.Errorf("cursor color not re-sent after Suspend, got %q", out.String())
+	}
+}
+
+func TestCursorColor_SuspendSilentWhenNothingWasSent(t *testing.T) {
+	cursorColorTestState(t)
+
+	mock := &mockTermOut{}
+	oldGetTermOut := getTermOut
+	getTermOut = func() interface {
+		WriteString(string) (int, error)
+		Sync() error
+	} {
+		return mock
+	}
+	defer func() { getTermOut = oldGetTermOut }()
+
+	isPrepared = true
+	inAltScreen = true
+	inputRestore = func() {}
+
+	Suspend()
+	if strings.Contains(mock.builder.String(), seqResetCursorColor) {
+		t.Errorf("Suspend reset a cursor color it never set: %q", mock.builder.String())
+	}
+}

--- a/terminal_env.go
+++ b/terminal_env.go
@@ -13,8 +13,14 @@ const (
 	seqAutoWrapOn        = "\x1b[?7h"
 	seqBlinkingUnderline = "\x1b[3 q"
 	seqDefaultCursor     = "\x1b[0 q"
-	seqResetPalette      = "\x1b]104\x07"
-	seqResetAttributes   = "\x1b[0m"
+	// The cursor is the one glyph on screen the application does not paint
+	// itself, so its color comes from the terminal's own theme and can land
+	// anywhere -- including on top of the background the application chose.
+	// OSC 12 names it, OSC 112 hands it back.
+	seqCursorColor      = "\x1b]12;#%06X\x07"
+	seqResetCursorColor = "\x1b]112\x07"
+	seqResetPalette     = "\x1b]104\x07"
+	seqResetAttributes  = "\x1b[0m"
 	// vtui hands the terminal rows in visual order (see bidi.go), so a
 	// terminal that runs the bidi algorithm itself (VTE, and everything
 	// following the terminal-wg BiDi recommendation) must be told not to
@@ -34,6 +40,17 @@ var (
 	isPrepared        bool
 	inAltScreen       bool
 	ManageCursorStyle bool = true
+
+	// CursorColor is the color the terminal is asked to paint the cursor
+	// with, packed as 0xRRGGBB. A negative value leaves the terminal's own
+	// cursor color alone. It is honored on the ANSI backend only: the GUI
+	// renderers draw the caret themselves.
+	CursorColor int = -1
+
+	// cursorColorSent is what the terminal was last told, or -2 when that is
+	// unknown -- at start, and after every Resume, because whatever ran while
+	// vtui was suspended may have sent OSC 12 or OSC 112 of its own.
+	cursorColorSent = -2
 
 	// consoleCursorTypeStale is set whenever something other than vtui may
 	// have changed the console's cursor *type* (Legacy, Underscore,
@@ -215,6 +232,11 @@ func Suspend() {
 					out.WriteString(seqDefaultCursor)
 				}
 			}
+			if cursorColorSent >= 0 {
+				_, _ = out.WriteString(seqResetCursorColor)
+				DebugLog("CURSOR: OSC 112, cursor color handed back to the terminal")
+			}
+			cursorColorSent = -2
 			out.WriteString(seqResetPalette + seqResetAttributes)
 		} else if vt {
 			// syscons' native local-cursor command.  Unlike DECTCEM it is
@@ -320,6 +342,7 @@ func resumeLocked(withAltScreen bool) error {
 		// Whatever ran while f4 was suspended may have restyled the
 		// console cursor; the next SetCursorStyleOS has to assume so.
 		consoleCursorTypeStale = true
+		cursorColorSent = -2
 		if modernVT && ManageCursorStyle && !cursorStyleViaConsoleAPI() {
 			out.WriteString(seqBlinkingUnderline)
 		}


### PR DESCRIPTION
Каретку рисует терминал, а не приложение, поэтому её цвет берётся из темы терминала и может оказаться каким угодно — в том числе почти совпасть с фоном, который выбрало приложение. При форме «подчёркивание» (`ESC[3 q`) это линия в один пиксель, и неудачный цвет делает её невидимой.

Так и всплыло в f4: тема терминала задаёт `cursor: #044289`, панели f4 синие, каретки не видно. Сказать про цвет vtui было нечем.

## Что добавлено

- `CursorColor` — цвет каретки, `0xRRGGBB`. Отрицательное значение (по умолчанию) оставляет цвет терминала, так что для существующих пользователей не меняется ничего.
- `OSC 12` уходит из `PrepareFlush` рядом с DECSCUSR, под существующим `ManageCursorStyle`: приложение, обещавшее не трогать курсор терминала, не трогает и цвет.
- `Suspend` возвращает цвет терминалу (`OSC 112`), `Resume` помечает его неизвестным — запущенная тем временем программа могла поставить свой.

Что терминалу уже сказано — состояние пакета, а не рендерера: терминал один, и инвалидируют значение именно Suspend/Resume. Отправленным оно считается только после записи, поэтому включение `ManageCursorStyle` на ходу всё равно доставит цвет.

## Область

Только tty: ANSI-бэкенд. GUI-рендереры (`x11`, `wayland`, `gogpu`, `win32`, `ebiten`) рисуют каретку сами, цвет пока не читают — отдельная задача. На классической консоли Windows последовательность подавляется вместе с DECSCUSR, по существующей проверке `cursorStyleViaConsoleAPI`.

## Тесты

`screenbuf_cursor_color_test.go`: цвет уходит один раз и повторно только при смене, подавляется при `ManageCursorStyle = false` и доставляется после его включения, возвращается на `Suspend` и отправляется заново после него. `go test .` зелёный.